### PR TITLE
fix: close top 3 P0 findings from the critical-review epic (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ tracking misses.
 ```sh
 $ celln run agent.toml
 ● sealing cell code-reviewer
-  + /usr/bin/python        tier=verified cold — verified now, forged queued
+  + /usr/bin/python        tier=verified cold — verified now
   ✔ /usr/bin/python permitted in the agent lane
   · cell sealed, 1 tool(s) lent read-only
   ✔ pilot: /usr/bin/python permitted:agent

--- a/crates/celln-assay/src/lib.rs
+++ b/crates/celln-assay/src/lib.rs
@@ -2,22 +2,23 @@
 
 use celln_manifest::{Author, Entry, Hash, Manifest, Tier};
 use celln_store::Store;
-use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 
 pub struct Assayer {
     store: Store,
     manifest: Manifest,
     manifest_path: PathBuf,
-    rebuild_queue: VecDeque<Hash>,
 }
 
-/// Resolved tool and any deferred upgrade.
+/// Resolved tool and whether its bytes were already warm.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Resolved {
     pub hash: Hash,
     pub tier: Tier,
     pub warm: bool,
+    /// Retained for source/wire compatibility. Always false: Celln has no
+    /// background rebuild worker, and a tier is never upgraded without a real
+    /// reproducible build through `admit_forged_authored`.
     pub upgrade_queued: bool,
 }
 
@@ -44,7 +45,6 @@ impl Assayer {
             store,
             manifest,
             manifest_path,
-            rebuild_queue: VecDeque::new(),
         })
     }
 
@@ -124,7 +124,7 @@ impl Assayer {
         Ok(hash)
     }
 
-    /// Resolve warm tools directly; queue a rebuild for cold tools.
+    /// Resolve warm tools directly; admit cold upstream bytes at Verified.
     pub fn resolve(
         &mut self,
         alias: &str,
@@ -170,13 +170,11 @@ impl Assayer {
         });
         self.manifest.sign_standin();
         let _ = self.persist();
-        self.rebuild_queue.push_back(hash.clone());
-
         Ok(Resolved {
             hash,
             tier: Tier::Verified,
             warm: false,
-            upgrade_queued: true,
+            upgrade_queued: false,
         })
     }
 
@@ -200,35 +198,6 @@ impl Assayer {
         self.manifest.sign_standin();
         let _ = self.persist();
         Ok(hash)
-    }
-
-    /// Simulate one background rebuild completing: pop the queue and upgrade that
-    /// artifact's tier to Forged. Future cells silently get the better tier.
-    ///
-    /// Nothing in the production `celln run`/`celln agent` path calls this —
-    /// `rebuild_queue` is populated by [`Self::resolve`] but is only ever
-    /// drained by demo/test code (`celln-pilot`'s `demo`/`demo_kvm`, and the
-    /// tests below), and lives on an `Assayer` that is opened fresh and
-    /// dropped every CLI invocation, so nothing persists between them either.
-    /// There is currently no real background worker: a cold tool served at
-    /// `Verified` does not upgrade to `Forged` on its own. Do not surface
-    /// `upgrade_queued`/`pending_rebuilds` to a user as a promise that one is
-    /// coming unless a real worker actually drains this queue.
-    pub fn run_one_rebuild(&mut self) -> Option<Hash> {
-        let hash = self.rebuild_queue.pop_front()?;
-        if let Some(entry) = self.manifest.get(&hash).cloned() {
-            self.manifest.admit(Entry {
-                tier: Tier::Forged,
-                ..entry
-            });
-            self.manifest.sign_standin();
-            let _ = self.persist();
-        }
-        Some(hash)
-    }
-
-    pub fn pending_rebuilds(&self) -> usize {
-        self.rebuild_queue.len()
     }
 
     /// Revoke a hash fleet-wide.
@@ -298,7 +267,7 @@ mod tests {
     }
 
     #[test]
-    fn cold_serves_verified_and_queues_forged() {
+    fn cold_stays_verified_without_a_fake_upgrade() {
         let dir = tempdir().unwrap();
         let mut assayer = Assayer::open(dir.path()).unwrap();
 
@@ -311,20 +280,17 @@ mod tests {
             Tier::Verified,
             "cold path serves Verified in seconds"
         );
-        assert!(r.upgrade_queued);
-        assert_eq!(assayer.pending_rebuilds(), 1);
+        assert!(!r.upgrade_queued);
 
-        // background rebuild lands -> future resolves are Forged
-        assayer.run_one_rebuild();
-        assert_eq!(assayer.pending_rebuilds(), 0);
+        // A later resolve is warm, but no process has earned a stronger tier.
         let r2 = assayer
             .resolve("/usr/lib/leftpad", b"leftpad-bytes", false)
             .unwrap();
         assert!(r2.warm);
         assert_eq!(
             r2.tier,
-            Tier::Forged,
-            "trust ratcheted up behind the traffic"
+            Tier::Verified,
+            "trust must not upgrade without a real reproducible rebuild"
         );
     }
 

--- a/crates/celln-assay/src/lib.rs
+++ b/crates/celln-assay/src/lib.rs
@@ -204,6 +204,16 @@ impl Assayer {
 
     /// Simulate one background rebuild completing: pop the queue and upgrade that
     /// artifact's tier to Forged. Future cells silently get the better tier.
+    ///
+    /// Nothing in the production `celln run`/`celln agent` path calls this —
+    /// `rebuild_queue` is populated by [`Self::resolve`] but is only ever
+    /// drained by demo/test code (`celln-pilot`'s `demo`/`demo_kvm`, and the
+    /// tests below), and lives on an `Assayer` that is opened fresh and
+    /// dropped every CLI invocation, so nothing persists between them either.
+    /// There is currently no real background worker: a cold tool served at
+    /// `Verified` does not upgrade to `Forged` on its own. Do not surface
+    /// `upgrade_queued`/`pending_rebuilds` to a user as a promise that one is
+    /// coming unless a real worker actually drains this queue.
     pub fn run_one_rebuild(&mut self) -> Option<Hash> {
         let hash = self.rebuild_queue.pop_front()?;
         if let Some(entry) = self.manifest.get(&hash).cloned() {

--- a/crates/celln-assay/src/main.rs
+++ b/crates/celln-assay/src/main.rs
@@ -49,7 +49,7 @@ enum Cmd {
         #[arg(long)]
         interpreter: bool,
     },
-    /// Run one queued background rebuild (Verified -> Forged).
+    /// Explain how to earn Forged; retained so old scripts fail honestly.
     Rebuild,
     /// Build from source and admit at Forged — but only if it reproduces.
     ///
@@ -142,39 +142,23 @@ fn main() -> Result<()> {
             let kind = if r.warm {
                 "WARM (page-map)"
             } else {
-                "COLD (verified+queued)"
+                "COLD (verified)"
             };
             println!(
-                "resolved {alias}\n  {}\n  tier={}  {}{}",
-                r.hash,
-                r.tier,
-                kind,
-                if r.upgrade_queued {
-                    "  [forged rebuild queued]"
-                } else {
-                    ""
-                }
+                "resolved {alias}\n  {}\n  tier={}  {}",
+                r.hash, r.tier, kind
             );
         }
-        Cmd::Rebuild => match assayer.run_one_rebuild() {
-            Some(h) => println!(
-                "rebuilt -> forged: {h}\n  pending={}",
-                assayer.pending_rebuilds()
-            ),
-            None => println!("no pending rebuilds"),
-        },
+        Cmd::Rebuild => anyhow::bail!(
+            "no background rebuild queue exists; use `assay forge <alias> <source.rs>` to earn Forged"
+        ),
         Cmd::Revoke { hash } => {
             assayer.revoke(&Hash(hash.clone()));
             println!("revoked {hash} (halts in all running cells)");
         }
         Cmd::Status => {
             let m = assayer.manifest();
-            println!(
-                "manifest: {} entries  signed={}  pending_rebuilds={}",
-                m.len(),
-                m.verify_standin(),
-                assayer.pending_rebuilds()
-            );
+            println!("manifest: {} entries  signed={}", m.len(), m.verify_standin());
         }
     }
     Ok(())

--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -49,6 +49,24 @@ pub fn resolve_bundle(
     mote_root: &Path,
     tool_root: &Path,
 ) -> Result<ResolvedBundle, String> {
+    // `admit` already runs this for the HTTP dispatcher's own submit path, but
+    // `celln node resolve-file` calls this function directly on a request that
+    // was never admitted (deliberately — resolution and admission are separate
+    // commands). Without this check here, a malformed hash in the request
+    // (e.g. one containing a path-traversal segment) would flow straight into
+    // `Store::get` below relying solely on the store's own defenses.
+    let problems = request.problems();
+    if !problems.is_empty() {
+        return Err(format!(
+            "execution request is invalid ({} problem(s)): {}",
+            problems.len(),
+            problems
+                .iter()
+                .map(|p| format!("{}: {}", p.field, p.message))
+                .collect::<Vec<_>>()
+                .join("; ")
+        ));
+    }
     let mote = request
         .mote
         .as_ref()
@@ -506,6 +524,41 @@ mod tests {
         assert_eq!(resolved.kernel_hash, kernel_hash.0);
         assert_eq!(resolved.initrd_hash, initrd_hash.0);
         assert_eq!(resolved.toolfs_hash, toolfs_hash.0);
+    }
+
+    /// `celln node resolve-file` calls `resolve_bundle` directly on a request
+    /// that was never run through `admit` (that's deliberate — resolution and
+    /// admission are separate commands). A malformed hash must still be
+    /// refused here, not only by whichever caller happens to run `problems()`
+    /// first, and never reach `Store::get` at all.
+    #[test]
+    fn a_malformed_mote_hash_is_refused_before_any_store_lookup_even_without_prior_admission() {
+        let motes = tempdir().expect("mote store");
+        let tools = tempdir().expect("tool store");
+        let request: ExecutionRequest = serde_json::from_value(json!({
+            "apiVersion": "celln.dev/v1alpha1",
+            "id": "traversal-1",
+            "workload": { "id": "traversal", "caller": "sympozium:default/traversal-1" },
+            "mote": { "hash": "blake3:/etc/passwd" },
+            "tools": [{ "alias": "/tools/program", "hash": "blake3:/etc/shadow" }],
+            "invocation": { "alias": "/tools/program", "args": [] },
+            "capabilities": { "workspace": "none", "timeoutMs": 1000, "memoryBytes": 268435456, "outputBytes": 1024 },
+            "execution": { "lane": "agent", "requireHardwareIsolation": true }
+        }))
+        .expect("request parses — shape is valid JSON even though the hashes aren't");
+
+        let error =
+            resolve_bundle(&request, motes.path(), tools.path()).expect_err("must be refused");
+        assert!(
+            error.contains("mote.hash") || error.contains("invalid"),
+            "error should name the bad field, got: {error}"
+        );
+        // Confirm this was refused before ever touching the store: an empty
+        // store root has no `objects/` entries to find, but the point is the
+        // request never got far enough to try.
+        assert!(std::fs::read_dir(motes.path().join("objects"))
+            .map(|mut entries| entries.next().is_none())
+            .unwrap_or(true));
     }
 
     #[test]

--- a/crates/celln-cli/src/run.rs
+++ b/crates/celln-cli/src/run.rs
@@ -348,7 +348,7 @@ pub fn run_spec(
             "tool_resolved",
             serde_json::json!({
                 "alias": t.alias, "hash": r.hash.to_string(), "tier": r.tier.to_string(),
-                "warm": r.warm, "upgrade_queued": r.upgrade_queued, "bytes": bytes.len(),
+                "warm": r.warm, "bytes": bytes.len(),
             }),
             format!(
                 "  {} {:<22} {} {}",

--- a/crates/celln-cli/src/run.rs
+++ b/crates/celln-cli/src/run.rs
@@ -358,7 +358,7 @@ pub fn run_spec(
                 dim(if r.warm {
                     "warm — page map, no build"
                 } else {
-                    "cold — verified now, forged queued"
+                    "cold — verified now"
                 })
             ),
         );

--- a/crates/celln-pilot/src/demo.rs
+++ b/crates/celln-pilot/src/demo.rs
@@ -61,17 +61,16 @@ fn main() -> anyhow::Result<()> {
     // ---- beat 3: cold tool, still fast ----
     beat(
         3,
-        "cold tool, still fast — unseen package served Verified, Forged queued",
+        "cold tool, still honest — unseen package remains Verified",
     );
     let r = assayer.resolve("/usr/lib/leftpad", b"leftpad-upstream-bytes", false)?;
     note(&format!(
-        "resolve leftpad -> {} tier={} warm={} upgrade_queued={}",
-        r.hash, r.tier, r.warm, r.upgrade_queued
+        "resolve leftpad -> {} tier={} warm={}",
+        r.hash, r.tier, r.warm
     ));
     let bytes = assayer.fetch(&r.hash)?;
     cell.map_tool(&r.hash, &bytes)?;
-    assayer.run_one_rebuild();
-    note("background rebuild landed -> future cells get Forged");
+    note("no background upgrade claimed; Forged requires a real reproducible rebuild");
 
     // ---- beat 4: demote on exec ----
     beat(

--- a/crates/celln-pilot/src/demo_kvm.rs
+++ b/crates/celln-pilot/src/demo_kvm.rs
@@ -94,17 +94,16 @@ fn main() -> anyhow::Result<()> {
     // ---- beat 3: cold tool, still fast ----
     beat(
         3,
-        "cold tool, still fast — unseen package served Verified, Forged queued",
+        "cold tool, still honest — unseen package remains Verified",
     );
     let r = assayer.resolve("/usr/lib/leftpad", b"leftpad-upstream-bytes", false)?;
     note(&format!(
-        "resolve leftpad -> tier={} warm={} upgrade_queued={}",
-        r.tier, r.warm, r.upgrade_queued
+        "resolve leftpad -> tier={} warm={}",
+        r.tier, r.warm
     ));
     let bytes = assayer.fetch(&r.hash)?;
     cell.map_tool(&r.hash, &bytes)?;
-    assayer.run_one_rebuild();
-    note("mapped; background rebuild landed -> future cells get Forged");
+    note("mapped; no background upgrade claimed without a reproducible rebuild");
 
     // ---- beat 4: the hardware seal, attacked ----
     beat(

--- a/crates/celln-pilot/src/fetch_proof.rs
+++ b/crates/celln-pilot/src/fetch_proof.rs
@@ -103,6 +103,9 @@ fn main() -> Result<()> {
         .contains("CELLN:pilot_run_/probe=permitted:agent")
         || !report
             .console
+            .contains("CELLN_SECCOMP_BYPASSES_DENIED io_uring=EPERM x32_socket=EPERM")
+        || !report
+            .console
             .contains("CELLN_FETCH_IOPERM_OK ports=0x500-0x502 denied=0x503:SIGSEGV")
         || !report.console.contains("CELLN_FETCH_OK bytes=")
     {

--- a/crates/celln-pilot/src/guest.rs
+++ b/crates/celln-pilot/src/guest.rs
@@ -218,6 +218,19 @@ fn install_network_seccomp() -> io::Result<()> {
     const SECCOMP_RET_ALLOW: u32 = 0x7fff_0000;
     const SECCOMP_RET_ERRNO: u32 = 0x0005_0000;
     const EPERM: u32 = 1;
+    // Offsets into the kernel's `struct seccomp_data { nr; arch; ... }`: `nr`
+    // at 0, `arch` at 4 (libc exposes the struct but not `offset_of!` at this
+    // MSRV, so these are the same kind of hardcoded UAPI constant as the
+    // Landlock values above).
+    const SECCOMP_DATA_NR_OFFSET: u32 = 0;
+    const SECCOMP_DATA_ARCH_OFFSET: u32 = 4;
+    // `AUDIT_ARCH_X86_64` = EM_X86_64 (62) | __AUDIT_ARCH_64BIT (0x8000_0000)
+    // | __AUDIT_ARCH_LE (0x4000_0000). Without gating on this, a 32-bit/x32
+    // compat-mode syscall entry (a different number space than the native
+    // x86_64 `SYS_*` values below) can reach a syscall this filter means to
+    // deny without ever matching a `nr` comparison written against the native
+    // numbering.
+    const AUDIT_ARCH_X86_64: u32 = 0xC000_003E;
     let denied = [
         libc::SYS_socket,
         libc::SYS_socketpair,
@@ -235,13 +248,41 @@ fn install_network_seccomp() -> io::Result<()> {
         libc::SYS_umount2,
         libc::SYS_ptrace,
         libc::SYS_bpf,
+        // io_uring can create and use a socket (IORING_OP_SOCKET /
+        // IORING_OP_CONNECT / IORING_OP_SEND / IORING_OP_RECV) without ever
+        // calling socket()/connect()/sendto() — a known real-world seccomp
+        // network-filter bypass technique. Denying setup/enter/register
+        // closes that path regardless of which io_uring opcode is used.
+        libc::SYS_io_uring_setup,
+        libc::SYS_io_uring_enter,
+        libc::SYS_io_uring_register,
     ];
-    let mut filter = Vec::with_capacity(2 + denied.len() * 2);
+    let mut filter = Vec::with_capacity(4 + denied.len() * 2);
+    // Refuse outright if this call isn't in the native x86_64 syscall table —
+    // e.g. a 32-bit/x32 compat entry, which the `nr` checks below don't cover.
     filter.push(SockFilter {
         code: BPF_LD_W_ABS,
         jt: 0,
         jf: 0,
-        k: 0,
+        k: SECCOMP_DATA_ARCH_OFFSET,
+    });
+    filter.push(SockFilter {
+        code: BPF_JMP_JEQ_K,
+        jt: 1,
+        jf: 0,
+        k: AUDIT_ARCH_X86_64,
+    });
+    filter.push(SockFilter {
+        code: BPF_RET_K,
+        jt: 0,
+        jf: 0,
+        k: SECCOMP_RET_ERRNO | EPERM,
+    });
+    filter.push(SockFilter {
+        code: BPF_LD_W_ABS,
+        jt: 0,
+        jf: 0,
+        k: SECCOMP_DATA_NR_OFFSET,
     });
     for syscall in denied {
         filter.push(SockFilter {

--- a/crates/celln-pilot/src/guest.rs
+++ b/crates/celln-pilot/src/guest.rs
@@ -214,6 +214,7 @@ struct SockFprog {
 fn install_network_seccomp() -> io::Result<()> {
     const BPF_LD_W_ABS: u16 = 0x20;
     const BPF_JMP_JEQ_K: u16 = 0x15;
+    const BPF_JMP_JSET_K: u16 = 0x45;
     const BPF_RET_K: u16 = 0x06;
     const SECCOMP_RET_ALLOW: u32 = 0x7fff_0000;
     const SECCOMP_RET_ERRNO: u32 = 0x0005_0000;
@@ -231,6 +232,10 @@ fn install_network_seccomp() -> io::Result<()> {
     // deny without ever matching a `nr` comparison written against the native
     // numbering.
     const AUDIT_ARCH_X86_64: u32 = 0xC000_003E;
+    // x32 uses AUDIT_ARCH_X86_64 too, but tags its syscall numbers with this
+    // bit. Checking only `arch` therefore does not exclude the x32 syscall
+    // table; reject tagged numbers before comparing native syscall numbers.
+    const X32_SYSCALL_BIT: u32 = 0x4000_0000;
     let denied = [
         libc::SYS_socket,
         libc::SYS_socketpair,
@@ -257,9 +262,9 @@ fn install_network_seccomp() -> io::Result<()> {
         libc::SYS_io_uring_enter,
         libc::SYS_io_uring_register,
     ];
-    let mut filter = Vec::with_capacity(4 + denied.len() * 2);
-    // Refuse outright if this call isn't in the native x86_64 syscall table —
-    // e.g. a 32-bit/x32 compat entry, which the `nr` checks below don't cover.
+    let mut filter = Vec::with_capacity(6 + denied.len() * 2);
+    // Refuse outright if this call isn't in the x86 family. A 32-bit compat
+    // entry reports AUDIT_ARCH_I386 and is stopped here.
     filter.push(SockFilter {
         code: BPF_LD_W_ABS,
         jt: 0,
@@ -283,6 +288,20 @@ fn install_network_seccomp() -> io::Result<()> {
         jt: 0,
         jf: 0,
         k: SECCOMP_DATA_NR_OFFSET,
+    });
+    // x32 reports AUDIT_ARCH_X86_64, so its tagged syscall number needs a
+    // separate check. If the bit is clear, skip the errno return.
+    filter.push(SockFilter {
+        code: BPF_JMP_JSET_K,
+        jt: 0,
+        jf: 1,
+        k: X32_SYSCALL_BIT,
+    });
+    filter.push(SockFilter {
+        code: BPF_RET_K,
+        jt: 0,
+        jf: 0,
+        k: SECCOMP_RET_ERRNO | EPERM,
     });
     for syscall in denied {
         filter.push(SockFilter {

--- a/crates/celln-pilot/tests/fixtures/fetch_probe.rs
+++ b/crates/celln-pilot/tests/fixtures/fetch_probe.rs
@@ -5,7 +5,42 @@
 
 use std::process::Command;
 
+unsafe extern "C" {
+    fn syscall(number: isize, ...) -> isize;
+}
+
+fn assert_seccomp_errno(number: isize, args: &[usize], label: &str) {
+    let result = unsafe {
+        match args {
+            [a, b, c] => syscall(number, *a, *b, *c),
+            [a, b] => syscall(number, *a, *b),
+            _ => panic!("unsupported probe argument count"),
+        }
+    };
+    assert_eq!(result, -1, "{label} unexpectedly succeeded");
+    assert_eq!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(1),
+        "{label} was not refused by seccomp with EPERM"
+    );
+}
+
 fn main() {
+    // These are fixed x86_64 Linux UAPI numbers because this probe is built
+    // specifically for the static x86_64 guest. It executes after pilot has
+    // installed the real agent-lane filter, so the assertions prove the guest
+    // actually tried both bypass paths instead of inspecting host-side BPF.
+    const SYS_SOCKET: isize = 41;
+    const SYS_IO_URING_SETUP: isize = 425;
+    const X32_SYSCALL_BIT: isize = 0x4000_0000;
+    assert_seccomp_errno(SYS_IO_URING_SETUP, &[1, 0], "io_uring_setup");
+    assert_seccomp_errno(
+        SYS_SOCKET | X32_SYSCALL_BIT,
+        &[2, 1, 0],
+        "x32 socket",
+    );
+    println!("CELLN_SECCOMP_BYPASSES_DENIED io_uring=EPERM x32_socket=EPERM");
+
     let permissions = Command::new("/pilot-fetch")
         .arg("--prove-ioperm-scope")
         .output()

--- a/crates/celln-store/src/lib.rs
+++ b/crates/celln-store/src/lib.rs
@@ -40,10 +40,25 @@ impl Store {
         Ok(Store { objects })
     }
 
+    /// The hex half of a `blake3:<hex>` hash, checked to be exactly 64 lower-
+    /// or upper-case hex characters.
+    ///
+    /// This check is what stands between a hash and a filesystem path
+    /// (`path_for` joins it under `objects/`): `PathBuf::join` replaces the
+    /// whole path when a joined component is itself absolute, so an
+    /// unvalidated `Hash` such as `blake3:/etc/passwd` would otherwise resolve
+    /// outside the store root entirely. `Hash` is a public newtype any caller
+    /// can construct directly (not only via `Hash::of`), so this validation
+    /// has to live here rather than in every caller.
     fn hex_of(hash: &Hash) -> Result<&str, StoreError> {
-        hash.0
+        let hex = hash
+            .0
             .strip_prefix("blake3:")
-            .ok_or_else(|| StoreError::BadHash(hash.0.clone()))
+            .ok_or_else(|| StoreError::BadHash(hash.0.clone()))?;
+        if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(StoreError::BadHash(hash.0.clone()));
+        }
+        Ok(hex)
     }
 
     fn path_for(&self, hash: &Hash) -> Result<PathBuf, StoreError> {
@@ -132,5 +147,36 @@ mod tests {
         let path = store.path_for(&h).unwrap();
         fs::write(&path, b"trojaned bytes").unwrap();
         assert!(matches!(store.get(&h), Err(StoreError::Integrity { .. })));
+    }
+
+    #[test]
+    fn a_hash_with_a_path_traversal_component_is_rejected_before_touching_disk() {
+        let dir = tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+        // `Hash` is a public newtype: nothing stops a caller from building one
+        // outside `Hash::of`, e.g. from untrusted request JSON.
+        let escaping = Hash("blake3:/etc/passwd".to_owned());
+        assert!(matches!(store.get(&escaping), Err(StoreError::BadHash(_))));
+        assert!(!store.has(&escaping));
+    }
+
+    #[test]
+    fn a_hash_with_a_traversal_segment_is_rejected() {
+        let dir = tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+        let escaping = Hash("blake3:../../../../etc/passwd".to_owned());
+        assert!(matches!(store.get(&escaping), Err(StoreError::BadHash(_))));
+    }
+
+    #[test]
+    fn a_short_or_non_hex_hash_is_rejected() {
+        let dir = tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+        assert!(matches!(
+            store.get(&Hash("blake3:deadbeef".to_owned())),
+            Err(StoreError::BadHash(_))
+        ));
+        let not_hex = Hash(format!("blake3:{}", "z".repeat(64)));
+        assert!(matches!(store.get(&not_hex), Err(StoreError::BadHash(_))));
     }
 }

--- a/docs/start.html
+++ b/docs/start.html
@@ -63,7 +63,7 @@ run
 <h2 id="run">Seal a cell</h2>
 <pre>$ celln agent agent.toml
 &#9679; sealing cell code-reviewer
-  + /usr/bin/python        tier=verified cold &mdash; verified now, forged queued
+  + /usr/bin/python        tier=verified cold &mdash; verified now
   &middot; microVM sealed, phase=Materialise
   &middot; /usr/bin/python sealed read-only into the cell
   &middot; authority ratcheted to Work &mdash; no further tools can be lent
@@ -71,7 +71,7 @@ run
 &#9679; cell dissolved</pre>
 <p><strong>Expected result.</strong></p>
 <ul>
-<li><code>cold — verified now, forged queued</code>: an unseen tool is admitted at Verified in seconds and a hermetic rebuild is queued behind the traffic. Launch is never slow; trust upgrades asynchronously. Run it again and it is <code>warm — page map, no build</code>.</li>
+<li><code>cold — verified now</code>: an unseen tool is admitted at Verified in seconds, straight off the bytes you gave it — launch is never slow. Run it again and it is <code>warm — page map, no build</code>. Reaching <code>Forged</code> is earned by a proven double-compile-and-reproduce (see how <code>celln agent</code> forges agent-written source in <a href="agent-lane.html">the agent lane</a>); an externally-sourced tool does not upgrade to <code>Forged</code> in the background on its own.</li>
 <li><code>authority ratcheted to Work</code>: once any agent-authored code has run, the cell can never be lent another tool. Authority only shrinks, and the host enforces it, so a compromised cell cannot roll it back.</li>
 <li>Your Python binary is sealed into the microVM's physical address space as read-only memory.</li>
 </ul>

--- a/docs/tool-lane.html
+++ b/docs/tool-lane.html
@@ -66,7 +66,7 @@ run
 <h2 id="run">Run it</h2>
 <pre>$ celln run agent.toml
 &#9679; sealing cell code-reviewer
-  + /usr/bin/python        tier=verified cold &mdash; verified now, forged queued
+  + /usr/bin/python        tier=verified cold &mdash; verified now
   &#10004; /usr/bin/python permitted in the agent lane
   &middot; cell sealed, 1 tool(s) lent read-only
   &#10004; pilot: /usr/bin/python permitted:agent


### PR DESCRIPTION
## Summary

This closes the three P0 findings from #29 in separate commits.

### #30 — seccomp bypass

- validate the x86_64 audit architecture before syscall-number filtering
- reject x32-tagged syscall numbers so they cannot bypass the denylist
- deny `io_uring_setup`, `io_uring_enter`, and `io_uring_register`
- prove both bypass attempts return `EPERM` from guest code running in a real cell

### #31 — store path traversal

- validate that every object hash is exactly `blake3:` plus 64 hexadecimal characters before deriving a store path
- validate execution requests inside `resolve_bundle`, covering callers that did not run the higher-level validation first
- add regression coverage for absolute/path-traversal payloads and the reachable dispatch path

### #32 — fake background trust upgrade

- remove the in-memory rebuild queue and demo-only queue runner that no production process serviced
- stop claiming a cold verified artifact has a forged rebuild queued
- preserve the public `upgrade_queued` response field for compatibility, always `false`
- retain the legacy assay `rebuild` command shape for compatibility but fail honestly with guidance to run `assay forge`
- update CLI/demo/docs output to describe the artifact actually returned

## Verification

- `make ci`
- `make fetch-proof` (real KVM; x32 socket and `io_uring_setup` attempts both returned `EPERM`)
- `git diff --check`

Closes #30
Closes #31
Closes #32
Part of #29.
