### PR TITLE
fix(assay): preserve agent authorship on verified admission

### DIFF
--- a/crates/celln-assay/src/lib.rs
+++ b/crates/celln-assay/src/lib.rs
@@ -65,13 +65,27 @@ impl Assayer {
         bytes: &[u8],
         interpreter: bool,
     ) -> Result<Hash, AssayError> {
+        self.admit_verified_authored(alias, bytes, interpreter, Author::Host)
+    }
+
+    /// Admit externally built bytes at `Verified`, preserving who authored
+    /// their source. Agent authorship is execution-relevant provenance: it
+    /// keeps the artifact out of the tool lane even though the bytes are
+    /// hash-pinned and verified.
+    pub fn admit_verified_authored(
+        &mut self,
+        alias: &str,
+        bytes: &[u8],
+        interpreter: bool,
+        author: Author,
+    ) -> Result<Hash, AssayError> {
         let hash = self.store.put(bytes)?;
         self.manifest.admit(Entry {
             alias: alias.into(),
             hash: hash.clone(),
             tier: Tier::Verified,
             interpreter,
-            author: Author::Host,
+            author,
             recipe: None,
         });
         self.manifest.sign_standin();

--- a/crates/celln-assay/src/main.rs
+++ b/crates/celln-assay/src/main.rs
@@ -91,10 +91,13 @@ fn main() -> Result<()> {
             } else {
                 celln_manifest::Author::Host
             };
-            let _ = author;
             let bytes = std::fs::read(&file)?;
-            let h = assayer.admit_verified(&alias, &bytes, interpreter)?;
-            println!("admitted {alias}\n  {h}\n  tier=verified author=host");
+            let h = assayer.admit_verified_authored(&alias, &bytes, interpreter, author)?;
+            let entry = assayer.manifest().get(&h).expect("just admitted");
+            println!(
+                "admitted {alias}\n  {h}\n  tier={} author={}",
+                entry.tier, entry.author
+            );
             // Verified, not Forged, and the difference is the whole point: we
             // have these bytes and hashed them, but nothing rebuilt them. Use
             // `assay forge` when the source is available and the tier should

--- a/crates/celln-assay/tests/admit_authorship.rs
+++ b/crates/celln-assay/tests/admit_authorship.rs
@@ -1,0 +1,77 @@
+use celln_manifest::{resolve_exec_lane, Author, Hash, Input, Lane, Manifest, Tier};
+use std::path::Path;
+use std::process::{Command, Output};
+use tempfile::tempdir;
+
+const ARTIFACT: &[u8] = b"verified artifact bytes";
+
+fn run_admit(root: &Path, file: &Path, alias: &str, agent_authored: bool) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
+    command
+        .arg("--root")
+        .arg(root)
+        .arg("admit")
+        .arg(alias)
+        .arg(file);
+    if agent_authored {
+        command.arg("--agent-authored");
+    }
+    command.output().expect("assay CLI runs")
+}
+
+fn persisted_manifest(root: &Path) -> Manifest {
+    let bytes = std::fs::read(root.join("manifest.json")).expect("manifest was persisted");
+    serde_json::from_slice(&bytes).expect("persisted manifest parses")
+}
+
+#[test]
+fn admit_cli_preserves_both_author_modes_and_the_laundering_ban() {
+    let work = tempdir().unwrap();
+    let artifact = work.path().join("artifact");
+    std::fs::write(&artifact, ARTIFACT).unwrap();
+    let hash = Hash::of(ARTIFACT);
+
+    let agent_root = work.path().join("agent-store");
+    let output = run_admit(&agent_root, &artifact, "/agent/program", true);
+    assert!(
+        output.status.success(),
+        "agent-authored admission failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("author=agent"),
+        "CLI must report the provenance it persisted"
+    );
+    let manifest = persisted_manifest(&agent_root);
+    assert!(manifest.verify_standin(), "persisted manifest stays signed");
+    let entry = manifest.get(&hash).expect("agent entry is present");
+    assert_eq!(entry.author, Author::Agent);
+    assert_eq!(entry.tier, Tier::Verified);
+    assert_eq!(
+        resolve_exec_lane(entry, Input::None),
+        Lane::Data,
+        "verified agent-authored code must not gain tool-lane authority"
+    );
+
+    let host_root = work.path().join("host-store");
+    let output = run_admit(&host_root, &artifact, "/host/program", false);
+    assert!(
+        output.status.success(),
+        "host-authored admission failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("author=host"),
+        "CLI must report the provenance it persisted"
+    );
+    let manifest = persisted_manifest(&host_root);
+    assert!(manifest.verify_standin(), "persisted manifest stays signed");
+    let entry = manifest.get(&hash).expect("host entry is present");
+    assert_eq!(entry.author, Author::Host);
+    assert_eq!(entry.tier, Tier::Verified);
+    assert_eq!(
+        resolve_exec_lane(entry, Input::None),
+        Lane::Tool,
+        "the default host-authored path must retain its prior authority"
+    );
+}


### PR DESCRIPTION
Closes #35

Part of #29.

## What changed
- thread explicit authorship through verified admission while preserving the existing host-default API
- report the persisted entry provenance from `assay admit`
- exercise the real CLI for host- and agent-authored modes and prove agent-authored verified code remains in the agent lane

## Verification
- `cargo test -p celln-assay`
- `make ci`