### PR TITLE
fix: scope pilot-fetch I/O permissions

### DIFF
--- a/crates/celln-pilot/src/fetch.rs
+++ b/crates/celln-pilot/src/fetch.rs
@@ -1,13 +1,19 @@
 //! `pilot-fetch URL` — the guest-side half of the host-brokered fetch ABI.
 //!
-//! It has no sockets and does no DNS. It sends an HTTPS URL over four private
+//! It has no sockets and does no DNS. It sends an HTTPS URL over three private
 //! I/O ports; `warden` owns validation, DNS pinning, TLS and the request.
 
 use std::io::Write;
+use std::os::unix::process::ExitStatusExt;
+use std::process::Command;
 
 const TX: u16 = 0x500;
 const CALL: u16 = 0x501;
 const RX: u16 = 0x502;
+const PORT_COUNT: u16 = RX - TX + 1;
+const FIRST_DENIED_PORT: u16 = RX + 1;
+const SCOPE_PROBE: &str = "--prove-ioperm-scope";
+const DENIAL_PROBE: &str = "--probe-denied-port";
 
 #[inline]
 unsafe fn out(port: u16, byte: u8) {
@@ -21,18 +27,81 @@ unsafe fn input(port: u16) -> u8 {
     byte
 }
 
+fn grant_broker_ports() -> std::io::Result<()> {
+    // ioperm changes only the thread's I/O bitmap. Unlike iopl(3), it does not
+    // grant instruction-level privilege or access to the other 65,533 ports.
+    let rc = unsafe { libc::ioperm(TX.into(), PORT_COUNT.into(), 1) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+fn prove_ioperm_scope() -> std::io::Result<()> {
+    grant_broker_ports()?;
+
+    // Exercise the actual direction of every operation in the ABI: request
+    // bytes and dispatch are writes, response bytes are reads. A deliberately
+    // malformed request is rejected by warden, but still yields a framed
+    // response.
+    unsafe {
+        out(TX, b'x');
+        out(CALL, 1);
+        let mut len = [0u8; 4];
+        for byte in &mut len {
+            *byte = input(RX);
+        }
+        let len = u32::from_le_bytes(len);
+        if len > 1 << 20 {
+            return Err(std::io::Error::other(
+                "host sent invalid proof response length",
+            ));
+        }
+        for _ in 0..len {
+            let _ = input(RX);
+        }
+    }
+
+    // Linux turns an unprivileged IN/OUT #GP into SIGSEGV. Probe in a child so
+    // the real guest observes the hardware/kernel denial and can report it.
+    // I/O permission bitmaps survive exec, so the child has precisely the
+    // three permissions granted above; success would prove the scope leaked.
+    let status = Command::new(std::env::current_exe()?)
+        .arg(DENIAL_PROBE)
+        .status()?;
+    if status.signal() != Some(libc::SIGSEGV) {
+        return Err(std::io::Error::other(format!(
+            "out-of-range port access was not denied with SIGSEGV: {status}"
+        )));
+    }
+    println!("CELLN_FETCH_IOPERM_OK ports=0x500-0x502 denied=0x503:SIGSEGV");
+    Ok(())
+}
+
 fn main() {
     let Some(url) = std::env::args().nth(1) else {
         eprintln!("usage: pilot-fetch https://allowed.example/path");
         std::process::exit(2);
     };
+    if url == DENIAL_PROBE {
+        unsafe { out(FIRST_DENIED_PORT, 0) };
+        std::process::exit(0);
+    }
+    if url == SCOPE_PROBE {
+        if let Err(e) = prove_ioperm_scope() {
+            eprintln!("pilot-fetch: I/O permission proof failed: {e}");
+            std::process::exit(1);
+        }
+        return;
+    }
     if url.len() > 8192 || url.contains('\0') {
         eprintln!("pilot-fetch: invalid URL request");
         std::process::exit(2);
     }
     // This capability is deliberately visible to the host VMM as I/O exits;
     // there is no guest network stack behind it.
-    if unsafe { libc::iopl(3) } != 0 {
+    if grant_broker_ports().is_err() {
         eprintln!("pilot-fetch: broker channel unavailable");
         std::process::exit(1);
     }
@@ -62,4 +131,16 @@ fn main() {
     std::io::stdout()
         .write_all(&body)
         .expect("writing response");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permission_range_is_exactly_the_ports_used_by_the_client() {
+        assert_eq!((TX, CALL, RX), (0x500, 0x501, 0x502));
+        assert_eq!(PORT_COUNT, 3);
+        assert_eq!(FIRST_DENIED_PORT, 0x503);
+    }
 }

--- a/crates/celln-pilot/src/fetch_proof.rs
+++ b/crates/celln-pilot/src/fetch_proof.rs
@@ -2,10 +2,11 @@
 //!
 //! Run `cargo run -p celln-pilot --features kvm --bin celln-fetch-proof -- URL` on a
 //! KVM host. A pass means a program running *inside* a real cell invoked the
-//! guest-only `/pilot-fetch` client and received a bounded HTTPS response from
-//! the host broker. It deliberately runs in the agent lane, which is the
-//! public `celln agent --allow-host` path and the one that must be able to
-//! execute the broker client without receiving authority over other guest code.
+//! guest-only `/pilot-fetch` client, proved that its three I/O ports work while
+//! the adjacent port is denied, and received a bounded HTTPS response from the
+//! host broker. It deliberately runs in the agent lane, which is the public
+//! `celln agent --allow-host` path and the one that must be able to execute the
+//! broker client without receiving authority over other guest code.
 
 use anyhow::{bail, Context, Result};
 use celln_manifest::{Author, Entry, Hash, Manifest, Tier};
@@ -100,6 +101,9 @@ fn main() -> Result<()> {
     if !report
         .console
         .contains("CELLN:pilot_run_/probe=permitted:agent")
+        || !report
+            .console
+            .contains("CELLN_FETCH_IOPERM_OK ports=0x500-0x502 denied=0x503:SIGSEGV")
         || !report.console.contains("CELLN_FETCH_OK bytes=")
     {
         bail!(
@@ -107,7 +111,9 @@ fn main() -> Result<()> {
             report.tail(40)
         );
     }
-    println!("PASS: a real cell fetched HTTPS through pilot; no guest network device was present");
+    println!(
+        "PASS: a real cell used only pilot-fetch ports 0x500-0x502 and fetched HTTPS through pilot"
+    );
     Ok(())
 }
 

--- a/crates/celln-pilot/tests/fixtures/fetch_probe.rs
+++ b/crates/celln-pilot/tests/fixtures/fetch_probe.rs
@@ -6,6 +6,24 @@
 use std::process::Command;
 
 fn main() {
+    let permissions = Command::new("/pilot-fetch")
+        .arg("--prove-ioperm-scope")
+        .output()
+        .expect("pilot-fetch must exist in the initramfs");
+    assert!(
+        permissions.status.success(),
+        "pilot-fetch I/O permission proof failed: {}",
+        String::from_utf8_lossy(&permissions.stderr)
+    );
+    let permission_report = String::from_utf8_lossy(&permissions.stdout);
+    assert!(
+        permission_report.contains(
+            "CELLN_FETCH_IOPERM_OK ports=0x500-0x502 denied=0x503:SIGSEGV"
+        ),
+        "pilot-fetch did not prove its I/O permission scope"
+    );
+    print!("{permission_report}");
+
     let url = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "https://example.com/".into());

--- a/guest/init/init.c
+++ b/guest/init/init.c
@@ -30,7 +30,7 @@
 #define SYS_dup2 33
 #define SYS_execve 59
 #define SYS_finit_module 313
-#define SYS_iopl 172
+#define SYS_ioperm 173
 
 /* Unused I/O port the guest pokes to say "I am live", so the host can
  * timestamp a cell reaching userspace in a single exit. Must match
@@ -442,10 +442,13 @@ void _start(void) {
 	 * per byte, which would be measuring our serial emulation rather than
 	 * spawn latency. A single OUT to an unused port is the cheapest thing a
 	 * guest can do that the host can timestamp. */
-	if (sys(SYS_iopl, 3, 0, 0, 0, 0, 0) == 0) {
+	if (sys(SYS_ioperm, CELLN_LIVE_PORT, 1, 1, 0, 0, 0) == 0) {
 		__asm__ volatile("outb %0, %1"
 		                 :
 		                 : "a"((unsigned char)0x5a), "Nd"((unsigned short)CELLN_LIVE_PORT));
+		/* I/O bitmap permissions survive execve. Revoke this one-shot grant
+		 * before pilot replaces init so no cell workload inherits it. */
+		sys(SYS_ioperm, CELLN_LIVE_PORT, 1, 0, 0, 0, 0);
 	}
 	report("cell", "live");
 


### PR DESCRIPTION
Closes #34
Part of #29

## Summary
- replace `pilot-fetch`'s unrestricted `iopl(3)` with `ioperm(0x500, 3, 1)`
- narrow guest init's liveness-port grant and revoke it before `execve`, preventing inherited ambient I/O authority
- extend the real-cell fetch proof to exercise TX/CALL/RX and verify an adjacent `outb` is denied with `SIGSEGV`

## Verification
- `make ci`
- `cargo run -p celln-pilot --features kvm --bin celln-fetch-proof -- https://example.com/`
- `cargo test -p celln-pilot --bin pilot-fetch`