### PR TITLE
fix: give a node its tool images, and size them so they build

### DIFF
--- a/crates/celln-cli/src/agent.rs
+++ b/crates/celln-cli/src/agent.rs
@@ -351,24 +351,26 @@ pub fn setup(
     no_tools: bool,
     o: &Out,
 ) -> Result<u8> {
+    // Which model writes code has nothing to do with which tools a host can
+    // lend, so a missing agent CLI must not skip the rest of setup. It used to
+    // return here, which meant a node provisioned without one silently got no
+    // tool images at all — the failure was reported as a warning about the
+    // wrong thing entirely.
     let backend = match preferred {
-        Some(backend) if backend.available() => backend,
+        Some(backend) if backend.available() => Some(backend),
         Some(backend) => {
             o.warn(format!(
                 "{} is not available — install and authenticate `{}` first",
                 backend.label(),
                 backend.program()
             ));
-            return Ok(crate::exit::HOST_INCAPABLE);
+            None
         }
         None => {
             // Interactive: show available backends and let the user pick.
             // Non-interactive (piped): fall back to auto-discovery.
             if std::io::stdout().is_terminal() {
-                match interactive_backend_select(o)? {
-                    Some(backend) => backend,
-                    None => return Ok(crate::exit::HOST_INCAPABLE),
-                }
+                interactive_backend_select(o)?
             } else {
                 match discover_backend() {
                     Some(backend) => {
@@ -377,34 +379,37 @@ pub fn setup(
                             dim("·"),
                             backend.label()
                         ));
-                        backend
+                        Some(backend)
                     }
                     None => {
                         o.warn("no agent CLI found — install and authenticate codex, claude, deepseek, or ollama, then rerun `celln setup`");
-                        return Ok(crate::exit::HOST_INCAPABLE);
+                        None
                     }
                 }
             }
         }
     };
-    let path = crate::config::set_default_agent(backend.saved_name())?;
-    o.event(
-        "agent_default",
-        serde_json::json!({"backend": backend.saved_name(), "config": path}),
-        format!("✔ default agent: {} ({})", backend.label(), path.display()),
-    );
 
-    // Validate credentials so the user finds out now, not on first use.
-    match backend.validate() {
-        Ok(()) => {
-            o.event(
-                "agent_validated",
-                serde_json::json!({"backend": backend.saved_name()}),
-                format!("✔ {} credentials verified", backend.label()),
-            );
-        }
-        Err(msg) => {
-            o.warn(format!("{}: {msg}", backend.label()));
+    if let Some(backend) = backend {
+        let path = crate::config::set_default_agent(backend.saved_name())?;
+        o.event(
+            "agent_default",
+            serde_json::json!({"backend": backend.saved_name(), "config": path}),
+            format!("✔ default agent: {} ({})", backend.label(), path.display()),
+        );
+
+        // Validate credentials so the user finds out now, not on first use.
+        match backend.validate() {
+            Ok(()) => {
+                o.event(
+                    "agent_validated",
+                    serde_json::json!({"backend": backend.saved_name()}),
+                    format!("✔ {} credentials verified", backend.label()),
+                );
+            }
+            Err(msg) => {
+                o.warn(format!("{}: {msg}", backend.label()));
+            }
         }
     }
 
@@ -437,7 +442,13 @@ pub fn setup(
         }
     }
 
-    Ok(crate::exit::OK)
+    // Still say so in the exit code: a host with tools but no agent CLI can
+    // run a declared spec and cannot ask a model to write one.
+    Ok(if backend.is_some() {
+        crate::exit::OK
+    } else {
+        crate::exit::HOST_INCAPABLE
+    })
 }
 
 /// List available backends interactively and prompt the user to pick one.

--- a/crates/celln-cli/src/image.rs
+++ b/crates/celln-cli/src/image.rs
@@ -243,12 +243,18 @@ fn layer_digests(dir: &Path) -> Result<Vec<String>> {
         .collect()
 }
 
-/// Bytes an image rootfs actually occupies.
+/// Space an image rootfs will occupy in an ext2 filesystem.
 ///
