### PR TITLE
fix(dispatch): derive results from guest exit status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
           cargo test -p celln-warden --features kvm
           cargo run -p celln-cli -- verify --no-json
           make acceptance-kvm
+          cargo build --release --target x86_64-unknown-linux-musl -p celln-pilot --bin celln-pilot --bin pilot-fetch
+          cargo test -p celln-cli dispatch_outcomes_on_real_kvm -- --ignored --nocapture
       - name: no /dev/kvm on this runner
         if: steps.kvm.outputs.have == 'no'
         run: |

--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -121,15 +121,30 @@ pub fn resolve_bundle(
 /// receipt is an immutable, versioned wire contract with no room for a human
 /// diagnostic, and a caller polling a pending execution needs a place to put
 /// one. The dispatcher builds the receipt from this after the cell is gone.
+#[derive(Debug)]
 pub struct LaunchOutcome {
     pub cell_id: String,
-    /// `Some` only when the program ran and produced bounded output.
+    /// Bounded workload bytes, including failure output; may be empty.
     pub output: Option<Vec<u8>>,
-    /// `Some` when pilot refused to run the resolved program (a safe policy
-    /// verdict, not a crash) or the cell produced no output block at all.
-    /// The receipt still reports `Failed` either way — this is the reason.
+    /// A refusal, nonzero exit, signal, timeout or protocol failure reason.
     pub denial: Option<String>,
+    pub exit_code: Option<i32>,
+    pub signal: Option<i32>,
+    pub timed_out: bool,
 }
+
+impl LaunchOutcome {
+    pub fn succeeded(&self) -> bool {
+        self.exit_code == Some(0)
+            && self.signal.is_none()
+            && !self.timed_out
+            && self.denial.is_none()
+    }
+}
+
+#[path = "dispatch_outcome.rs"]
+mod outcome;
+use outcome::parse_report;
 
 /// What `forge` produced: the exact bytes now admitted into this node's
 /// attested manifest, and their content hash.
@@ -253,13 +268,17 @@ pub fn launch(
     // Admit the bytes into this node's own attested manifest so pilot's exec
     // gate has an entry to check against. For a declared request the hash
     // this computes lines up with the request's own declared hash by
-    // construction — `resolve_bundle` already proved that. For a forged
-    // request, `forge` already admitted it upstream of this call; admitting
-    // again here is a harmless no-op (assay dedups by hash).
+    // construction — `resolve_bundle` already proved that. Preserve any entry
+    // already admitted upstream, including its authorship and proof.
     let mut assayer = assay::Assayer::open(assay_root).map_err(|error| error.to_string())?;
-    assayer
-        .admit_verified(alias, program_bytes, false)
-        .map_err(|error| error.to_string())?;
+    // Forge has already recorded agent authorship and its proof. Re-admitting
+    // those bytes as Host would silently promote them back to the tool lane.
+    // Existing provenance is authoritative; a requested lane can only narrow it.
+    if assayer.manifest().get(&Hash::of(program_bytes)).is_none() {
+        assayer
+            .admit_verified(alias, program_bytes, false)
+            .map_err(|error| error.to_string())?;
+    }
 
     let work = crate::agent::tempdir().map_err(|error| error.to_string())?;
     let work = work.path();
@@ -280,6 +299,8 @@ pub fn launch(
             "args": args,
             "agent_authored_input": matches!(request.execution.lane, RequestedLane::Agent),
             "allow_fetch": !request.capabilities.egress.is_empty(),
+            "report_output_limit": request.capabilities.output_bytes,
+            "force_agent_lane": matches!(request.execution.lane, RequestedLane::Agent),
         }))
         .map_err(|error| error.to_string())?,
     )
@@ -377,45 +398,17 @@ pub fn launch(
         }
     };
 
