### PR TITLE
release: 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+## 0.5.0
+
+Celln could seal and attest any file, but only ever *run* one shape of thing: a
+static musl binary it built itself. Real tools are not that shape — a `python`
+is a binary plus a loader plus a tree of shared objects resolved by absolute
+path, and on a working developer machine 3 of 2064 binaries in `/usr/bin` are
+static. This release lends a tool's whole dependency closure instead, as a
+sealed filesystem built from a digest-pinned OCI image.
+
+### Breaking
+
+- **`celln ask` is removed.** It sent a question to the configured model CLI on
+  the host — no cell, no tools, no attestation. Use that CLI directly.
+- **`Tool.path` is now optional.** A tool comes from exactly one of `path`
+  (a static binary on this host), `image` + `exec` (a dependency closure), or
+  `builtin = "fetch"`. Specs setting none, or more than one, are refused.
+
+### Added
+
+- **Images as tools.** `[[tool]] image = "python"` with `exec`, pinned by
+  digest; tags are refused, because a moved tag would change what a cell is
+  lent without the spec changing.
+- **A tool catalogue**, compiled into the binary and refreshed by CI.
+  `celln image add <image:tag>` resolves the digest, materialises the image,
+  inspects it without mounting, and exposes what it finds. Hosts extend it at
+  `<root>/tools.toml` without rebuilding; a local entry shadows a shipped one.
+  Also `celln image pull|list|catalogue|spec|remove`.
+- **`celln run` executes.** It previously sealed tools and dissolved without
+  running anything.
+- **Several images per cell.** Each becomes its own pmem namespace mounted at
+  `/tools`, `/tools1`, …; tools naming the same image share its mount and its
+  single physical copy.
+- **Several invocations per cell** via `[[run]]`. `[run]` still takes one.
+- **Brokered egress from a spec**: `[cell] allow_hosts` with a tool declaring
+  `builtin = "fetch"`. The cell still has no network stack — the host performs
+  the fetch, HTTPS only, DNS pinned before connect, each redirect
+  re-authorised, size and time bounded.
+- **`[agent]` blocks.** The spec keeps the policy — tools, memory, hosts — and
+  a model fills in the program. `celln run --task` overrides the task;
+  `celln agent --tool python "…"` does the same without a file.
+- **`celln tools`** lists what the host has attested rather than a count.
+
+### Fixed
+
+- **The VFS↔memslot proofs were red.** The Celln rename widened `PROBE_MAGIC`
+  from 8 bytes to 9 *and* relaxed its type from `&[u8; 8]` to `&[u8]`, turning
+  two compile-checked lengths into runtime bugs. The join this design rests on
+  was unverified.
+- **Sealed images mounted read-write**, because the read-only remount sat
+  behind an early return taken whenever a test fixture was absent. Writes
+  returned success, appeared to create files, and landed nowhere.
+- **A warm hit matched on alias, not content.** Two images can both claim
+  `/bin/sh`; the host attested one image's bytes while the other's ran.
+- **`Manifest::resolve_alias` returned revoked entries.**
+- **Image sizing counted hardlinks repeatedly** — busybox links ~400 applets to
+  one binary, so a 4 MiB rootfs was sized as ~400 MiB.
+- **Scratch directories leaked per run** into `/tmp`, image-sized, and `/tmp` is
+  a tmpfs on most hosts.
+- **The tool window capped images at 32 MiB.** It is now sized to the image.
+  Moving it above RAM does not work: pmem past `last_pfn` is parsed and then
+  never registered, so no device appears.
+
+### Known limits
+
+Images are capped at 512 MiB; past roughly a gigabyte the guest panics in
+`kernel_init`. `curl` deliberately cannot use the fetch capability — reaching it
+through curl means brokering raw TCP rather than a validated URL, which discards
+the DNS pinning and redirect re-authorisation that make it safe. File ownership
+in built images is still the extracting user's, and cell scratch still lives in
+`/tmp`. See `docs/OCI_TOOL_LANE.md`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "celln-assay"
-version = "0.4.13"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "celln-forge",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "celln-cli"
-version = "0.4.13"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "celln-assay",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "celln-forge"
-version = "0.4.13"
+version = "0.5.0"
 dependencies = [
  "celln-manifest",
  "serde",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "celln-manifest"
-version = "0.4.13"
+version = "0.5.0"
 dependencies = [
  "blake3",
  "serde",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "celln-pilot"
-version = "0.4.13"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "celln-assay",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "celln-spec"
-version = "0.4.13"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "celln-store"
-version = "0.4.13"
+version = "0.5.0"
 dependencies = [
  "blake3",
  "celln-manifest",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "celln-warden"
-version = "0.4.13"
+version = "0.5.0"
 dependencies = [
  "celln-manifest",
  "kvm-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.13"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"

--- a/crates/celln-assay/Cargo.toml
+++ b/crates/celln-assay/Cargo.toml
@@ -16,9 +16,9 @@ name = "assay"
 path = "src/lib.rs"
 
 [dependencies]
-celln-manifest = { version = "0.4.0", path = "../celln-manifest" }
-celln-forge = { version = "0.4.0", path = "../celln-forge" }
-celln-store = { version = "0.4.0", path = "../celln-store" }
+celln-manifest = { version = "0.5.0", path = "../celln-manifest" }
+celln-forge = { version = "0.5.0", path = "../celln-forge" }
+celln-store = { version = "0.5.0", path = "../celln-store" }
 clap.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/celln-cli/Cargo.toml
+++ b/crates/celln-cli/Cargo.toml
@@ -13,13 +13,13 @@ name = "celln"
 path = "src/main.rs"
 
 [dependencies]
-celln-spec = { version = "0.4.0", path = "../celln-spec" }
-celln-manifest = { version = "0.4.0", path = "../celln-manifest" }
-celln-store = { version = "0.4.0", path = "../celln-store" }
-celln-assay = { version = "0.4.0", path = "../celln-assay" }
-celln-forge = { version = "0.4.0", path = "../celln-forge" }
-celln-pilot = { version = "0.4.0", path = "../celln-pilot" }
-celln-warden = { version = "0.4.0", path = "../celln-warden" }
+celln-spec = { version = "0.5.0", path = "../celln-spec" }
+celln-manifest = { version = "0.5.0", path = "../celln-manifest" }
+celln-store = { version = "0.5.0", path = "../celln-store" }
+celln-assay = { version = "0.5.0", path = "../celln-assay" }
+celln-forge = { version = "0.5.0", path = "../celln-forge" }
+celln-pilot = { version = "0.5.0", path = "../celln-pilot" }
+celln-warden = { version = "0.5.0", path = "../celln-warden" }
 anyhow.workspace = true
 clap.workspace = true
 serde.workspace = true
@@ -38,4 +38,4 @@ libc.workspace = true
 # else `celln` still validates specs and runs the mock proof, and says so rather
 # than pretending.
 [target.'cfg(target_os = "linux")'.dependencies]
-celln-warden = { version = "0.4.0", path = "../celln-warden", features = ["kvm"] }
+celln-warden = { version = "0.5.0", path = "../celln-warden", features = ["kvm"] }

--- a/crates/celln-forge/Cargo.toml
+++ b/crates/celln-forge/Cargo.toml
@@ -11,6 +11,6 @@ description = "The build plane: rebuilds an artifact from source and proves the 
 name = "forge"
 
 [dependencies]
-celln-manifest = { version = "0.4.0", path = "../celln-manifest" }
+celln-manifest = { version = "0.5.0", path = "../celln-manifest" }
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/celln-pilot/Cargo.toml
+++ b/crates/celln-pilot/Cargo.toml
@@ -48,10 +48,10 @@ name = "pilot"
 path = "src/lib.rs"
 
 [dependencies]
-celln-manifest = { version = "0.4.0", path = "../celln-manifest" }
-celln-store = { version = "0.4.0", path = "../celln-store" }
-celln-assay = { version = "0.4.0", path = "../celln-assay" }
-celln-warden = { version = "0.4.0", path = "../celln-warden" }
+celln-manifest = { version = "0.5.0", path = "../celln-manifest" }
+celln-store = { version = "0.5.0", path = "../celln-store" }
+celln-assay = { version = "0.5.0", path = "../celln-assay" }
+celln-warden = { version = "0.5.0", path = "../celln-warden" }
 libc.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/celln-store/Cargo.toml
+++ b/crates/celln-store/Cargo.toml
@@ -11,7 +11,7 @@ description = "Content-addressed store: the on-disk half of assay's distro."
 name = "celln_store"
 
 [dependencies]
-celln-manifest = { version = "0.4.0", path = "../celln-manifest" }
+celln-manifest = { version = "0.5.0", path = "../celln-manifest" }
 blake3.workspace = true
 thiserror.workspace = true
 

--- a/crates/celln-warden/Cargo.toml
+++ b/crates/celln-warden/Cargo.toml
@@ -19,7 +19,7 @@ mock = []
 kvm = ["dep:kvm-ioctls", "dep:kvm-bindings", "dep:libc"]
 
 [dependencies]
-celln-manifest = { version = "0.4.0", path = "../celln-manifest" }
+celln-manifest = { version = "0.5.0", path = "../celln-manifest" }
 thiserror.workspace = true
 kvm-ioctls = { workspace = true, optional = true }
 kvm-bindings = { workspace = true, optional = true }


### PR DESCRIPTION
The version bump for the work merged in #18. That PR landed one commit
before this one was pushed, so `main` currently carries the features at
`0.4.13`.

**Minor, not patch** — two things break:

- `celln ask` is removed. It sent a question to the configured model CLI on
  the host: no cell, no tools, no attestation.
- `Tool.path` is now optional. A tool comes from exactly one of `path`,
  `image` + `exec`, or `builtin = "fetch"`, so a spec setting none or several
  is refused rather than quietly preferring one.

Inter-crate pins move with the workspace version; `^0.4.0` would not resolve
against `0.5.0`.

Also adds a `CHANGELOG.md`, which the repository did not have. It records the
known limits next to the features — the 512 MiB image ceiling, curl's inability
to use the fetch capability, and cell scratch still living in `/tmp` — because
those are things a reader should meet before they hit them.

Verified on KVM hardware: `fmt --check`, `clippy -D warnings --all-features`,
`cargo test --workspace` (19 suites), `celln-warden --features kvm` (29
proofs), and `make acceptance-kvm`.