### PR TITLE
test(kubernetes): add the first conformance preflight

### DIFF
--- a/integrations/kubernetes/Dockerfile
+++ b/integrations/kubernetes/Dockerfile
@@ -9,4 +9,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /opt/celln/runtime /var/lib/celln
+COPY celln /usr/local/bin/celln
 ENTRYPOINT ["/usr/local/bin/celln"]

--- a/integrations/kubernetes/README.md
+++ b/integrations/kubernetes/README.md
@@ -23,23 +23,17 @@ the host root filesystem, or an ambient network capability into a cell.
 ./integrations/kubernetes/prove.sh
 ```
 
-The script builds and loads the local image, deploys the DaemonSet, and writes the
-real node report and admission verdict below `target/kubernetes-proof/`. The current
-kind node exposes `/dev/kvm`, so an unavailable KVM boundary would be reported as
-`unsupported`, never silently downgraded. It does not contain a prepared Celln mote
-or tool store, so this fresh cluster truthfully returns `no_eligible_node`. Populate
-signed mote and tool stores on the node before a node is eligible; do not create
-placeholder files just to make the report pass.
+The preflight requires Cargo, Docker, Kind, kubectl, and jq on an x86-64 host.
+The script builds the static Celln CLI, packages it as `celln-node:dev`, loads it
+into an ephemeral Kind cluster, and writes evidence below
+`target/kubernetes-proof/`. Its first conformance case deliberately gives the pod
+no `/dev/kvm`: an execution request requiring hardware isolation must exit `5`
+and return `verdict: refused` with `reason: unsupported`, never silently
+downgrade or pretend the request ran.
 
-The command emits JSON only. `verdict: accepted` means the node admitted the intent;
-it does not claim the request's workload was run. An accepted node now also requires
-a bootable guest kernel: KVM visibility and non-empty directories are not a truthful
-execution capability. The versioned terminal result contract is
-[`examples/execution/succeeded-receipt.json`](../../examples/execution/succeeded-receipt.json);
-it binds a request, node, cell, resolved authority, and optional output to immutable
-BLAKE3 references. It is a contract for the dispatcher, not evidence that a dispatcher
-exists yet. Executing a workload through the node agent and writing that receipt back
-to Sympozium remains the next slice.
+This is an admission preflight, not an isolation proof. It does not accept or run
+the workload, and it makes no claim about guest enforcement. The cluster is
+deleted after the run; set `KEEP_CLUSTER=1` to retain it for inspection.
 
 ## Exercise actual Celln cells on the KVM host
 
@@ -60,9 +54,3 @@ latter; it stores raw hardware measurements in `target/celln-bench/`.
 
 Open `docs/kubernetes.html` locally for the full-stack SVG and two animated
 walkthroughs, including the recorded 10- and 20-run measurements.
-
-Clean up with:
-
-```sh
-kubectl delete -f integrations/kubernetes/node-probe.yaml
-```

--- a/integrations/kubernetes/README.md
+++ b/integrations/kubernetes/README.md
@@ -23,17 +23,23 @@ the host root filesystem, or an ambient network capability into a cell.
 ./integrations/kubernetes/prove.sh
 ```
 
-The preflight requires Cargo, Docker, Kind, kubectl, and jq on an x86-64 host.
-The script builds the static Celln CLI, packages it as `celln-node:dev`, loads it
-into an ephemeral Kind cluster, and writes evidence below
-`target/kubernetes-proof/`. Its first conformance case deliberately gives the pod
-no `/dev/kvm`: an execution request requiring hardware isolation must exit `5`
-and return `verdict: refused` with `reason: unsupported`, never silently
-downgrade or pretend the request ran.
+The script builds and loads the local image, deploys the DaemonSet, and writes the
+real node report and admission verdict below `target/kubernetes-proof/`. The current
+kind node exposes `/dev/kvm`, so an unavailable KVM boundary would be reported as
+`unsupported`, never silently downgraded. It does not contain a prepared Celln mote
+or tool store, so this fresh cluster truthfully returns `no_eligible_node`. Populate
+signed mote and tool stores on the node before a node is eligible; do not create
+placeholder files just to make the report pass.
 
