### PR TITLE
fix: make it impossible to publish crates in a broken order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       # this it would only ever be exercised in production. It stubs skopeo.
       - name: the tool-digest refresher still holds
         run: scripts/refresh-tool-digests.sh --self-test
+      # An inter-crate pin left behind at an older version publishes fine and
+      # breaks for whoever installs it, so it must not reach main.
+      - name: crate versions agree
+        run: scripts/release.sh --check
       # The CLI has to work on a machine with no hardware isolation, because
       # most people will meet it there first.
       - name: cli works without /dev/kvm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Publishing a crate before a sibling it depends on silently shipped a
+  version that cannot be installed.** Cargo resolves a requirement to the
+  newest version satisfying it, so a dependent published ahead of its
+  dependency does not fail — it succeeds, and breaks for whoever runs
+  `cargo install`. Every inter-crate requirement was pinned at `0.5.0` while
+  the workspace was four releases past it, which made this reachable at any
+  time; 0.5.4 came within one command of it, with `celln-cli` calling a
+  `celln-spec` function that published `celln-spec` did not have.
+
+  Requirements now track the workspace version exactly, so a missing sibling
+  is a publish-time refusal instead. They live in `[workspace.dependencies]`
+  so there is one place to move them, `scripts/release.sh --bump` moves them
+  with the version, and `--check` fails if one drifts — which ci runs on
+  every PR. `--publish` derives its order from the dependency graph and waits
+  for each crate to reach the index before the next.
+
+### Changed
+
+- The README's spec example moved below installation, so the page reads
+  one-liner, what it is, install, then the durable form.
+
 ## 0.5.4
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,20 @@ repository = "https://github.com/sympozium-ai/celln"
 
 # Pinned to versions that build on Rust 1.75 (edition 2021).
 [workspace.dependencies]
+# Inter-crate versions track `workspace.package.version` exactly, and
+# `scripts/release.sh --bump` moves them together. A pin left behind at an
+# older version is not a stale nicety: publishing a crate whose sibling has not
+# been published yet then succeeds, and breaks for whoever runs `cargo install`,
+# because cargo resolves a requirement to the newest version satisfying it.
+# Requiring the current version turns that into a publish-time refusal.
+# `scripts/release.sh --check` fails if one of these drifts, and ci runs it.
+celln-manifest = { version = "0.5.4", path = "crates/celln-manifest" }
+celln-spec = { version = "0.5.4", path = "crates/celln-spec" }
+celln-store = { version = "0.5.4", path = "crates/celln-store" }
+celln-assay = { version = "0.5.4", path = "crates/celln-assay" }
+celln-forge = { version = "0.5.4", path = "crates/celln-forge" }
+celln-pilot = { version = "0.5.4", path = "crates/celln-pilot" }
+celln-warden = { version = "0.5.4", path = "crates/celln-warden" }
 blake3 = "=1.5.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -28,11 +28,56 @@ demotes the invocation. Authority is decided per call, not per binary.
        alt="Two digest-pinned tool images are lent into a hardware-isolated cell, each sealed read-only at its own mount. A model writes a program, an attested python is asked to run it and that call is demoted to the agent lane, it runs and returns its answer, and the lend is finally taken back as the cell dissolves.">
 </p>
 
