### PR TITLE
fix: tell people how to add a tool, and make both that and the digest refresh work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
       - run: cargo fmt --all --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test --workspace
+      # The digest refresher runs weekly against a live registry, so without
+      # this it would only ever be exercised in production. It stubs skopeo.
+      - name: the tool-digest refresher still holds
+        run: scripts/refresh-tool-digests.sh --self-test
       # The CLI has to work on a machine with no hardware isolation, because
       # most people will meet it there first.
       - name: cli works without /dev/kvm

--- a/.github/workflows/tool-digests.yml
+++ b/.github/workflows/tool-digests.yml
@@ -23,33 +23,14 @@ jobs:
       - name: Install skopeo
         run: sudo apt-get update && sudo apt-get install -y skopeo
 
+      # The refresher is a script rather than a block of YAML so it can be run
+      # and tested off a registry; `--self-test` covers it on every PR in ci.
+      - name: Check the refresher itself
+        run: scripts/refresh-tool-digests.sh --self-test
+
       - name: Re-resolve each pinned tag
         id: refresh
-        run: |
-          set -euo pipefail
-          f=crates/celln-cli/tools.toml
-          changed=0
-          # `tag` is the moving reference the pin was taken from; `ref` is the pin.
-          tags=$(grep -oP '^tag = "\K[^"]+' "$f")
-          for tag in $tags; do
-            digest=$(skopeo inspect --format '{{.Digest}}' "docker://$tag")
-            name=${tag%%:*}
-            old=$(grep -A1 "^tag = \"$tag\"$" "$f" | grep -oP '^ref = "\K[^"]+' || true)
-            new="$name@$digest"
-            if [ "$old" != "$new" ]; then
-              echo "  $tag: $old -> $new"
-              python3 - "$f" "$tag" "$new" <<'PY'
-          import sys, re
-          path, tag, new = sys.argv[1:4]
-          s = open(path).read()
-          s = re.sub(rf'(^tag = "{re.escape(tag)}"$\n)ref = "[^"]+"',
-                     rf'\g<1>ref = "{new}"', s, flags=re.M)
-          open(path, "w").write(s)
-          PY
-              changed=1
-            fi
-          done
-          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+        run: scripts/refresh-tool-digests.sh
 
       - name: Verify the catalogue still parses and the workspace builds
         if: steps.refresh.outputs.changed == '1'

--- a/.github/workflows/tool-digests.yml
+++ b/.github/workflows/tool-digests.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Verify the catalogue still parses and the workspace builds
         if: steps.refresh.outputs.changed == '1'
-        run: cargo test -p celln-cli --lib catalogue
+        run: cargo test -p celln-cli catalogue
 
       - name: Open a pull request
         if: steps.refresh.outputs.changed == '1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Naming a tool the host does not have now says how to get one.** `celln