-This is an admission preflight, not an isolation proof. It does not accept or run
-the workload, and it makes no claim about guest enforcement. The cluster is
-deleted after the run; set `KEEP_CLUSTER=1` to retain it for inspection.
+The command emits JSON only. `verdict: accepted` means the node admitted the intent;
+it does not claim the request's workload was run. An accepted node now also requires
+a bootable guest kernel: KVM visibility and non-empty directories are not a truthful
+execution capability. The versioned terminal result contract is
+[`examples/execution/succeeded-receipt.json`](../../examples/execution/succeeded-receipt.json);
+it binds a request, node, cell, resolved authority, and optional output to immutable
+BLAKE3 references. It is a contract for the dispatcher, not evidence that a dispatcher
+exists yet. Executing a workload through the node agent and writing that receipt back
+to Sympozium remains the next slice.
 
 ## Exercise actual Celln cells on the KVM host
 
@@ -54,3 +60,9 @@ latter; it stores raw hardware measurements in `target/celln-bench/`.
 
 Open `docs/kubernetes.html` locally for the full-stack SVG and two animated
 walkthroughs, including the recorded 10- and 20-run measurements.
+
+Clean up with:
+
+```sh
+kubectl delete -f integrations/kubernetes/node-probe.yaml
+```

--- a/integrations/kubernetes/conformance/unsupported-hardware.yaml
+++ b/integrations/kubernetes/conformance/unsupported-hardware.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: celln-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: celln-conformance-unsupported-request
+  namespace: celln-system
+data:
+  request.json: |
+    {
+      "apiVersion": "celln.dev/v1alpha1",
+      "id": "celln-conformance-unsupported",
+      "workload": {
+        "id": "conformance-unsupported",
+        "caller": "celln:conformance"
+      },
+      "mote": {
+        "hash": "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "tools": [],
+      "capabilities": {
+        "workspace": "none",
+        "egress": [],
+        "timeoutMs": 30000,
+        "memoryBytes": 268435456,
+        "outputBytes": 65536
+      },
+      "execution": {
+        "lane": "agent",
+        "requireHardwareIsolation": true
+      }
+    }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: celln-conformance-unsupported
+  namespace: celln-system
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: celln-conformance
+        celln.dev/conformance-case: unsupported-hardware
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      containers:
+      - name: conformance
+        image: celln-node:dev
+        imagePullPolicy: Never
+        command: ["/bin/sh", "-ec"]
+        args:
+        - |
+          set +e
+          output="$(celln node admit /requests/request.json \
+            --node-name="$NODE_NAME" \
+            --mote-store=/var/lib/celln/motes \
+            --tool-store=/var/lib/celln/tools \
+            --max-cells=1 \
+            --memory-bytes=268435456 2>&1)"
+          status=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$status" -ne 5 ]; then
+            echo "expected celln node admit to exit 5, got $status" >&2
+            exit 1
+          fi
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: request
+          mountPath: /requests
+          readOnly: true
+      volumes:
+      - name: request
+        configMap:
+          name: celln-conformance-unsupported-request

--- a/integrations/kubernetes/prove.sh
+++ b/integrations/kubernetes/prove.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Run the first Kubernetes execution-plane conformance case.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+out="${CELLN_KUBERNETES_PROOF_DIR:-$root/target/kubernetes-proof}"
+cluster="${CELLN_KIND_CLUSTER:-celln-conformance}"
+context="kind-$cluster"
+image="celln-node:dev"
+manifest="$root/integrations/kubernetes/conformance/unsupported-hardware.yaml"
+binary="$root/target/x86_64-unknown-linux-musl/release/celln"
+image_context="$(mktemp -d "${TMPDIR:-/tmp}/celln-conformance-image.XXXXXX")"
+cluster_created=false
+
+cleanup() {
+  rm -rf "$image_context"
+  if [[ "$cluster_created" == true && "${KEEP_CLUSTER:-0}" != 1 ]]; then
+    kind delete cluster --name "$cluster" >/dev/null
+  fi
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "error: $1 is required to run the Kubernetes conformance preflight" >&2
+    exit 1
+  }
+}
+
+for tool in cargo docker jq kind kubectl; do
+  need "$tool"
+done
+
+if [[ "$(uname -m)" != x86_64 ]]; then
+  echo "error: the Celln KVM backend and release binary currently require x86_64" >&2
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "error: the Docker daemon is unavailable" >&2
+  exit 1
+fi
+
+clusters="$(kind get clusters 2>/dev/null || true)"
+if grep -Fxq "$cluster" <<< "$clusters"; then
+  echo "error: Kind cluster '$cluster' already exists; choose CELLN_KIND_CLUSTER or delete it" >&2
+  exit 1
+fi
+
+mkdir -p "$out"
+rm -f "$out/unsupported-hardware.json" "$out/summary.json"
+
+echo "building the static Celln node binary"
+(
+  cd "$root"
+  cargo build --release --locked --target x86_64-unknown-linux-musl -p celln-cli
+)
+cp "$binary" "$image_context/celln"
+
+echo "building and loading $image"
+docker build --tag "$image" --file "$root/integrations/kubernetes/Dockerfile" "$image_context"
+kind create cluster --name "$cluster" --wait 120s
+cluster_created=true
+kind load docker-image "$image" --name "$cluster"
+
+echo "running unsupported-hardware conformance case"
+kubectl --context "$context" apply --filename "$manifest" >/dev/null
+if ! kubectl --context "$context" wait \
+  --namespace celln-system \
+  --for=condition=complete \
+  job/celln-conformance-unsupported \
+  --timeout=120s >/dev/null; then
+  kubectl --context "$context" describe \
+    --namespace celln-system job/celln-conformance-unsupported >&2 || true
+  kubectl --context "$context" logs \
+    --namespace celln-system job/celln-conformance-unsupported >&2 || true
+  exit 1
+fi
+
+raw="$out/unsupported-hardware.json"
+kubectl --context "$context" logs \
+  --namespace celln-system job/celln-conformance-unsupported | tee "$raw"
+
+jq -e '
+  .verdict == "refused" and
+  .reason == "unsupported" and
+  .request_id == "celln-conformance-unsupported" and
+  .node.kvm == false
+' "$raw" >/dev/null
+
+jq -n --slurpfile evidence "$raw" '{
+  suite: "celln-kubernetes-conformance",
+  status: "passed",
+  cases: [{
+    name: "unsupported_hardware",
+    status: "passed",
+    evidence: $evidence[0]
+  }]
+}' > "$out/summary.json"
+
+echo "conformance: unsupported hardware was truthfully refused"
+echo "evidence: $out"

