### PR TITLE
fix: write provider config with mode 0600

### DIFF
--- a/crates/celln-cli/src/config.rs
+++ b/crates/celln-cli/src/config.rs
@@ -2,6 +2,12 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+#[cfg(unix)]
+use std::fs::OpenOptions;
+#[cfg(unix)]
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::PathBuf;
 
 /// Written as `[provider]`. `[agent]` is the name this had before providers
@@ -80,8 +86,32 @@ pub fn set_default_agent(agent: &str) -> Result<PathBuf> {
         agent: Provider::default(),
     };
     let source = toml::to_string_pretty(&config).context("encoding celln config")?;
-    std::fs::write(&path, source).with_context(|| format!("writing config {}", path.display()))?;
+    write_private(&path, source.as_bytes())
+        .with_context(|| format!("writing config {}", path.display()))?;
     Ok(path)
+}
+
+#[cfg(unix)]
+fn write_private(path: &std::path::Path, contents: &[u8]) -> std::io::Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .mode(0o600)
+        .open(path)?;
+
+    // `mode` applies only when open creates the file, and is still filtered by
+    // umask. Tighten an existing file before replacing its contents, then set
+    // the exact final mode so even an unusually restrictive umask cannot alter
+    // this config's contract.
+    file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    file.set_len(0)?;
+    file.write_all(contents)
+}
+
+#[cfg(not(unix))]
+fn write_private(path: &std::path::Path, contents: &[u8]) -> std::io::Result<()> {
+    std::fs::write(path, contents)
 }
 
 #[cfg(test)]

--- a/crates/celln-cli/tests/config_permissions.rs
+++ b/crates/celln-cli/tests/config_permissions.rs
@@ -1,0 +1,94 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn celln_with_umask(xdg: &Path, args: &[&str], path: Option<&Path>) -> Output {
+    let binary = env!("CARGO_BIN_EXE_celln");
+    let mut command = Command::new("sh");
+    command
+        .args(["-c", "umask 000; exec \"$@\"", "celln", binary])
+        .args(args)
+        .env("XDG_CONFIG_HOME", xdg)
+        .env("HOME", xdg.parent().expect("XDG config parent"));
+    if let Some(path) = path {
+        command.env("PATH", path);
+    }
+    command.output().expect("run celln")
+}
+
+fn config_path(xdg: &Path) -> PathBuf {
+    xdg.join("celln/config.toml")
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "celln failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_mode_0600(path: &Path) {
+    let mode = fs::metadata(path)
+        .expect("config metadata")
+        .permissions()
+        .mode()
+        & 0o7777;
+    assert_eq!(mode, 0o600, "unexpected mode for {}", path.display());
+}
+
+#[test]
+fn providers_creates_config_with_mode_0600_despite_permissive_umask() {
+    let home = tempfile::tempdir().expect("temporary home");
+    let xdg = home.path().join("config");
+
+    let output = celln_with_umask(&xdg, &["providers", "--set-default", "local"], None);
+
+    assert_success(&output);
+    assert_mode_0600(&config_path(&xdg));
+}
+
+#[test]
+fn setup_tightens_an_existing_config_to_mode_0600() {
+    let home = tempfile::tempdir().expect("temporary home");
+    let xdg = home.path().join("config");
+    let config = config_path(&xdg);
+    fs::create_dir_all(config.parent().expect("config parent")).expect("create config dir");
+    fs::write(&config, "[provider]\ndefault = \"openai\"\n").expect("seed config");
+    fs::set_permissions(&config, fs::Permissions::from_mode(0o644)).expect("set loose mode");
+
+    let bin = home.path().join("bin");
+    fs::create_dir(&bin).expect("create fake bin dir");
+    let ollama = bin.join("ollama");
+    fs::write(&ollama, "#!/bin/sh\nexit 0\n").expect("write fake ollama");
+    fs::set_permissions(&ollama, fs::Permissions::from_mode(0o755)).expect("make fake executable");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let state = home.path().join("state");
+    let output = celln_with_umask(
+        &xdg,
+        &[
+            "--root",
+            state.to_str().expect("UTF-8 state path"),
+            "setup",
+            "--provider",
+            "local",
+            "--no-tools",
+        ],
+        Some(Path::new(&path)),
+    );
+
+    assert_success(&output);
+    assert_mode_0600(&config);
+    assert!(fs::read_to_string(config)
+        .expect("read rewritten config")
+        .contains("default = \"local\""));
+}


### PR DESCRIPTION
Closes #42
Part of #29

## Summary
- create the Unix provider config with mode `0600` using safe Rust filesystem APIs
- tighten existing config permissions before truncating and rewriting their contents
- preserve the existing portable write path on non-Unix targets
- cover both `providers --set-default` and `setup --provider` under a permissive umask

## Verification
- `cargo test -p celln-cli --test config_permissions`
- `cargo test -p celln-cli config::tests`
- `make ci`