+  agent --tool go` listed what was available and stopped there, which tells
+  you the command failed but not what to do about it. It now gives the
+  `celln image add` line, including the `--name` form for when a tool is
+  published under a different name than you call it — `go` lives in `golang`.
+
+- **Being told a tool cannot run model-written code now says why, and what
+  to use instead.** The old message named a missing `language` and
+  `code_flag` without explaining that `--tool` needs an interpreter taking a
+  program on a flag, which plenty of useful tools have no reason to do. It
+  now points at `celln image spec NAME`, which is how those are lent.
+
+### Fixed
+
+- **`celln image add` produced entries that `celln agent --tool` then
+  refused.** It wrote `interpreter` but never `language` or `code_flag`, so
+  adding an interpreter and immediately using it failed on a field the user
+  was never told to write. A recognised interpreter now records the flag it
+  takes code on, and adding one is enough to use it.
+
+- **The weekly digest refresh would have failed before opening its PR.** Its
+  one verification step ran `cargo test -p celln-cli --lib catalogue`, and
+  `celln-cli` has no library target, so the command errors rather than
+  running the tests. It is scheduled weekly and had not yet found a moved
+  digest, so it had never run the step — the pins would simply have stopped
+  being refreshed, quietly, which is what the workflow exists to prevent.
+
 ## 0.5.3
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,25 @@
   was never told to write. A recognised interpreter now records the flag it
   takes code on, and adding one is enough to use it.
 
-- **The weekly digest refresh would have failed before opening its PR.** Its
-  one verification step ran `cargo test -p celln-cli --lib catalogue`, and
-  `celln-cli` has no library target, so the command errors rather than
-  running the tests. It is scheduled weekly and had not yet found a moved
-  digest, so it had never run the step — the pins would simply have stopped
-  being refreshed, quietly, which is what the workflow exists to prevent.
+- **The weekly digest refresh could not have worked.** It exists so a moved
+  upstream tag arrives as a reviewable PR rather than silently at pull time,
+  and it had never run its own body — it is gated on a digest having moved,
+  and none had. Three faults, which only made sense to fix together:
+
+  - Its one verification ran `cargo test -p celln-cli --lib catalogue`, and
+    `celln-cli` has no library target, so the command errors instead of
+    running the tests. That step failing is the only thing that would have
+    stopped the next two from reaching a pull request.
+  - A registry answering with something that is not a digest — an empty
+    string on a hiccup, `unauthorized` on a rate limit — was pinned verbatim,
+    producing `ref = "docker.io/library/python@"`. No pull can satisfy that.
+  - Stripping the tag off a reference ate the port of any registry that has
+    one, turning `reg:5000/team/tool:v1` into `reg`.
+
+  The refresher is now `scripts/refresh-tool-digests.sh` rather than a block
+  of YAML, so it can be run and tested without a registry. Its `--self-test`
+  stubs skopeo and covers all three, and runs in ci on every PR — the point
+  being that weekly-only code is otherwise tested exclusively in production.
 
 ## 0.5.3
 

--- a/crates/celln-cli/src/image.rs
+++ b/crates/celln-cli/src/image.rs
@@ -97,7 +97,14 @@ pub fn interpreter_for(name: &str, root: &Path) -> Result<(CatalogueImage, Provi
         .find(|i| i.name == name)
         .with_context(|| {
             format!(
-                "no tool named {name:?}. Available: {}",
+                "no tool named {name:?}. Available: {}\n\n  \
+                 Add it from an image that carries it:\n    \
+                 celln image add {name}:<tag>\n\n  \
+                 If it is published under a different name, map it:\n    \
+                 celln image add <image>:<tag> --name {name}\n\n  \
+                 The tag is resolved to a digest and pinned, so what a cell is \
+                 lent\n  cannot change afterwards. `celln image catalogue` \
+                 lists everything\n  this host knows how to lend.",
                 cat.images
                     .iter()
                     .map(|i| i.name.as_str())
@@ -111,9 +118,20 @@ pub fn interpreter_for(name: &str, root: &Path) -> Result<(CatalogueImage, Provi
         .find(|p| p.language.is_some() && p.code_flag.is_some())
         .cloned()
         .with_context(|| {
+            let aliases: Vec<&str> = image.provides.iter().map(|p| p.alias.as_str()).collect();
             format!(
-                "{name} cannot run model-written code: no entry declares a \
-                 language and code_flag. Add them to its catalogue entry."
+                "{name} is available, but nothing it provides ({}) can run \
+                 model-written code.\n\n  \
+                 `--tool` needs an interpreter that accepts a program on a \
+                 flag, because\n  that is how a model's code reaches it. Plenty \
+                 of useful tools do not: a\n  compiler wants a source file, \
+                 curl wants a URL. Lend those from a spec,\n  which says what \
+                 to run:\n    celln image spec {name} > cell.toml\n\n  \
+                 If {name} does take code on a flag, declare which in {}:\n    \
+                 {{ alias = \"…\", exec = \"…\", interpreter = true, language = \
+                 \"…\", code_flag = \"-c\" }}",
+                aliases.join(", "),
+                user_catalogue_path(root).display(),
             )
         })?;
     Ok((image.clone(), provide))
@@ -1065,11 +1083,18 @@ pub fn add(
         "\n[[image]]\nname = \"{name}\"\ntag = \"{tag}\"\nref = \"{pinned}\"\n\
          about = \"added with `celln image add`\"\ndefault = {make_default}\nprovides = [\n"
     );
+    // A recognised interpreter records how it takes code, so `agent --tool`
+    // works straight after adding it rather than failing on a missing field.
     for (alias, exec) in &provides {
-        let interp = celln_spec::looks_like_interpreter(alias);
-        entry.push_str(&format!(
-            "  {{ alias = \"{alias}\", exec = \"{exec}\", interpreter = {interp} }},\n"
-        ));
+        match celln_spec::interpreter_hint(alias) {
+            Some((language, code_flag)) => entry.push_str(&format!(
+                "  {{ alias = \"{alias}\", exec = \"{exec}\", interpreter = true, \
+                 language = \"{language}\", code_flag = \"{code_flag}\" }},\n"
+            )),
+            None => entry.push_str(&format!(
+                "  {{ alias = \"{alias}\", exec = \"{exec}\", interpreter = false }},\n"
+            )),
+        }
     }
     entry.push_str("]\n");
 

--- a/crates/celln-cli/tools.toml
+++ b/crates/celln-cli/tools.toml
@@ -23,6 +23,11 @@
 #    is the pin that is actually pulled. `default = true` means `celln setup`
 #    materialises it, so reserve that for tools most people want.
 #
+#    A tool that can run a program a model wrote also declares `language` and
+#    `code_flag` — the flag it takes that program on. That is what makes it
+#    usable with `celln agent --tool NAME`; without both, that command refuses.
+#    A compiler has no such flag and should not claim one.
+#
 # 4. Find the exec paths *inside* the image, without mounting it:
 #
 #      celln image pull NAME@sha256:...

--- a/crates/celln-spec/src/lib.rs
+++ b/crates/celln-spec/src/lib.rs
@@ -1013,31 +1013,40 @@ fn check_digest_pinned(reference: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Names that are interpreters in practice. Used only to warn.
+/// Interpreters in practice, and the flag each takes code on.
+///
+/// Being on this list is what makes a tool usable with `celln agent --tool`:
+/// a model writes a program, and it has to reach the interpreter somehow. A
+/// compiler is not here — `go` wants a file, not a flag — and neither is a
+/// language whose flag we have not confirmed.
+///
+/// This only ever guesses defaults. A catalogue entry that states its own
+/// `language` and `code_flag` is believed over anything here.
+pub fn interpreter_hint(alias: &str) -> Option<(&'static str, &'static str)> {
+    let base = alias.rsplit('/').next().unwrap_or(alias);
+    let base = base.trim_end_matches(|c: char| c.is_ascii_digit() || c == '.');
+    Some(match base {
+        "python" | "python3" => ("Python", "-c"),
+        "sh" | "dash" => ("POSIX shell", "-c"),
+        "bash" => ("Bash", "-c"),
+        "zsh" => ("Zsh", "-c"),
+        "node" | "nodejs" => ("JavaScript", "-e"),
+        "deno" => ("TypeScript", "eval"),
+        "bun" => ("JavaScript", "-e"),
+        "ruby" => ("Ruby", "-e"),
+        "perl" => ("Perl", "-e"),
+        "php" => ("PHP", "-r"),
+        "lua" => ("Lua", "-e"),
+        "tclsh" => ("Tcl", "-c"),
+        "awk" => ("Awk", "--source"),
+        _ => return None,
+    })
+}
+
 /// Names that are interpreters in practice. Used to warn, and to guess when
 /// adding a tool to the catalogue.
 pub fn looks_like_interpreter(alias: &str) -> bool {
-    let base = alias.rsplit('/').next().unwrap_or(alias);
-    let base = base.trim_end_matches(|c: char| c.is_ascii_digit() || c == '.');
-    matches!(
-        base,
-        "python"
-            | "python3"
-            | "sh"
-            | "bash"
-            | "zsh"
-            | "dash"
-            | "node"
-            | "nodejs"
-            | "ruby"
-            | "perl"
-            | "lua"
-            | "php"
-            | "deno"
-            | "bun"
-            | "awk"
-            | "tclsh"
-    )
+    interpreter_hint(alias).is_some()
 }
 
 /// `256MiB`, `1GiB`, `512M`, `1073741824`.
@@ -1121,6 +1130,27 @@ mod tests {
 
     fn spec_from(s: &str) -> Spec {
         toml::from_str(s).expect("parses")
+    }
+
+    #[test]
+    fn a_recognised_interpreter_says_how_it_takes_code() {
+        // `celln image add` writes these into a catalogue entry, and
+        // `agent --tool` refuses any entry missing them. A name on this list
+        // without a flag would add a tool that cannot then be used.
+        for alias in ["/usr/bin/python3.12", "/bin/sh", "/usr/local/bin/node"] {
+            let (language, flag) = interpreter_hint(alias).expect("recognised");
+            assert!(!language.is_empty() && !flag.is_empty(), "{alias}");
+            assert!(looks_like_interpreter(alias), "{alias}");
+        }
+    }
+
+    #[test]
+    fn a_compiler_is_not_an_interpreter() {
+        // A model's program reaches an interpreter on a flag; `go` and `gcc`
+        // want a file, so `--tool go` should fail rather than guess a flag.
+        for alias in ["/usr/bin/go", "/usr/bin/gcc", "/usr/bin/curl"] {
+            assert!(interpreter_hint(alias).is_none(), "{alias}");
+        }
     }
 
     #[test]

--- a/scripts/refresh-tool-digests.sh
+++ b/scripts/refresh-tool-digests.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Re-resolve every tag the tool catalogue pins, and rewrite any pin that moved.
+#
+# The catalogue pins by digest so a moved tag can never change what a cell is
+# lent without celln changing. Keeping those pins current is therefore a code
+# change: this rewrites them in place and the caller opens a pull request, so
+# the update arrives with a diff and a review rather than at pull time.
+#
+# Writes `changed=1` to $GITHUB_OUTPUT when any pin moved. Exits non-zero if a
+# tag could not be resolved, so a half-checked catalogue never becomes a PR.
+#
+# Test it without touching a registry:
+#   scripts/refresh-tool-digests.sh --self-test
+
+set -euo pipefail
+
+f=${1:-crates/celln-cli/tools.toml}
+
+resolve() { skopeo inspect --format '{{.Digest}}' "docker://$1"; }
+
+# `docker.io/library/python:3.12-slim` -> `docker.io/library/python`, without
+# eating the port in `registry:5000/team/tool:v1`. Only a colon in the last
+# path segment starts a tag.
+repo_of() {
+    case "${1##*/}" in
+    *:*) printf '%s' "${1%:*}" ;;
+    *) printf '%s' "$1" ;;
+    esac
+}
+
+# A registry can answer with something that is not a digest — an empty string
+# on a hiccup, an error on a rate limit. Writing that produces a ref no pull
+# can ever satisfy, so nothing unverified reaches the file.
+is_digest() {
+    local hex=${1#sha256:}
+    [ "$1" != "$hex" ] && [ ${#hex} -eq 64 ] &&
+        case "$hex" in *[!0-9a-f]*) false ;; *) true ;; esac
+}
+
+refresh() {
+    local f=$1 changed=0 failed=0 tag name old new digest
+    while IFS= read -r tag; do
+        [ -n "$tag" ] || continue
+        if ! digest=$(resolve "$tag" 2>&1); then
+            echo "  ! $tag: could not resolve: $digest" >&2
+            failed=1
+            continue
+        fi
+        if ! is_digest "$digest"; then
+            echo "  ! $tag: not a digest: ${digest:-<empty>}" >&2
+            failed=1
+            continue
+        fi
+        name=$(repo_of "$tag")
+        old=$(grep -A1 "^tag = \"$tag\"$" "$f" | grep -oP '^ref = "\K[^"]+' || true)
+        new="$name@$digest"
+        [ "$old" = "$new" ] && continue
+        echo "  $tag: $old -> $new"
+        python3 - "$f" "$tag" "$new" <<'PY'
+import sys, re
+path, tag, new = sys.argv[1:4]
+s = open(path).read()
+s, n = re.subn(rf'(^tag = "{re.escape(tag)}"$\n)ref = "[^"]+"',
+               rf'\g<1>ref = "{new}"', s, flags=re.M)
+if n != 1:
+    sys.exit(f"  ! {tag}: rewrote {n} pins, expected exactly 1")
+open(path, "w").write(s)
+PY
+        changed=1
+    done < <(grep -oP '^tag = "\K[^"]+' "$f")
+
+    [ -n "${GITHUB_OUTPUT:-}" ] && echo "changed=$changed" >>"$GITHUB_OUTPUT"
+    [ "$failed" -eq 0 ] || {
+        echo "one or more tags could not be resolved; not proposing a change" >&2
+        return 1
+    }
+    return 0
+}
+
+# ── self-test ────────────────────────────────────────────────────────────────
+# The real thing runs weekly against a live registry, so it is exactly the kind
+# of code that is only ever exercised in production. These stub the registry.
+
+self_test() {
+    local dir rc=0
+    dir=$(mktemp -d)
+    trap 'rm -rf "$dir"' RETURN
+    mkdir -p "$dir/bin"
+    export PATH="$dir/bin:$PATH"
+
+    _stub() { printf '#!/bin/sh\n%s\n' "$1" >"$dir/bin/skopeo"; chmod +x "$dir/bin/skopeo"; }
+    _fixture() {
+        cat >"$dir/t.toml" <<EOF
+[[image]]
+name = "python"
+tag = "docker.io/library/python:3.12-slim"
+ref = "docker.io/library/python@sha256:$(printf '2%.0s' {1..64})"
+
+[[image]]
+name = "internal"
+tag = "reg.example.com:5000/team/tool:v1"
+ref = "reg.example.com:5000/team/tool@sha256:$(printf '3%.0s' {1..64})"
+EOF
+    }
+    _check() {
+        if [ "$2" = "$3" ]; then echo "  ok   $1"; else
+            echo "  FAIL $1"; echo "        want: $3"; echo "        got:  $2"; rc=1
+        fi
+    }
+
+    local a b ec GITHUB_OUTPUT=$dir/out
+
+    # A moved tag is rewritten; an unmoved one is left alone.
+    _fixture
+    a=$(printf '2%.0s' {1..64}); b=$(printf 'a%.0s' {1..64})
+    _stub "case \"\$4\" in *python*) echo sha256:$b ;; *) echo sha256:$(printf '3%.0s' {1..64}) ;; esac"
+    : >"$GITHUB_OUTPUT"
+    refresh "$dir/t.toml" >/dev/null
+    _check "a moved pin is rewritten" \
+        "$(grep -c "python@sha256:$b" "$dir/t.toml")" "1"
+    _check "an unmoved pin is untouched" \
+        "$(grep -c "tool@sha256:$(printf '3%.0s' {1..64})" "$dir/t.toml")" "1"
+    _check "it reports that something changed" "$(cat "$GITHUB_OUTPUT")" "changed=1"
+
+    # Running again with nothing moved must be a no-op.
+    : >"$GITHUB_OUTPUT"
+    refresh "$dir/t.toml" >/dev/null
+    _check "a second run reports no change" "$(cat "$GITHUB_OUTPUT")" "changed=0"
+
+    # A registry hiccup must not become a pin. This is the one that matters:
+    # an empty answer used to be written as `ref = "reg.example.com@"`.
+    _fixture
+    _stub 'echo ""'
+    : >"$GITHUB_OUTPUT"
+    refresh "$dir/t.toml" >/dev/null 2>&1 && ec=0 || ec=$?
+    _check "an empty digest fails the run" "exit $ec" "exit 1"
+    _check "an empty digest is never written" "$(grep -c '@"' "$dir/t.toml")" "0"
+
+    # A registry port is not a tag.
+    _fixture
+    b=$(printf 'b%.0s' {1..64})
+    _stub "case \"\$4\" in *5000*) echo sha256:$b ;; *) echo sha256:$a ;; esac"
+    : >"$GITHUB_OUTPUT"
+    refresh "$dir/t.toml" >/dev/null
+    _check "a registry port survives" \
+        "$(grep -c "^ref = \"reg.example.com:5000/team/tool@sha256:$b\"$" "$dir/t.toml")" "1"
+
+    # A tag that resolves to a non-digest is refused.
+    _fixture
+    _stub 'echo "unauthorized: authentication required"'
+    : >"$GITHUB_OUTPUT"
+    refresh "$dir/t.toml" >/dev/null 2>&1 && ec=0 || ec=$?
+    _check "an error string fails the run" "exit $ec" "exit 1"
+    _check "an error string is never written" "$(grep -c 'unauthorized' "$dir/t.toml")" "0"
+
+    [ "$rc" -eq 0 ] && echo "  all checks passed"
+    return "$rc"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    self_test
+else
+    refresh "$f"
+fi


### PR DESCRIPTION
Two fixes that started from one report: `celln agent --tool go` says what is
available and nothing about how to get more.

## Naming a tool the host does not have

The message now gives the command, including the `--name` form — the reported
example needs it, since Docker publishes `golang`, not `go`.

```
error: no tool named "go". Available: python, curl

  Add it from an image that carries it:
    celln image add go:<tag>

  If it is published under a different name, map it:
    celln image add <image>:<tag> --name go

  The tag is resolved to a digest and pinned, so what a cell is lent
  cannot change afterwards. `celln image catalogue` lists everything
  this host knows how to lend.