--- a/integrations/kubernetes/prove.sh
+++ b/integrations/kubernetes/prove.sh
@@ -15,7 +15,7 @@ cluster_created=false
 cleanup() {
   rm -rf "$image_context"
   if [[ "$cluster_created" == true && "${KEEP_CLUSTER:-0}" != 1 ]]; then
-    kind delete cluster --name "$cluster" >/dev/null
+    kind delete cluster --name "$cluster" >/dev/null 2>&1 || true
   fi
 }
 trap cleanup EXIT
@@ -61,8 +61,8 @@ cp "$binary" "$image_context/celln"
 
 echo "building and loading $image"
 docker build --tag "$image" --file "$root/integrations/kubernetes/Dockerfile" "$image_context"
-kind create cluster --name "$cluster" --wait 120s
 cluster_created=true
+kind create cluster --name "$cluster" --wait 120s
 kind load docker-image "$image" --name "$cluster"
 
 echo "running unsupported-hardware conformance case"


### PR DESCRIPTION
## Summary

- add the missing `integrations/kubernetes/prove.sh` entrypoint
- run a deterministic execution request inside an ephemeral Kind cluster without `/dev/kvm`
- require exit code `5` and a structured `unsupported` refusal
- retain raw JSON and a machine-readable summary under `target/kubernetes-proof/`

## Why this slice

This is deliberately the smallest truthful base for #12. It exercises the public node-admission contract through Kubernetes and proves that required hardware isolation is never silently downgraded.

It is an admission preflight, not a guest-isolation proof, and it does not attempt cancellation, revocation propagation, or multi-node behavior. I would like to confirm this harness shape before extending it toward those KVM-backed cases.

## Validation

- `bash -n integrations/kubernetes/prove.sh`
- `./integrations/kubernetes/prove.sh` twice against fresh Kind clusters
- `make ci`
- `git diff --check`

Observed evidence:

```json
{"verdict":"refused","request_id":"celln-conformance-unsupported","node":{"kvm":false},"reason":"unsupported"}
```

Refs #12