+## How is this different?
+
+Most agent runtimes give an agent a machine. Celln gives it a temporary,
+read-only lease on the tools it needs.
+
+[Read the documentation →](https://sympozium-ai.github.io/celln/) ·
+[Guided tutorial →](https://sympozium-ai.github.io/celln/tutorial.html)
+
+> *Software is a service the host provides to the process, not property the
+> machine owns.*
+
+## Install
+
+```sh
+brew install sympozium-ai/celln/celln
+```
+
+Homebrew names the `sympozium-ai/homebrew-celln` repository as the
+`sympozium-ai/celln` tap. The tap and source repository are public. On Linux,
+the formula downloads the static release archive; it does not build Celln with
+Rust locally. Building from source needs the one static target that the local
+build plane uses for generated programs:
+
+```sh
+rustup target add x86_64-unknown-linux-musl
+```
+
+Release archives target Linux x86_64; Celln does not publish an ARM64 archive
+while its KVM backend is x86-specific.
+
+<details>
+<summary>or from source</summary>
+
+```sh
+git clone https://github.com/sympozium-ai/celln.git
+cd celln
+cargo build --release -p celln-cli
+./target/release/celln doctor
+```
+</details>
+
+Sealing cells needs Linux with `/dev/kvm`; generated-program cells additionally
+need `gcc`, `cpio`, and `e2fsprogs`. Everywhere else `celln` still validates
+specs and runs `celln demo`, and `celln doctor` says which you have.
+
 ## Declaring it instead
 
-That one-liner is the short path. For anything you'd repeat, a spec is the
-durable artifact — reviewable, checked in, and the thing that says what a cell
-may ever be lent. Two tools, from two separate images, in one cell:
+The one-liner at the top is the short path. For anything you'd repeat, a spec is
+the durable artifact — reviewable, checked in, and the thing that says what a
+cell may ever be lent. Two tools, from two separate images, in one cell:
 
 ```toml
 # cell.toml
@@ -89,51 +134,6 @@ $ celln image add node:22-slim
   + added node to ~/.celln/tools.toml
       /usr/bin/node → /usr/local/bin/node
 ```
-
-## How is this different?
-
-Most agent runtimes give an agent a machine. Celln gives it a temporary,
-read-only lease on the tools it needs.
-
-[Read the documentation →](https://sympozium-ai.github.io/celln/) ·
-[Guided tutorial →](https://sympozium-ai.github.io/celln/tutorial.html)
-
-> *Software is a service the host provides to the process, not property the
-> machine owns.*
-
-## Install
-
-```sh
-brew install sympozium-ai/celln/celln
-```
-
-Homebrew names the `sympozium-ai/homebrew-celln` repository as the
-`sympozium-ai/celln` tap. The tap and source repository are public. On Linux,
-the formula downloads the static release archive; it does not build Celln with
-Rust locally. Building from source needs the one static target that the local
-build plane uses for generated programs:
-
-```sh
-rustup target add x86_64-unknown-linux-musl
-```
-
-Release archives target Linux x86_64; Celln does not publish an ARM64 archive
-while its KVM backend is x86-specific.
-
-<details>
-<summary>or from source</summary>
-
-```sh
-git clone https://github.com/sympozium-ai/celln.git
-cd celln
-cargo build --release -p celln-cli
-./target/release/celln doctor
-```
-</details>
-
-Sealing cells needs Linux with `/dev/kvm`; generated-program cells additionally
-need `gcc`, `cpio`, and `e2fsprogs`. Everywhere else `celln` still validates
-specs and runs `celln demo`, and `celln doctor` says which you have.
 
 ## Use it
 

--- a/crates/celln-assay/Cargo.toml
+++ b/crates/celln-assay/Cargo.toml
@@ -16,9 +16,9 @@ name = "assay"
 path = "src/lib.rs"
 
 [dependencies]
-celln-manifest = { version = "0.5.0", path = "../celln-manifest" }
-celln-forge = { version = "0.5.0", path = "../celln-forge" }
-celln-store = { version = "0.5.0", path = "../celln-store" }
+celln-manifest.workspace = true
+celln-forge.workspace = true
+celln-store.workspace = true
 clap.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/celln-cli/Cargo.toml
+++ b/crates/celln-cli/Cargo.toml
@@ -13,13 +13,13 @@ name = "celln"
 path = "src/main.rs"
 
 [dependencies]
-celln-spec = { version = "0.5.0", path = "../celln-spec" }
-celln-manifest = { version = "0.5.0", path = "../celln-manifest" }
-celln-store = { version = "0.5.0", path = "../celln-store" }
-celln-assay = { version = "0.5.0", path = "../celln-assay" }
-celln-forge = { version = "0.5.0", path = "../celln-forge" }
-celln-pilot = { version = "0.5.0", path = "../celln-pilot" }
-celln-warden = { version = "0.5.0", path = "../celln-warden" }
+celln-spec.workspace = true
+celln-manifest.workspace = true
+celln-store.workspace = true
+celln-assay.workspace = true
+celln-forge.workspace = true
+celln-pilot.workspace = true
+celln-warden.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 serde.workspace = true
@@ -38,4 +38,4 @@ libc.workspace = true
 # else `celln` still validates specs and runs the mock proof, and says so rather
 # than pretending.
 [target.'cfg(target_os = "linux")'.dependencies]
-celln-warden = { version = "0.5.0", path = "../celln-warden", features = ["kvm"] }
+celln-warden = { workspace = true, features = ["kvm"] }

--- a/crates/celln-forge/Cargo.toml
+++ b/crates/celln-forge/Cargo.toml
@@ -11,6 +11,6 @@ description = "The build plane: rebuilds an artifact from source and proves the 
 name = "forge"
 
 [dependencies]
-celln-manifest = { version = "0.5.0", path = "../celln-manifest" }
+celln-manifest.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/celln-pilot/Cargo.toml
+++ b/crates/celln-pilot/Cargo.toml
@@ -48,10 +48,10 @@ name = "pilot"
 path = "src/lib.rs"
 
 [dependencies]
-celln-manifest = { version = "0.5.0", path = "../celln-manifest" }
-celln-store = { version = "0.5.0", path = "../celln-store" }
-celln-assay = { version = "0.5.0", path = "../celln-assay" }
-celln-warden = { version = "0.5.0", path = "../celln-warden" }
+celln-manifest.workspace = true
+celln-store.workspace = true
+celln-assay.workspace = true
+celln-warden.workspace = true
 libc.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/celln-store/Cargo.toml
+++ b/crates/celln-store/Cargo.toml
@@ -11,7 +11,7 @@ description = "Content-addressed store: the on-disk half of assay's distro."
 name = "celln_store"
 
 [dependencies]
-celln-manifest = { version = "0.5.0", path = "../celln-manifest" }
+celln-manifest.workspace = true
 blake3.workspace = true
 thiserror.workspace = true
 

--- a/crates/celln-warden/Cargo.toml
+++ b/crates/celln-warden/Cargo.toml
@@ -19,7 +19,7 @@ mock = []
 kvm = ["dep:kvm-ioctls", "dep:kvm-bindings", "dep:libc"]
 
 [dependencies]
-celln-manifest = { version = "0.5.0", path = "../celln-manifest" }
+celln-manifest.workspace = true
 thiserror.workspace = true
 kvm-ioctls = { workspace = true, optional = true }
 kvm-bindings = { workspace = true, optional = true }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Publish the workspace to crates.io, in an order that cannot break.
+#
+# Cargo resolves a dependency requirement to the newest version satisfying it,
+# so publishing a crate before a sibling it depends on does not fail — it
+# succeeds, and breaks later for whoever runs `cargo install`. That happened
+# on the way to 0.5.4: `celln-cli` called a new `celln-spec` function while
+# published `celln-spec` was still 0.5.0.
+#
+# Two things prevent it here. Inter-crate requirements track the workspace
+# version exactly, so a missing sibling is a publish-time refusal rather than a
+# broken release; `--check` enforces that and runs in ci. And publish order is
+# derived from the dependency graph, not from a list someone maintains.
+#
+#   scripts/release.sh --check          verify versions agree (ci runs this)
+#   scripts/release.sh --bump 0.5.5     move every version together
+#   scripts/release.sh --dry-run        show what would be published
+#   scripts/release.sh --publish        publish, in dependency order
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ws_version() { grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2; }
+
+# Workspace members in an order where every crate follows what it depends on.
+publish_order() {
+    cargo metadata --format-version 1 --no-deps 2>/dev/null | python3 -c '
+import json, sys
+m = json.load(sys.stdin)
+names = {p["name"] for p in m["packages"]}
+deps = {p["name"]: {d["name"] for d in p["dependencies"]} & names for p in m["packages"]}
+out = []
+while deps:
+    ready = sorted(n for n, d in deps.items() if not d - set(out))
+    if not ready:
+        sys.exit("dependency cycle: " + ", ".join(sorted(deps)))
+    out += ready
+    for n in ready:
+        del deps[n]
+print("\n".join(out))
+'
+}
+
+# Every inter-crate requirement must equal the workspace version.
+check() {
+    local v rc=0 name req
+    v=$(ws_version)
+    echo "workspace version ${v}"
+
+    local seen=0
+    while IFS='=' read -r name req; do
+        seen=$((seen + 1))
+        if [ "$req" = "$v" ]; then
+            echo "  ok   $name = \"$req\""
+        else
+            echo "  FAIL $name = \"$req\", expected \"$v\""
+            rc=1
+        fi
+    done < <(sed -n 's/^\(celln-[a-z]*\) = { version = "\([^"]*\)".*/\1=\2/p' Cargo.toml)
+
+    # An empty list would make this pass while checking nothing.
+    [ "$seen" -gt 0 ] || {
+        echo "  FAIL no inter-crate versions found in Cargo.toml"
+        rc=1
+    }
+
+    # A crate that changed but kept its version ships nothing; catch the case
+    # where the tag exists already.
+    if git rev-parse -q --verify "refs/tags/v${v}" >/dev/null 2>&1 &&
+        [ "$(git rev-parse "v${v}")" != "$(git rev-parse HEAD)" ]; then
+        echo "  note v${v} is already tagged at a different commit"
+    fi
+
+    grep -q "^## ${v}\$" CHANGELOG.md || {
+        echo "  FAIL CHANGELOG.md has no '## ${v}' entry"
+        rc=1
+    }
+    return "$rc"
+}
+
+# Move the workspace version and every inter-crate requirement together, so
+# they cannot drift apart in the first place.
+bump() {
+    local from to
+    to=$1
+    from=$(ws_version)
+    [ "$from" != "$to" ] || {
+        echo "already at ${to}"
+        return 0
+    }
+    sed -i "0,/^version = \"${from}\"/s//version = \"${to}\"/" Cargo.toml
+    sed -i "s/^\(celln-[a-z]* = { version = \)\"${from}\"/\1\"${to}\"/" Cargo.toml
+    echo "${from} -> ${to}"
+    grep -E '^(version|celln-[a-z]+) = ' Cargo.toml | sed 's/^/  /'
+}
+
+published() {
+    local crate=$1 version=$2 path
+    path=$(printf '%s' "$crate" | cut -c1-2)/$(printf '%s' "$crate" | cut -c3-4)/"$crate"
+    curl -sf -A "celln-release" "https://index.crates.io/${path}" 2>/dev/null |
+        grep -q "\"vers\":\"${version}\""
+}
+
+publish() {
+    local dry=$1 v crate
+    v=$(ws_version)
+    check >/dev/null || {
+        check
+        echo "refusing to publish with versions that disagree" >&2
+        return 1
+    }
+    for crate in $(publish_order); do
+        if published "$crate" "$v"; then
+            echo "  · ${crate} ${v} already on crates.io"
+            continue
+        fi
+        if $dry; then
+            echo "  → would publish ${crate} ${v}"
+            continue
+        fi
+        echo "  → publishing ${crate} ${v}"
+        # No --no-verify: verification builds the packaged crate against the
+        # registry, which is what catches a sibling that is not there yet.
+        cargo publish -p "$crate"
+        # The next crate's requirement cannot resolve until this one is in the
+        # index, so wait rather than racing it.
+        for _ in $(seq 1 60); do
+            published "$crate" "$v" && break
+            sleep 5
+        done
+        published "$crate" "$v" || {
+            echo "  ! ${crate} ${v} did not appear in the index" >&2
+            return 1
+        }
+    done
+    echo "  all crates at ${v}"
+}
+
+case "${1:---check}" in
+--check) check ;;
+--bump) bump "${2:?usage: release.sh --bump X.Y.Z}" ;;
+--dry-run) publish true ;;
+--publish) publish false ;;
+*)
+    sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Cutting 0.5.4 came within one command of shipping a version nobody could
install. Worth fixing at the mechanism, not the instance.