-    let mut denied: Option<String> = None;
-    for line in report.console.lines() {
-        let Some(rest) = line.strip_prefix("CELLN:pilot_run_") else {
-            continue;
-        };
-        let Some((key, value)) = rest.split_once('=') else {
-            continue;
-        };
-        if !key.ends_with("_exit") && (value.starts_with("refused") || value == "denied") {
-            denied = Some(value.to_owned());
-        }
+    let outcome = parse_report(
+        &report.console,
+        cell_id,
+        request.capabilities.output_bytes as usize,
+        report.end == warden::vmm::boot::BootEnd::TimedOut,
+        report.end == warden::vmm::boot::BootEnd::Shutdown,
+    );
+    if let Some(record) = record.as_mut() {
+        crate::cells::finish(state_root, record, "kvm", outcome.denial.clone());
     }
-
-    let output_cap = request.capabilities.output_bytes.max(1) as usize;
-    match crate::agent::slice_output(&report.console) {
-        Some(text) => {
-            if let Some(record) = record.as_mut() {
-                crate::cells::finish(state_root, record, "kvm", None);
-            }
-            let mut bytes = text.into_bytes();
-            bytes.truncate(output_cap);
-            Ok(LaunchOutcome {
-                cell_id,
-                output: Some(bytes),
-                denial: None,
-            })
-        }
-        None => {
-            let reason = denied.unwrap_or_else(|| "program produced no output".to_owned());
-            if let Some(record) = record.as_mut() {
-                crate::cells::refuse(state_root, record, "kvm", reason.clone());
-            }
-            Ok(LaunchOutcome {
-                cell_id,
-                output: None,
-                denial: Some(reason),
-            })
-        }
-    }
+    Ok(outcome)
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -567,6 +560,144 @@ mod tests {
         // 1969-12-31T23:59:59Z — one second before the epoch, the standard
         // edge case for a from-scratch civil calendar conversion.
         assert_eq!(rfc3339_utc(-1), "1969-12-31T23:59:59Z");
+    }
+
+    #[test]
+    #[ignore = "requires KVM, guest kernel, musl and built pilot binaries"]
+    #[cfg(target_os = "linux")]
+    fn dispatch_outcomes_on_real_kvm() {
+        use std::process::Command;
+        if !Path::new("/dev/kvm").exists() || warden::vmm::boot::BootConfig::host_kernel().is_none()
+        {
+            eprintln!("skipping: KVM or readable matching kernel unavailable");
+            return;
+        }
+        let work = tempdir().unwrap();
+        let Some(runtime) = test_runtime_root(work.path()) else {
+            return;
+        };
+        let binary = work.path().join("outcome-probe");
+        let source =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/dispatch_outcome_probe.rs");
+        assert!(Command::new("rustc")
+            .args([
+                "--edition=2021",
+                "-O",
+                "--target",
+                "x86_64-unknown-linux-musl",
+                "-o"
+            ])
+            .arg(&binary)
+            .arg(source)
+            .status()
+            .unwrap()
+            .success());
+        let bytes = std::fs::read(binary).unwrap();
+        let mut request: ExecutionRequest =
+            serde_json::from_str(include_str!("../../../examples/execution/forge-task.json"))
+                .unwrap();
+        request.capabilities.timeout_ms = 8000;
+        request.capabilities.output_bytes = 1024;
+        request.capabilities.egress.clear();
+        for (mode, code, signal, timeout) in [
+            ("silent", Some(0), None, false),
+            ("failed", Some(7), None, false),
+            ("signal", None, Some(6), false),
+            ("spoof", Some(9), None, false),
+            ("flood", Some(0), None, false),
+            ("timeout", None, None, true),
+        ] {
+            let state = work.path().join(format!("state-{mode}"));
+            std::fs::create_dir_all(&state).unwrap();
+            let outcome = launch(
+                &request,
+                "/agent/program",
+                &[mode.into()],
+                &bytes,
+                &runtime,
+                &work.path().join("assay"),
+                &state,
+            )
+            .unwrap();
+            assert_eq!(outcome.exit_code, code, "{mode}: {outcome:?}");
+            assert_eq!(outcome.signal, signal, "{mode}: {outcome:?}");
+            assert_eq!(outcome.timed_out, timeout, "{mode}: {outcome:?}");
+            assert_eq!(outcome.succeeded(), code == Some(0), "{mode}: {outcome:?}");
+            let output = outcome.output.as_deref().unwrap();
+            match mode {
+                "silent" => assert!(output.is_empty()),
+                "failed" => assert_eq!(output, b"failure detail\n"),
+                "spoof" => assert!(String::from_utf8_lossy(output).contains("CELLN:dispatch=")),
+                "flood" => assert_eq!(output.len(), 1024),
+                "timeout" => assert!(String::from_utf8_lossy(output).contains("before timeout")),
+                _ => {}
+            }
+            assert_eq!(
+                crate::cells::live_count(&state),
+                0,
+                "{mode} left a live record"
+            );
+            eprintln!("PASS: {mode}, exit={code:?}, signal={signal:?}, timeout={timeout}");
+        }
+        let outcome = launch(
+            &request,
+            "/invalid",
+            &[],
+            b"not executable",
+            &runtime,
+            &work.path().join("assay"),
+            &work.path().join("invalid-state"),
+        )
+        .unwrap();
+        assert!(!outcome.succeeded());
+        assert_eq!(outcome.denial.as_deref(), Some("pilot exec setup failed"));
+        // An agent artifact stays in the agent lane even if a later caller
+        // asks for the tool lane. The spoof probe also attempts unshare.
+        let assay_root = work.path().join("assay");
+        let mut assayer = assay::Assayer::open(&assay_root).unwrap();
+        let hash = assayer
+            .admit_verified_authored(
+                "/agent/program",
+                &bytes,
+                false,
+                celln_manifest::Author::Agent,
+            )
+            .unwrap();
+        request.execution.lane = RequestedLane::Tool;
+        let outcome = launch(
+            &request,
+            "/agent/program",
+            &["spoof".into()],
+            &bytes,
+            &runtime,
+            &assay_root,
+            &work.path().join("preserved-author"),
+        )
+        .unwrap();
+        assert_eq!(outcome.exit_code, Some(9), "{outcome:?}");
+        assert_eq!(
+            assay::Assayer::open(&assay_root)
+                .unwrap()
+                .manifest()
+                .get(&hash)
+                .unwrap()
+                .author,
+            celln_manifest::Author::Agent
+        );
+        assayer.revoke(&hash);
+        let outcome = launch(
+            &request,
+            "/agent/program",
+            &["silent".into()],
+            &bytes,
+            &runtime,
+            &assay_root,
+            &work.path().join("refused-state"),
+        )
+        .unwrap();
+        assert!(!outcome.succeeded());
+        assert_eq!(outcome.denial.as_deref(), Some("pilot refused execution"));
+        eprintln!("PASS: exec setup failure, retained agent lane, and pilot refusal");
     }
 
     /// A runtime root the launch pipeline can build an initrd/toolfs from,

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -524,21 +524,7 @@ fn run_execution(
     };
 
     let output = outcome.output.as_deref().filter(|bytes| !bytes.is_empty());
-    let stored_output = output.and_then(|bytes| {
-        Store::open(root.join("outputs"))
-            .and_then(|store| store.put(bytes))
-            .ok()
-            .map(|hash| ExecutionOutput {
-                hash: hash.0,
-                media_type: "application/octet-stream".into(),
-                bytes: bytes.len() as u64,
-            })
-    });
-    let phase = if stored_output.is_some() {
-        ExecutionPhase::Succeeded
-    } else {
-        ExecutionPhase::Failed
-    };
+    let (phase, stored_output, reason) = collect_result(&outcome, &root.join("outputs"));
     let receipt = ExecutionReceipt {
         api_version: "celln.dev/v1alpha1".into(),
         request_id: request.id.clone(),
@@ -561,10 +547,53 @@ fn run_execution(
     let output_text = output.map(|bytes| String::from_utf8_lossy(bytes).into_owned());
     update_execution(&executions, &request.id, |record| {
         record.phase = format!("{:?}", receipt.phase);
-        record.reason = outcome.denial.clone();
+        record.reason = reason;
         record.output = output_text;
         record.receipt = Some(receipt.clone());
     });
+}
+
+/// Guest success and output persistence are separate facts. A silent exit 0
+/// succeeds with no output object; nonzero exits keep their bounded output.
+fn collect_result(
+    outcome: &crate::dispatch::LaunchOutcome,
+    output_root: &Path,
+) -> (ExecutionPhase, Option<ExecutionOutput>, Option<String>) {
+    let mut reason = outcome.denial.clone();
+    let stored = outcome
+        .output
+        .as_deref()
+        .filter(|bytes| !bytes.is_empty())
+        .map(|bytes| {
+            Store::open(output_root)
+                .and_then(|store| store.put(bytes))
+                .map(|hash| ExecutionOutput {
+                    hash: hash.0,
+                    media_type: "application/octet-stream".into(),
+                    bytes: bytes.len() as u64,
+                })
+        })
+        .transpose();
+    match stored {
+        Ok(output) => (
+            if outcome.succeeded() {
+                ExecutionPhase::Succeeded
+            } else {
+                ExecutionPhase::Failed
+            },
+            output,
+            reason,
+        ),
+        Err(_) => {
+            // Keep local paths and filesystem diagnostics out of the wire.
+            let prefix = reason.take().map(|s| format!("{s}; ")).unwrap_or_default();
+            (
+                ExecutionPhase::Failed,
+                None,
+                Some(format!("{prefix}output persistence failed")),
+            )
+        }
+    }
 }
 
 fn reply(stream: &mut TcpStream, status: u16, body: &impl Serialize) -> Result<()> {
@@ -588,6 +617,44 @@ fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    #[test]
+    fn receipt_phase_tracks_exit_and_output_storage_independently() {
+        let work = tempfile::tempdir().unwrap();
+        let mut outcome = crate::dispatch::LaunchOutcome {
+            cell_id: "cell".into(),
+            output: Some(vec![]),
+            denial: None,
+            exit_code: Some(0),
+            signal: None,
+            timed_out: false,
+        };
+        let (phase, output, reason) = collect_result(&outcome, work.path());
+        assert_eq!(phase, ExecutionPhase::Succeeded);
+        assert!(output.is_none() && reason.is_none());
+        outcome.exit_code = Some(7);
+        outcome.denial = Some("guest exited with code 7".into());
+        outcome.output = Some(b"failure detail".to_vec());
+        let (phase, output, reason) = collect_result(&outcome, work.path());
+        assert_eq!(phase, ExecutionPhase::Failed);
+        let output = output.unwrap();
+        assert_eq!(
+            Store::open(work.path())
+                .unwrap()
+                .get(&celln_manifest::Hash(output.hash))
+                .unwrap(),
+            b"failure detail"
+        );
+        assert_eq!(reason, outcome.denial);
+        let blocked = work.path().join("not-a-directory");
+        std::fs::write(&blocked, b"blocked").unwrap();
+        outcome.exit_code = Some(0);
+        outcome.denial = None;
+        let (phase, output, reason) = collect_result(&outcome, &blocked);
+        assert_eq!(phase, ExecutionPhase::Failed);
+        assert!(output.is_none());
+        assert_eq!(reason.as_deref(), Some("output persistence failed"));
+    }
 
     fn request_with_egress(destinations: &[&str]) -> ExecutionRequest {
         let mut request: ExecutionRequest =

--- a/crates/celln-cli/src/dispatch_outcome.rs
+++ b/crates/celln-cli/src/dispatch_outcome.rs
@@ -1,0 +1,158 @@
+use super::LaunchOutcome;
+use pilot::dispatch_report::{Frame, PREFIX, PROTOCOL};
+
+/// Only pilot frames carry a verdict. Legacy console output cannot establish
+/// success, and a host timeout takes precedence over any guest report.
+pub(super) fn parse_report(
+    console: &str,
+    cell_id: String,
+    limit: usize,
+    timed_out: bool,
+    shutdown: bool,
+) -> LaunchOutcome {
+    let mut result = LaunchOutcome {
+        cell_id,
+        output: Some(Vec::new()),
+        denial: None,
+        exit_code: None,
+        signal: None,
+        timed_out,
+    };
+    let mut terminal = false;
+    // An old pilot must not accept a workload's imitation of the new frames.
+    // Negotiate at the first supervisor startup, before it reads any request
+    // or executes a workload; later imitations cannot repair this check.
+    let mut startup = console
+        .lines()
+        .skip_while(|line| *line != "CELLN:pilot=alive");
+    let mut invalid = startup.next().is_none() || startup.next() != Some(PROTOCOL);
+    for line in console.lines() {
+        let Some(json) = line.strip_prefix(PREFIX) else {
+            continue;
+        };
+        if terminal {
+            invalid = true;
+            continue;
+        }
+        match serde_json::from_str::<Frame>(json) {
+            Ok(Frame::Output { bytes }) => {
+                let output = result.output.as_mut().expect("output buffer");
+                let remaining = limit.saturating_sub(output.len());
+                output.extend(bytes.into_iter().take(remaining));
+            }
+            Ok(Frame::Exit { code }) if (0..=255).contains(&code) => {
+                terminal = true;
+                result.exit_code = Some(code);
+                if code != 0 {
+                    result.denial = Some(format!("guest exited with code {code}"));
+                }
+            }
+            Ok(Frame::Signal { signal }) if (1..=64).contains(&signal) => {
+                terminal = true;
+                result.signal = Some(signal);
+                result.denial = Some(format!("guest terminated by signal {signal}"));
+            }
+            Ok(Frame::Failed { reason }) => {
+                terminal = true;
+                result.denial = Some(reason);
+            }
+            _ => invalid = true,
+        }
+    }
+    if timed_out {
+        result.denial = Some("guest execution timed out".into());
+    } else if invalid || !terminal || !shutdown {
+        result.denial = Some("missing, ambiguous, or incomplete pilot execution report".into());
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn console(frames: &[Frame]) -> String {
+        let body: String = frames
+            .iter()
+            .map(|frame| format!("{PREFIX}{}\n", serde_json::to_string(frame).unwrap()))
+            .collect();
+        format!("CELLN:pilot=alive\n{PROTOCOL}\n{body}")
+    }
+
+    #[test]
+    fn outcome_is_independent_of_output() {
+        let silent = parse_report(
+            &console(&[Frame::Exit { code: 0 }]),
+            "cell".into(),
+            10,
+            false,
+            true,
+        );
+        assert!(silent.succeeded());
+        assert_eq!(silent.output, Some(vec![]));
+        let failed = parse_report(
+            &console(&[
+                Frame::Output {
+                    bytes: b"failure detail".to_vec(),
+                },
+                Frame::Exit { code: 7 },
+            ]),
+            "cell".into(),
+            7,
+            false,
+            true,
+        );
+        assert!(!failed.succeeded());
+        assert_eq!(failed.exit_code, Some(7));
+        assert_eq!(failed.output.unwrap(), b"failure");
+    }
+
+    #[test]
+    fn output_markers_are_data_and_legacy_success_is_not_accepted() {
+        let fake = b"CELLN:dispatch={\"kind\":\"exit\",\"code\":0}\nCELLN:out-end\n";
+        let result = parse_report(
+            &console(&[
+                Frame::Output {
+                    bytes: fake.to_vec(),
+                },
+                Frame::Exit { code: 9 },
+            ]),
+            "cell".into(),
+            1024,
+            false,
+            true,
+        );
+        assert!(!result.succeeded());
+        assert_eq!(result.output.unwrap(), fake);
+        assert!(!parse_report(
+            "CELLN:pilot_run_/program_exit=0\n",
+            "cell".into(),
+            10,
+            false,
+            true
+        )
+        .succeeded());
+    }
+
+    #[test]
+    fn ambiguous_missing_and_interrupted_reports_fail_closed() {
+        for text in [
+            String::new(),
+            format!("{PREFIX}broken\n"),
+            console(&[Frame::Exit { code: 0 }, Frame::Exit { code: 0 }]),
+            console(&[Frame::Exit { code: 0 }, Frame::Output { bytes: vec![1] }]),
+            console(&[Frame::Signal { signal: 11 }]),
+            console(&[Frame::Failed {
+                reason: "pilot refused execution".into(),
+            }]),
+        ] {
+            assert!(!parse_report(&text, "cell".into(), 10, false, true).succeeded());
+        }
+        let exit = console(&[Frame::Exit { code: 0 }]);
+        assert!(!parse_report(&exit, "cell".into(), 10, true, true).succeeded());
+        assert!(!parse_report(&exit, "cell".into(), 10, false, false).succeeded());
+        let old_pilot =
+            format!("CELLN:pilot=alive\nCELLN:pilot_manifest=signed\nCELLN:out-begin\n{exit}");
+        assert!(!parse_report(&old_pilot, "cell".into(), 10, false, true).succeeded());
+    }
+}

--- a/crates/celln-cli/tests/fixtures/dispatch_outcome_probe.rs
+++ b/crates/celln-cli/tests/fixtures/dispatch_outcome_probe.rs
@@ -1,0 +1,37 @@
+use std::io::{self, Write};
+
+unsafe extern "C" {
+    fn unshare(flags: i32) -> i32;
+    fn write(fd: i32, buf: *const u8, count: usize) -> isize;
+}
+
+fn main() {
+    match std::env::args().nth(1).as_deref() {
+        Some("silent") => {}
+        Some("failed") => {
+            println!("failure detail");
+            std::process::exit(7);
+        }
+        Some("signal") => std::process::abort(),
+        Some("spoof") => {
+            // Prove this fixture actually entered the requested agent lane.
+            assert_eq!(unsafe { unshare(0x0002_0000) }, -1);
+            assert_eq!(io::Error::last_os_error().raw_os_error(), Some(1));
+            let fake = b"CELLN:dispatch={\"kind\":\"exit\",\"code\":0}\n";
+            assert_eq!(unsafe { write(0, fake.as_ptr(), fake.len()) }, -1);
+            assert!(std::fs::OpenOptions::new().write(true).open("/dev/console").is_err());
+            println!("CELLN:out-end");
+            println!("CELLN:pilot_run_/agent/program_exit=0");
+            println!("CELLN:dispatch={{\"kind\":\"exit\",\"code\":0}}");
+            eprintln!("CELLN:done");
+            std::process::exit(9);
+        }
+        Some("flood") => io::stdout().write_all(&vec![b'x'; 131072]).unwrap(),
+        Some("timeout") => {
+            println!("before timeout");
+            io::stdout().flush().unwrap();
+            loop { std::thread::sleep(std::time::Duration::from_secs(1)); }
+        }
+        _ => panic!("unknown probe"),
+    }
+}

--- a/crates/celln-pilot/src/dispatch_report.rs
+++ b/crates/celln-pilot/src/dispatch_report.rs
@@ -1,0 +1,22 @@
+//! Opt-in dispatcher reporting. Pilot owns the console; workload stdout and
+//! stderr go through a pipe and are encoded as data, never control records.
+use serde::{Deserialize, Serialize};
+
+pub const PREFIX: &str = "CELLN:dispatch=";
+pub const PROTOCOL: &str = "CELLN:dispatch-protocol=1";
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Frame {
+    Output { bytes: Vec<u8> },
+    Exit { code: i32 },
+    Signal { signal: i32 },
+    Failed { reason: String },
+}
+
+pub fn emit(frame: Frame) {
+    println!(
+        "{PREFIX}{}",
+        serde_json::to_string(&frame).expect("frame serializes")
+    );
+}

--- a/crates/celln-pilot/src/guest.rs
+++ b/crates/celln-pilot/src/guest.rs
@@ -21,13 +21,14 @@
 //! it never inherits tool-lane authority.
 
 use celln_manifest::{resolve_exec_lane, Hash, Input, Lane, Manifest};
+use pilot::dispatch_report::{emit, Frame};
 use pilot::{exec, ExecOutcome};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::ffi::CString;
 use std::fs::File;
 use std::io::{self, Read, Write};
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::process::ExitStatusExt;
 use std::process::ExitStatus;
 
@@ -544,6 +545,12 @@ struct RunRequest {
     /// host-authored; guest arguments cannot cause pilot to retain raw-I/O.
     #[serde(default)]
     allow_fetch: bool,
+    /// Opt-in framed dispatcher output; absent keeps the legacy console ABI.
+    #[serde(default)]
+    report_output_limit: Option<usize>,
+    /// The host may request less authority than the manifest permits.
+    #[serde(default)]
+    force_agent_lane: bool,
 }
 
 /// One cell can be asked to run several tools. Each invocation is hash-checked
@@ -566,6 +573,10 @@ struct RunFile {
     agent_authored_input: bool,
     #[serde(default)]
     allow_fetch: bool,
+    #[serde(default)]
+    report_output_limit: Option<usize>,
+    #[serde(default)]
+    force_agent_lane: bool,
 }
 
 impl RunFile {
@@ -590,6 +601,8 @@ impl RunFile {
                 agent_authored_input: self.agent_authored_input,
                 root: self.root,
                 allow_fetch: self.allow_fetch,
+                report_output_limit: self.report_output_limit,
+                force_agent_lane: self.force_agent_lane,
             }],
             _ => Vec::new(),
         }
@@ -647,6 +660,21 @@ fn child_error(error_fd: i32, error: io::Error) -> ! {
 /// description even if its old name is replaced between verification and
 /// execution.
 fn exec_open_file(file: &File, req: &RunRequest, confine: bool) -> io::Result<ExitStatus> {
+    let capture = if req.report_output_limit.is_some() {
+        let mut fds = [-1; 2];
+        if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Some(unsafe {
+            (
+                File::from_raw_fd(fds[0]),
+                File::from_raw_fd(fds[1]),
+                File::open("/dev/null")?,
+            )
+        })
+    } else {
+        None
+    };
     let argv_strings: Vec<CString> = std::iter::once(req.path.as_str())
         .chain(req.args.iter().map(String::as_str))
         .map(|arg| CString::new(arg).map_err(|_| io::Error::from(io::ErrorKind::InvalidInput)))
@@ -706,6 +734,21 @@ fn exec_open_file(file: &File, req: &RunRequest, confine: bool) -> io::Result<Ex
     }
     if pid == 0 {
         unsafe { libc::close(error_pipe[0]) };
+        if let Some((reader, writer, null)) = &capture {
+            // Do not leave stdin as an O_RDWR console handle either: a
+            // workload could write control-looking bytes through fd 0.
+            unsafe {
+                if libc::dup2(null.as_raw_fd(), 0) < 0
+                    || libc::dup2(writer.as_raw_fd(), 1) < 0
+                    || libc::dup2(writer.as_raw_fd(), 2) < 0
+                {
+                    child_error(error_pipe[1], io::Error::last_os_error());
+                }
+                libc::close(reader.as_raw_fd());
+                libc::close(writer.as_raw_fd());
+                libc::close(null.as_raw_fd());
+            }
+        }
         if let Some(root) = &req.root {
             if let Err(error) = enter_root(root) {
                 child_error(error_pipe[1], error);
@@ -752,6 +795,35 @@ fn exec_open_file(file: &File, req: &RunRequest, confine: bool) -> io::Result<Ex
     unsafe { libc::close(error_pipe[0]) };
     let read_error = (read < 0).then(io::Error::last_os_error);
 
+    let mut capture_error = None;
+    if let Some((mut reader, writer, null)) = capture {
+        drop(writer);
+        drop(null);
+        let mut remaining = req.report_output_limit.unwrap_or(0);
+        let mut chunk = [0; 256];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(count) => {
+                    let count = count.min(remaining);
+                    if count != 0 {
+                        emit(Frame::Output {
+                            bytes: chunk[..count].to_vec(),
+                        });
+                        remaining -= count;
+                    }
+                    // Drain beyond the bound so a verbose workload can still
+                    // terminate and report its real exit status.
+                }
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                Err(error) => {
+                    capture_error = Some(error);
+                    break;
+                }
+            }
+        }
+    }
+
     let mut raw_status = 0;
     loop {
         let waited = unsafe { libc::waitpid(pid, &mut raw_status, 0) };
@@ -764,6 +836,9 @@ fn exec_open_file(file: &File, req: &RunRequest, confine: bool) -> io::Result<Ex
         }
     }
     if let Some(error) = read_error {
+        return Err(error);
+    }
+    if let Some(error) = capture_error {
         return Err(error);
     }
     if read == errno_bytes.len() as isize {
@@ -782,6 +857,7 @@ fn exec_open_file(file: &File, req: &RunRequest, confine: bool) -> io::Result<Ex
 
 fn main() {
     report("pilot", "alive");
+    println!("{}", pilot::dispatch_report::PROTOCOL);
 
     let manifest: Manifest = match std::fs::read(MANIFEST) {
         Ok(bytes) => match serde_json::from_slice(&bytes) {
@@ -915,6 +991,11 @@ fn run_one(manifest: &Manifest, req: &RunRequest) {
     };
     let Ok((executable, hash)) = open_and_hash(&host_view) else {
         report(&format!("pilot_run_{}", req.alias), "absent");
+        if req.report_output_limit.is_some() {
+            emit(Frame::Failed {
+                reason: "executable absent".into(),
+            });
+        }
         return;
     };
 
@@ -928,11 +1009,21 @@ fn run_one(manifest: &Manifest, req: &RunRequest) {
     match exec(manifest, &hash, input) {
         ExecOutcome::Denied(e) => {
             report(&format!("pilot_run_{}", req.alias), "denied");
+            if req.report_output_limit.is_some() {
+                emit(Frame::Failed {
+                    reason: "pilot refused execution".into(),
+                });
+            }
             for line in e.to_json().lines() {
                 println!("CELLN:explain {line}");
             }
         }
         ExecOutcome::Run { lane, .. } => {
+            let lane = if req.force_agent_lane {
+                Lane::Data
+            } else {
+                lane
+            };
             report(
                 &format!("pilot_run_{}", req.alias),
                 &format!("permitted:{lane}"),
@@ -944,6 +1035,20 @@ fn run_one(manifest: &Manifest, req: &RunRequest) {
             let confine = lane != Lane::Tool;
             let status = exec_open_file(&executable, req, confine);
             println!("CELLN:out-end");
+
+            if req.report_output_limit.is_some() {
+                emit(match &status {
+                    Ok(s) => match s.code() {
+                        Some(code) => Frame::Exit { code },
+                        None => Frame::Signal {
+                            signal: s.signal().unwrap_or(0),
+                        },
+                    },
+                    Err(_) => Frame::Failed {
+                        reason: "pilot exec setup failed".into(),
+                    },
+                });
+            }
 
             match status {
                 Ok(s) => report(
@@ -1013,6 +1118,8 @@ mod tests {
             agent_authored_input: false,
             root: None,
             allow_fetch: false,
+            report_output_limit: None,
+            force_agent_lane: false,
         };
         let status = exec_open_file(&verified, &request, false).expect("executes verified fd");
         assert!(

--- a/crates/celln-pilot/src/lib.rs
+++ b/crates/celln-pilot/src/lib.rs
@@ -12,6 +12,8 @@
 use celln_manifest::{ExecDenied, Hash, Input, Lane, Manifest};
 use serde::Serialize;
 
+pub mod dispatch_report;
+
 /// The result of asking pilot to run something.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ExecOutcome {

--- a/docs/DISPATCH_RESULTS.md
+++ b/docs/DISPATCH_RESULTS.md
@@ -1,0 +1,55 @@
+# Dispatcher execution results
+
+The dispatcher determines success from pilot's observed exit status and the
+host's run termination. An exit of zero with a complete report succeeds even
+when the program is silent. Nonzero exits, signals, setup failures, pilot
+refusals, watchdog timeouts and missing or ambiguous reports fail.
+
+Output is collected independently. Failure output is retained up to the
+request's byte limit. A successful silent execution has no output reference.
+If nonempty output cannot be persisted, the execution is Failed with an
+output-persistence reason; a storage error must not masquerade as a guest
+exit error.
+
+## Reporting and compatibility
+
+Dispatcher-generated run requests opt into `report_output_limit`. Pilot
+connects the workload's stdout and stderr to a pipe, substitutes read-only
+`/dev/null` for stdin, and emits JSON frames prefixed `CELLN:dispatch=`.
+Output frames contain byte arrays, so arbitrary bytes and marker-like text
+cannot become pilot control messages by being printed. Pilot drains output
+beyond the byte limit without forwarding it, allowing the process to exit.
+Exactly one terminal frame reports exit code, signal, or pilot failure.
+
+The dispatcher requires a protocol announcement immediately after the first
+pilot startup marker, these frames, and a clean guest shutdown. A workload
+cannot impersonate an updated pilot by printing an announcement later. Older pilot
+assets without this protocol fail closed with a missing-report reason.
+Install matching host and pilot assets together. Requests without the opt-in
+retain the legacy console format used by the CLI. The public
+`celln.dev/v1alpha1` receipt shape is unchanged: phase and the existing status
+reason carry the corrected outcome; structured receipt provenance additions
+remain tracked in #10.
+
+This separates workload output from supervisor reports; it is not independent
+attestation of a malicious privileged guest kernel or a trusted tool that
+deliberately takes over its guest. Agent-lane requests explicitly narrow the
+manifest lane, and existing artifact authorship/proofs survive dispatch.
+
+## Proof
+
+Build the static pilot binaries, then run:
+
+```sh
+cargo test -p celln-cli dispatch_outcomes_on_real_kvm -- --ignored --nocapture
+```
+
+The real guest probes cover silent success, output then nonzero exit, a signal,
+forged markers, output beyond the limit, timeout, exec failure, preservation of
+agent authorship and revoked-tool refusal. Ordinary host tests cover malformed,
+duplicate and missing frames and output persistence failures. The hardware CI
+job runs the guest proof when KVM is available.
+
+This completes the outcome slice of #13. Declared substrate consumption,
+unsupported input/closure authority, warm spawning and end-to-end cancellation
+remain separate work in that issue.


### PR DESCRIPTION
The dispatcher currently treats stored output as proof of success: a program that prints then exits 7 can succeed, while a silent exit 0 fails. This change derives the result from pilot's observed exit status and the host's termination state, and persists bounded output independently.

Pilot captures dispatcher workload stdout/stderr in a pipe and encodes bytes as JSON frames. Printed control markers remain data. A startup protocol announcement rejects older pilot assets without output framing; missing, duplicate, malformed and interrupted reports fail closed. Existing CLI requests retain their console format, and the public receipt schema is unchanged.

The reporting proof also exposed two dispatch authority problems: launch overwrote existing agent authorship with Host, and an agent-lane request did not narrow a non-interpreter's manifest lane. Existing provenance is now preserved, and pilot explicitly honors requests for the agent lane without permitting promotion.

## Validation

- `make ci`
- Real KVM dispatcher proof: silent success, printed failure, signal, forged markers, output flooding, timeout, exec setup failure, retained agent authorship/confinement, and revoked-tool refusal.
- Host tests: malformed/duplicate/missing reports, old-pilot impersonation, failure-output retention, silent receipts and output-store failure.
- Existing `make acceptance-kvm` and `make fetch-proof` passed.
- The new guest proof is included in the hardware CI job.

Install matching host and pilot assets together. An older pilot fails closed rather than providing a compatible dispatcher result. This is output/control separation within the existing guest trust model, not attestation against a compromised guest kernel or deliberately malicious privileged tool.

Refs #13, #2, #3, #12.

This implements the first outcome slice of #13. Unsupported input/closure authority, declared substrate consumption, warm spawning and end-to-end cancellation remain open.