-/// Counts each inode once. Hardlinks are everywhere in real images — busybox
-/// links ~400 applets to one binary — and summing directory entries instead
-/// inflated a 4 MiB rootfs to nearly 400 MiB, which then sized the filesystem
-/// (and the sealed page-set every cell shares) to match.
+/// Two corrections over summing file sizes, both learned the hard way.
+///
+/// Each inode is counted once: hardlinks are everywhere in real images —
+/// busybox links ~400 applets to one binary — and `mke2fs -d` preserves them,
+/// so counting each name inflated a 4 MiB rootfs to nearly 400 MiB.
+///
+/// And every file occupies whole blocks, so a tree of many small files costs
+/// far more than its bytes. python:3.12-slim is mostly small stdlib files:
+/// summing sizes underestimated it enough that mke2fs ran out of blocks
+/// mid-populate. Directories cost a block each too.
 fn dir_bytes(path: &Path) -> u64 {
     use std::collections::HashSet;
     use std::os::unix::fs::MetadataExt;
@@ -264,8 +270,9 @@ fn dir_bytes(path: &Path) -> u64 {
             let Ok(md) = e.metadata() else { continue };
             if md.is_dir() {
                 stack.push(e.path());
+                total += BLOCK;
             } else if md.nlink() <= 1 || seen.insert((md.dev(), md.ino())) {
-                total += md.len();
+                total += md.len().max(1).div_ceil(BLOCK) * BLOCK;
             }
         }
     }
@@ -278,7 +285,7 @@ fn build_ext2(rootfs: &Path, out: &Path) -> Result<()> {
     let blocks = want.div_ceil(BLOCK).div_ceil(blocks_per_align) * blocks_per_align;
 
     let _ = std::fs::remove_file(out);
-    let status = Command::new("mke2fs")
+    let result = Command::new("mke2fs")
         .args(["-q", "-t", "ext2", "-b", "4096", "-d"])
         .arg(rootfs)
         .args(["-F", "-U", IMAGE_UUID, "-E"])
@@ -286,10 +293,17 @@ fn build_ext2(rootfs: &Path, out: &Path) -> Result<()> {
         .arg(out)
         .arg(blocks.to_string())
         .env("SOURCE_DATE_EPOCH", "0")
-        .status()
+        .output()
         .context("running mke2fs (install e2fsprogs)")?;
-    if !status.success() {
-        bail!("mke2fs failed building the tool filesystem");
+    if !result.status.success() {
+        // mke2fs sizes the file before it populates it, so a failure leaves a
+        // plausible-looking image behind. Left there it would be listed as
+        // materialised and could be sealed into a cell.
+        let _ = std::fs::remove_file(out);
+        bail!(
+            "mke2fs could not build the tool filesystem: {}",
+            String::from_utf8_lossy(&result.stderr).trim()
+        );
     }
     Ok(())
 }
@@ -568,6 +582,39 @@ mod catalogue {
                 .filter(|i| i.name == "python")
                 .count(),
             1
+        );
+    }
+
+    #[test]
+    fn sizing_counts_blocks_and_counts_hardlinks_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // Many small files: each costs a whole block, so bytes-summed
+        // underestimates. python:3.12-slim is mostly small stdlib files, and
+        // summing sizes sized an image mke2fs then ran out of blocks filling.
+        std::fs::create_dir(root.join("many")).unwrap();
+        for i in 0..64 {
+            std::fs::write(root.join("many").join(format!("f{i}")), b"x").unwrap();
+        }
+        let counted = dir_bytes(root);
+        assert!(
+            counted >= 64 * BLOCK,
+            "64 one-byte files must cost at least 64 blocks, got {counted}"
+        );
+
+        // Hardlinks share an inode and mke2fs -d preserves them, so they must
+        // be counted once — busybox links ~400 applets to one binary.
+        let dir2 = tempfile::tempdir().unwrap();
+        let root2 = dir2.path();
+        std::fs::write(root2.join("big"), vec![0u8; 40 * 1024]).unwrap();
+        for i in 0..20 {
+            std::fs::hard_link(root2.join("big"), root2.join(format!("l{i}"))).unwrap();
+        }
+        let linked = dir_bytes(root2);
+        assert!(
+            linked < 20 * 40 * 1024,
+            "hardlinks must not be counted per name, got {linked}"
         );
     }
 

--- a/integrations/kubernetes/Dockerfile.installer
+++ b/integrations/kubernetes/Dockerfile.installer
@@ -18,6 +18,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates python3 \
     build-essential gcc cpio e2fsprogs xz-utils zstd \