## The trap

Cargo resolves a requirement to the newest version satisfying it. So publishing
a dependent *before* the dependency it needs does not fail — it succeeds, and
breaks later for whoever runs `cargo install`.

Every inter-crate requirement was pinned at `0.5.0` while the workspace was at
`0.5.4`, four releases on. `celln-cli` 0.5.4 calls `celln_spec::interpreter_hint`,
new in this release, and published `celln-spec` was still 0.5.0 — which
satisfies `^0.5.0`. Publishing `celln-cli` alone, the way 0.5.3 went out, would
have produced a release that installs and then fails to compile. It only went
out correctly because I checked the graph by hand first.

`--no-verify`, used on every publish so far, is exactly the flag that hides it.

## The fix

Inter-crate requirements now track the workspace version exactly, which turns
the silent break into a publish-time refusal. Verified against the real
registry — a requirement for a version that is not published errors during
resolution:

```
error: failed to select a version for the requirement `celln-spec = "^0.5.99"`
candidate versions found which didn't match: 0.5.4
```

They live in `[workspace.dependencies]`, so the 18 scattered pins become 7
entries in one place next to the version they must match.

`scripts/release.sh`:

- `--check` — every requirement equals the workspace version, and the CHANGELOG
  has an entry for it. **ci runs this on every PR**, so a stale pin cannot
  reach main. Reproduced the 0.5.4 trap against it: exit 1, and `--dry-run`
  refuses to publish.
- `--bump X.Y.Z` — moves the version and all seven requirements together, so
  they cannot drift in the first place.
- `--publish` — derives order from the dependency graph via `cargo metadata`
  rather than a hand-maintained list, skips crates already at that version, and
  waits for each to reach the index before the next. Drops `--no-verify`, since
  verification is what catches an absent sibling.

Derived order, confirmed: manifest → spec → forge → store → warden → assay →
pilot → cli.

## Consequence worth knowing

Exact requirements mean **every release now publishes the whole workspace**,
not just the crates that changed. That is the cost of the guarantee, and
`--publish` handles it.

## Also

Moves the README spec example below installation, so the page reads one-liner,
what it is, install, then the durable form.

## Checks

`cargo fmt --check`, `clippy -D warnings`, 19 suites including the 29 KVM
proofs, the digest-refresher self-test, `release.sh --check`, and the KVM
feature confirmed still active through the new dependency form.