### PR TITLE
fix(dispatcher): enforce bind and host egress policy

### DIFF
--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -12,9 +12,9 @@ use celln_spec::{
 };
 use celln_store::Store;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -132,16 +132,92 @@ type Executions = Arc<Mutex<HashMap<String, Entry<ExecutionRecord>>>>;
 
 struct State {
     token: String,
+    egress_policy: EgressPolicy,
     root: PathBuf,
     probe: NodeProbeArgs,
     executions: Executions,
+}
+
+#[derive(Debug)]
+struct EgressPolicy {
+    allow_hosts: BTreeSet<String>,
+}
+
+impl EgressPolicy {
+    fn new(allow_hosts: &[String]) -> Result<Self> {
+        let mut normalized = BTreeSet::new();
+        for host in allow_hosts {
+            let host = host.to_ascii_lowercase();
+            if host.is_empty()
+                || !host
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-'))
+            {
+                bail!(
+                    "invalid --allow-egress-host {host:?}: expected one exact hostname without a scheme, port, path, or wildcard"
+                );
+            }
+            normalized.insert(host);
+        }
+        Ok(Self {
+            allow_hosts: normalized,
+        })
+    }
+
+    fn check(&self, request: &ExecutionRequest) -> Result<()> {
+        for destination in &request.capabilities.egress {
+            // ExecutionRequest::problems() validates the HTTPS-only shape
+            // before this host policy runs. Keep this check fail-closed too,
+            // so it remains safe if called independently later.
+            let host = destination
+                .strip_prefix("https://")
+                .filter(|host| !host.is_empty())
+                .context("egress destination is not a named HTTPS host")?;
+            if !self.allow_hosts.contains(&host.to_ascii_lowercase()) {
+                bail!(
+                    "egress destination {destination:?} is outside this dispatcher's host allowlist"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Parse and validate the exact address that will be passed to `bind`.
+///
+/// Accepting a hostname here would require DNS resolution. Resolving once for
+/// policy and again inside `TcpListener::bind` creates a check/use gap in which
+/// the two answers can differ, so the dispatcher deliberately requires a
+/// numeric IP socket address at this security boundary.
+fn validate_listen(listen: &str, unsafe_non_loopback: bool) -> Result<(SocketAddr, bool)> {
+    let address: SocketAddr = listen.parse().with_context(|| {
+        format!(
+            "invalid dispatcher listen address {listen:?}; use a numeric IP socket address such as 127.0.0.1:8787 or [::1]:8787"
+        )
+    })?;
+    let non_loopback = !address.ip().is_loopback();
+    if non_loopback && !unsafe_non_loopback {
+        bail!(
+            "refusing non-loopback dispatcher bind {listen:?}; use --unsafe-non-loopback only behind a TLS-terminating reverse proxy"
+        );
+    }
+    Ok((address, non_loopback))
 }
 
 fn execution_is_active(record: &ExecutionRecord) -> bool {
     !matches!(record.phase.as_str(), "Succeeded" | "Failed" | "Refused")
 }
 
-pub fn serve(listen: &str, token_file: &Path, root: PathBuf, probe: &NodeProbeArgs) -> Result<u8> {
+pub fn serve(
+    listen: &str,
+    unsafe_non_loopback: bool,
+    token_file: &Path,
+    allow_egress_hosts: &[String],
+    root: PathBuf,
+    probe: &NodeProbeArgs,
+) -> Result<u8> {
+    let (listen_address, non_loopback) = validate_listen(listen, unsafe_non_loopback)?;
+    let egress_policy = EgressPolicy::new(allow_egress_hosts)?;
     let token = std::fs::read_to_string(token_file)
         .with_context(|| format!("reading dispatcher token {}", token_file.display()))?
         .trim()
@@ -149,15 +225,21 @@ pub fn serve(listen: &str, token_file: &Path, root: PathBuf, probe: &NodeProbeAr
     if token.len() < 24 {
         bail!("dispatcher token must contain at least 24 non-whitespace bytes");
     }
-    let listener =
-        TcpListener::bind(listen).with_context(|| format!("binding dispatcher {listen}"))?;
+    let listener = TcpListener::bind(listen_address)
+        .with_context(|| format!("binding dispatcher {listen_address}"))?;
     let state = Arc::new(State {
         token,
+        egress_policy,
         root,
         probe: probe.clone(),
         executions: Arc::new(Mutex::new(HashMap::new())),
     });
-    eprintln!("celln dispatcher listening on {listen}");
+    if non_loopback {
+        eprintln!(
+            "WARNING: dispatcher is exposed on a non-loopback address and provides no TLS; a TLS-terminating reverse proxy is required"
+        );
+    }
+    eprintln!("celln dispatcher listening on {listen_address}");
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
@@ -244,6 +326,16 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
                     &mut stream,
                     400,
                     &serde_json::json!({"error": "invalid execution request", "problems": problems}),
+                );
+            }
+            if let Err(error) = state.egress_policy.check(&request) {
+                return reply(
+                    &mut stream,
+                    403,
+                    &serde_json::json!({
+                        "error": "egress policy refused execution request",
+                        "reason": error.to_string(),
+                    }),
                 );
             }
             let record = ExecutionRecord {
@@ -496,6 +588,60 @@ fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    fn request_with_egress(destinations: &[&str]) -> ExecutionRequest {
+        let mut request: ExecutionRequest =
+            serde_json::from_str(include_str!("../../../examples/execution/forge-task.json"))
+                .expect("example request parses");
+        request.capabilities.egress = destinations
+            .iter()
+            .map(|value| (*value).to_owned())
+            .collect();
+        request
+    }
+
+    #[test]
+    fn non_loopback_bind_requires_explicit_unsafe_opt_in() {
+        assert!(!validate_listen("127.0.0.1:8787", false).unwrap().1);
+        assert!(!validate_listen("[::1]:8787", false).unwrap().1);
+
+        let error = validate_listen("0.0.0.0:8787", false).unwrap_err();
+        assert!(error.to_string().contains("--unsafe-non-loopback"));
+        assert!(error.to_string().contains("TLS-terminating reverse proxy"));
+        assert!(validate_listen("0.0.0.0:8787", true).unwrap().1);
+    }
+
+    #[test]
+    fn listen_policy_binds_the_exact_numeric_address_it_validated() {
+        let (address, _) = validate_listen("127.0.0.1:8787", false).unwrap();
+        assert_eq!(address, "127.0.0.1:8787".parse().unwrap());
+
+        let error = validate_listen("localhost:8787", false).unwrap_err();
+        assert!(error.to_string().contains("numeric IP socket address"));
+    }
+
+    #[test]
+    fn host_egress_policy_refuses_a_request_selected_destination() {
+        let policy = EgressPolicy::new(&["api.example.com".to_owned()]).unwrap();
+        policy
+            .check(&request_with_egress(&["https://api.example.com"]))
+            .expect("operator-approved host is allowed");
+
+        let error = policy
+            .check(&request_with_egress(&["https://metadata.example"]))
+            .unwrap_err();
+        assert!(error.to_string().contains("https://metadata.example"));
+        assert!(error.to_string().contains("outside"));
+    }
+
+    #[test]
+    fn empty_host_egress_policy_is_deny_all() {
+        let policy = EgressPolicy::new(&[]).unwrap();
+        assert!(policy.check(&request_with_egress(&[])).is_ok());
+        assert!(policy
+            .check(&request_with_egress(&["https://api.example.com"]))
+            .is_err());
+    }
 
     #[test]
     fn constant_time_eq_matches_equal_bytes_and_rejects_different_lengths() {

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -71,9 +71,17 @@ enum Cmd {
         /// Socket address to bind, for example 127.0.0.1:8787.
         #[arg(long, default_value = "127.0.0.1:8787")]
         listen: String,
+        /// Permit a non-loopback bind. UNSAFE by itself: the dispatcher speaks
+        /// plaintext HTTP, so a TLS-terminating reverse proxy is required.
+        #[arg(long)]
+        unsafe_non_loopback: bool,
         /// File containing the bearer token accepted from the control plane.
         #[arg(long)]
         token_file: PathBuf,
+        /// Exact HTTPS hostname requests may ask the host broker to reach.
+        /// Repeat for each allowed host; no entries means deny all egress.
+        #[arg(long, env = "CELLN_DISPATCHER_EGRESS_HOSTS", value_delimiter = ',')]
+        allow_egress_host: Vec<String>,
         /// This node's identity and capacity, used to admit
         /// `celln.dev/v1alpha1` ExecutionRequests posted to `/v1/executions`.
         #[command(flatten)]
@@ -355,9 +363,18 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
         Cmd::Doctor => Ok(doctor(o)),
         Cmd::Dispatcher {
             listen,
+            unsafe_non_loopback,
             token_file,
+            allow_egress_host,
             probe,
-        } => dispatch_http::serve(listen, token_file, root, probe),
+        } => dispatch_http::serve(
+            listen,
+            *unsafe_non_loopback,
+            token_file,
+            allow_egress_host,
+            root,
+            probe,
+        ),
         Cmd::Route {
             listen,
             backends,
@@ -520,6 +537,25 @@ fn doctor(o: &Out) -> u8 {
 #[cfg(test)]
 mod cli_tests {
     use super::*;
+
+    #[test]
+    fn dispatcher_defaults_to_loopback_and_requires_no_unsafe_opt_in() {
+        let cli = Cli::try_parse_from(["celln", "dispatcher", "--token-file", "/run/celln/token"])
+            .expect("dispatcher command parses");
+        match cli.cmd {
+            Cmd::Dispatcher {
+                listen,
+                unsafe_non_loopback,
+                allow_egress_host,
+                ..
+            } => {
+                assert_eq!(listen, "127.0.0.1:8787");
+                assert!(!unsafe_non_loopback);
+                assert!(allow_egress_host.is_empty(), "egress defaults to deny-all");
+            }
+            _ => panic!("expected dispatcher command"),
+        }
+    }
 
     #[test]
     fn an_agent_spec_accepts_prompt_and_legacy_task() {

--- a/docs/DISPATCHER_SECURITY.md
+++ b/docs/DISPATCHER_SECURITY.md
@@ -1,0 +1,43 @@
+# Dispatcher security boundary
+
+`celln dispatcher` speaks authenticated **plaintext HTTP**. It does not
+implement native TLS. The bearer token protects requests only when the
+transport also protects that token from observation.
+
+The dispatcher therefore binds to `127.0.0.1:8787` by default and refuses any
+non-loopback `--listen` address. For a fleet deployment, put a TLS-terminating
+reverse proxy or an equivalently authenticated encrypted transport in front of
+the dispatcher. Only after that boundary exists may the operator add
+`--unsafe-non-loopback`; the flag merely permits the bind and prints a warning.
+It does not enable TLS.
+
+For example, with a same-host TLS reverse proxy forwarding to loopback, no
+unsafe flag is needed:
+
+```console
+celln dispatcher \
+  --listen 127.0.0.1:8787 \
+  --token-file /etc/celln/dispatcher-token/token
+```
+
+## Host-owned egress policy
+
+An execution request cannot grant itself network authority. The dispatcher
+starts with a deny-all egress policy. The operator may add exact DNS hostnames
+with repeatable `--allow-egress-host` flags or the comma-separated
+`CELLN_DISPATCHER_EGRESS_HOSTS` environment variable:
+
+```console
+celln dispatcher \
+  --token-file /etc/celln/dispatcher-token/token \
+  --allow-egress-host api.example.com \
+  --allow-egress-host objects.example.com
+```
+
+Each `capabilities.egress` value in an otherwise valid request must be an HTTPS
+destination whose exact hostname appears in that host-owned allowlist. The
+dispatcher returns HTTP 403 for an out-of-policy destination before registering
+the execution or invoking a model provider. Wildcards, schemes, ports, paths,
+and URL fragments are not valid allowlist entries. This admission policy is in
+addition to the warden fetch broker's per-request bounds, HTTPS-only checks,
+DNS pinning, public-address check, and redirect reauthorization.

--- a/docs/SYMPOZIUM_ENSEMBLE_INTEGRATION.md
+++ b/docs/SYMPOZIUM_ENSEMBLE_INTEGRATION.md
@@ -8,6 +8,12 @@ Celln must not turn either mutable status text or a ConfigMap name into executio
 
 See `examples/execution/ensemble-handoff.json` for the wire request.
 
+The dispatcher transport and host-owned egress policy are documented in
+[`DISPATCHER_SECURITY.md`](DISPATCHER_SECURITY.md). In particular, the
+dispatcher has no native TLS: non-loopback deployments require an explicit
+unsafe bind opt-in and a TLS-terminating reverse proxy. Request egress is
+deny-all unless the host operator configures exact allowed hostnames.
+
 ## Redesigned integration shape: hermetic actions first
 
 Celln is not the initial backend for a full `AgentRun` or Ensemble. Sympozium

--- a/scripts/setup-host.sh
+++ b/scripts/setup-host.sh
@@ -208,7 +208,9 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/celln --root /var/lib/celln dispatcher --listen 0.0.0.0:8787 --token-file /etc/celln/dispatcher-token/token
+# The dispatcher has no native TLS. Keep it on loopback; expose it only through
+# a separately configured TLS-terminating reverse proxy.
+ExecStart=/usr/local/bin/celln --root /var/lib/celln dispatcher --listen 127.0.0.1:8787 --token-file /etc/celln/dispatcher-token/token
 Restart=always
 RestartSec=5
 Environment=PATH=/root/.cargo/bin:/usr/local/bin:/opt/celln/runtime/scripts:/usr/bin:/bin
@@ -236,15 +238,8 @@ else
     echo "✓ systemd service installed and started"
 fi
 
-# ── 9. Firewall ────────────────────────────────────────────────────────
-if $CONTAINER_MODE; then
-    nsenter --target 1 --mount -- firewall-cmd --add-port=8787/tcp --permanent 2>/dev/null || true
-    nsenter --target 1 --mount -- firewall-cmd --reload 2>/dev/null || true
-else
-    firewall-cmd --add-port=8787/tcp --permanent 2>/dev/null || true
-    firewall-cmd --reload 2>/dev/null || true
-fi
-echo "✓ firewall configured"
+# ── 9. Network exposure ───────────────────────────────────────────────
+echo "✓ dispatcher restricted to loopback (configure a TLS reverse proxy for remote access)"
 
 # ── 10. Environment for users ─────────────────────────────────────────
 grep -q "CELLN_ROOT" "${HOST}/etc/environment" 2>/dev/null || \


### PR DESCRIPTION
## Summary

- refuse non-loopback dispatcher binds unless `--unsafe-non-loopback` is explicitly supplied; the help and runtime warning state that the server is plaintext and requires TLS termination
- require a numeric `SocketAddr`, validate that exact address, and bind that same value so hostname re-resolution cannot turn an approved loopback bind into a non-loopback listener
- add a dispatcher-owned exact-host egress allowlist, deny all by default, and reject out-of-policy execution requests with HTTP 403 before registration or provider work
- make the host installer bind loopback and stop opening the dispatcher port
- document the transport boundary and egress policy without claiming native TLS

## Verification

- `cargo test -p celln-cli`
- `make ci`
- inspected `celln dispatcher --help` for the TLS warning and policy controls
- `git diff --check`

Closes #36
Part of #29.