+    skopeo \
     && rm -rf /var/lib/apt/lists/*
 
 # Rust toolchain (for forge compile step on the host)

--- a/scripts/setup-host.sh
+++ b/scripts/setup-host.sh
@@ -121,15 +121,36 @@ if [ -z "$DETECTED" ]; then
     echo "    See: https://github.com/sympozium-ai/celln#agent-backends"
 fi
 
-# Run celln setup to save the default backend
+# Run celln setup to save the default backend and install runtime assets.
+#
+# In container mode this is split deliberately. Agent config and runtime assets
+# belong to the host, so setup runs in the host namespace — with --no-tools,
+# because pulling images needs skopeo and the host has no reason to carry one.
+# The images are then materialised from inside this container, which does have
+# skopeo, writing straight into the host's store over the /host mount. They are
+# only files; nothing on the host needs to have produced them.
 if $CONTAINER_MODE; then
-    nsenter --target 1 --mount -- /bin/sh -c "PATH=/usr/local/bin:/opt/celln/runtime/scripts:/usr/bin:/bin /usr/local/bin/celln --root /var/lib/celln setup 2>&1" | while IFS= read -r line; do
+    nsenter --target 1 --mount -- /bin/sh -c "PATH=/usr/local/bin:/opt/celln/runtime/scripts:/usr/bin:/bin /usr/local/bin/celln --root /var/lib/celln setup --no-tools 2>&1" | while IFS= read -r line; do
         echo "  $line"
+    done
+
+    echo "  · materialising default tool images into ${HOST}/var/lib/celln"
+    mkdir -p "${HOST}/var/lib/celln"
+    for tool in $(/usr/local/bin/celln --root "${HOST}/var/lib/celln" --json image catalogue 2>/dev/null \
+                  | python3 -c 'import sys,json
+for line in sys.stdin:
+    try: e = json.loads(line)
+    except ValueError: continue
+    if e.get("event") == "catalogue" and e.get("default"): print(e["name"])'); do
+        /usr/local/bin/celln --root "${HOST}/var/lib/celln" --no-json image pull "$tool" 2>&1 \
+            | while IFS= read -r line; do echo "    $line"; done
     done
 else
     PATH=/usr/local/bin:/opt/celln/runtime/scripts:/usr/bin:/bin /usr/local/bin/celln --root /var/lib/celln setup 2>&1 | while IFS= read -r line; do
         echo "  $line"
     done
+    command -v skopeo >/dev/null 2>&1 || \
+        echo "  ! skopeo is not installed; tool images cannot be materialised on this host"
 fi
 # Celln supports multiple backends. Any of these env vars trigger
 # automatic key-file creation for the dispatcher.


### PR DESCRIPTION
Started from a question — *will the Sympozium installer make the default
catalogue available?* The answer was no, for three independent reasons.

## `setup` never reached the pull

`setup()` returned `HOST_INCAPABLE` at the agent-backend check, *before*
materialising images. `setup-host.sh` already anticipates a node without an
agent CLI — it prints `✘ no agent CLI detected` and continues — so any such
node silently got no tools at all, and the failure was reported as a warning
about something else entirely.

Which model writes code has nothing to do with which tools a host can lend.
They are now independent; the exit code still reports the missing backend.

## skopeo was in the wrong namespace

The installer copies `celln` to the host and runs setup through
`nsenter --target 1 --mount`, so skopeo would have had to be **on the host**.
It isn't, and putting it there means shipping a dynamically linked binary plus
its policy and registry config.

Instead the work is split where the tools already are: agent config and runtime
assets are installed on the host with `--no-tools`, and images are materialised
from inside the installer container — which now carries skopeo — writing into
the host store over the existing `/host` mount. Images are only files; nothing
on the host needs to have produced them. A direct, non-container install now
says plainly when skopeo is missing rather than warning about something vague.

## The images could not be built anyway

Found while testing the above: **`celln image pull python` fails outright on a
fresh store** on 0.5.1 and 0.5.2.

```
mke2fs could not build the tool filesystem: __populate_fs: Could not allocate
block in ext2 filesystem while writing file "perl-base.list"
```

Every file occupies whole blocks, so a tree of many small files costs far more
than the sum of its bytes — and `python:3.12-slim` is mostly small stdlib
files. Sizing counted bytes, so the image was built too small to hold its own
contents. It now counts blocks, and directories.

This was a regression from the hardlink fix in 0.5.1: deduping inodes was
correct — `mke2fs -d` does preserve hardlinks, verified with 21 names sharing
one inode — but it tightened the estimate enough to cross the line. Both
directions now have a regression test: 64 one-byte files must cost 64 blocks,
and 20 hardlinks must not cost 20 copies.

A failed `mke2fs` also left a plausible-looking partial image behind, which
`image list` reported as materialised and a spec could have sealed. It is now
removed on failure, and mke2fs's own words are surfaced instead of a generic
"mke2fs failed".

## Verification

Fresh store: python 150 MiB, curl 34 MiB, busybox 10 MiB — the busybox number
confirms hardlink dedup still holds. The rebuilt python image boots and runs
with its own OpenSSL. `fmt --check`, `clippy -D warnings --all-features`,
`cargo test --workspace` (19 suites), `celln-warden --features kvm` (29
proofs), and `make acceptance-kvm` all pass on KVM hardware.

Related: this is the provisioning half of sympozium-ai/sympozium#335. Even with
the catalogue present, no `ExecutionRequest` can name an image-backed tool yet.