```

Writing that hint exposed why it would not have helped: **`celln image add`
wrote `interpreter` but never `language` or `code_flag`**, and `agent --tool`
refuses an entry missing them. Following the advice landed you in a second
error about fields nobody had told you to write. A recognised interpreter now
records the flag it takes code on.

Proven on a fresh store:

```
celln image add akorn/lua:5.4-alpine --name lua     # 22 MiB
celln agent --tool lua "print the first 8 fibonacci numbers, one per line"
  ✔ pilot: /usr/bin/lua permitted:agent
  0 1 1 2 3 5 8 13
```

Agent lane, as it should be — the model wrote that program.

The second error was rewritten too, since `--tool curl` reaches it fairly. It
now explains that `--tool` needs an interpreter taking a program on a flag,
which a compiler or curl has no reason to do, and points at `celln image spec`.

## The digest refresh workflow

Checking that hint sent me to the catalogue, and the workflow that keeps it
current **had never run its own body** — it is gated on a digest having moved,
and none had. Three faults, worth fixing together because the first was
masking the others:

- Its one verification ran `cargo test -p celln-cli --lib catalogue`.
  `celln-cli` has no lib target, so that errors rather than running the tests.
  It failing is the only thing that would have stopped the next two reaching a
  pull request.
- A registry answering with a non-digest — empty on a hiccup, `unauthorized`
  on a rate limit — was pinned verbatim as `ref = "docker.io/library/python@"`.
- Stripping a tag ate the port of any registry that has one:
  `reg:5000/team/tool:v1` → `reg`.

Both of the last two are reproduced against a stub registry, and fixing only
the first would have turned "never opens a PR" into "can open a PR pinning a
digest that does not exist".

The logic moves into `scripts/refresh-tool-digests.sh` so it can be run and
tested without a registry. `--self-test` covers all three and runs in ci on
every PR — weekly-only code is otherwise tested exclusively in production.
Verified the checks bite: removing the digest guard fails exactly the four
that cover it. Run against the live registry, it reports the pins current and
leaves the file untouched.

## Checks

`cargo fmt --check`, `clippy -D warnings`, 19 suites including the 29 KVM
proofs, and the refresher self-test. Two spec tests added: every name on the
interpreter list carries a code flag, and `go`/`gcc`/`curl` stay off it.