### PR TITLE
fix(dispatch): refuse unsupported input and closure authority

### DIFF
--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -44,6 +44,25 @@ pub struct ResolvedBundle {
     pub toolfs_hash: String,
 }
 
+/// Runtime support is narrower than the transport schema. Do not silently
+/// discard requested authority or describe requested-but-unused objects as
+/// resolved provenance. Remove each refusal only with its delivery proof.
+pub(crate) fn check_supported_authority(request: &ExecutionRequest) -> Result<(), String> {
+    if !request.inputs.is_empty() {
+        return Err("unsupported authority: input delivery is not implemented".into());
+    }
+    if request.capabilities.workspace != celln_spec::WorkspaceAccess::None {
+        return Err("unsupported authority: workspace delivery is not implemented".into());
+    }
+    if request.tools.iter().any(|tool| tool.closure.is_some()) {
+        return Err("unsupported authority: tool closure delivery is not implemented".into());
+    }
+    if request.tools.len() > 1 {
+        return Err("unsupported authority: only the invoked tool can be delivered".into());
+    }
+    Ok(())
+}
+
 pub fn resolve_bundle(
     request: &ExecutionRequest,
     mote_root: &Path,
@@ -67,6 +86,7 @@ pub fn resolve_bundle(
                 .join("; ")
         ));
     }
+    check_supported_authority(request)?;
     let mote = request
         .mote
         .as_ref()
@@ -261,6 +281,7 @@ pub fn launch(
 ) -> Result<LaunchOutcome, String> {
     use warden::vmm::boot::{BootConfig, LinuxCell};
 
+    check_supported_authority(request)?;
     if !Path::new("/dev/kvm").exists() {
         return Err("no /dev/kvm — cannot seal a cell on this host".to_owned());
     }
@@ -413,7 +434,7 @@ pub fn launch(
 
 #[cfg(not(target_os = "linux"))]
 pub fn launch(
-    _request: &ExecutionRequest,
+    request: &ExecutionRequest,
     _alias: &str,
     _args: &[String],
     _program_bytes: &[u8],
@@ -421,6 +442,7 @@ pub fn launch(
     _assay_root: &Path,
     _state_root: &Path,
 ) -> Result<LaunchOutcome, String> {
+    check_supported_authority(request)?;
     Err("sealing cells needs Linux with /dev/kvm".to_owned())
 }
 
@@ -478,6 +500,69 @@ mod tests {
     use celln_store::Store;
     use serde_json::json;
     use tempfile::tempdir;
+
+    #[test]
+    fn unsupported_authority_refuses_before_resolution_or_launch() {
+        let base: ExecutionRequest = serde_json::from_value(json!({
+            "apiVersion": "celln.dev/v1alpha1", "id": "authority-test",
+            "workload": { "id": "test", "caller": "test" },
+            "mote": { "hash": Hash::of(b"mote").0 },
+            "tools": [{ "alias": "/tools/program", "hash": Hash::of(b"program").0 }],
+            "invocation": { "alias": "/tools/program" },
+            "capabilities": { "workspace": "none", "timeoutMs": 1000, "memoryBytes": 268435456, "outputBytes": 1024 },
+            "execution": { "lane": "agent", "requireHardwareIsolation": true }
+        })).unwrap();
+        assert!(base.problems().is_empty());
+        assert!(check_supported_authority(&base).is_ok());
+        let mut cases = Vec::new();
+        let mut input = base.clone();
+        input.inputs.push(celln_spec::ExecutionInput {
+            name: "data".into(),
+            hash: Hash::of(b"data").0,
+            media_type: "text/plain".into(),
+            bytes: 4,
+        });
+        cases.push((input, "input delivery"));
+        for access in [
+            celln_spec::WorkspaceAccess::ReadOnly,
+            celln_spec::WorkspaceAccess::ReadWrite,
+        ] {
+            let mut workspace = base.clone();
+            workspace.capabilities.workspace = access;
+            cases.push((workspace, "workspace delivery"));
+        }
+        let mut closure = base.clone();
+        closure.tools[0].closure = Some(celln_spec::ImmutableRef {
+            hash: Hash::of(b"closure").0,
+        });
+        cases.push((closure, "closure delivery"));
+        let mut extra = base.clone();
+        extra.tools.push(celln_spec::ToolRef {
+            alias: "/tools/extra".into(),
+            hash: Hash::of(b"extra").0,
+            closure: None,
+        });
+        cases.push((extra, "only the invoked tool"));
+        let work = tempdir().unwrap();
+        let missing = work.path().join("must-not-be-created");
+        for (request, reason) in cases {
+            assert!(request.problems().is_empty());
+            let error = resolve_bundle(&request, &missing, &missing).unwrap_err();
+            assert!(error.contains(reason), "{error}");
+            let error = launch(
+                &request,
+                "program",
+                &[],
+                b"program",
+                &missing,
+                &missing,
+                &missing,
+            )
+            .unwrap_err();
+            assert!(error.contains(reason), "{error}");
+            assert!(!missing.exists());
+        }
+    }
 
     #[test]
     fn resolved_bundle_binds_the_requested_invocation_to_the_declared_tool() {

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -328,6 +328,13 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
                     &serde_json::json!({"error": "invalid execution request", "problems": problems}),
                 );
             }
+            if let Err(reason) = crate::dispatch::check_supported_authority(&request) {
+                return reply(
+                    &mut stream,
+                    422,
+                    &serde_json::json!({"error": "request refused", "reason": "unsupported", "detail": reason}),
+                );
+            }
             if let Err(error) = state.egress_policy.check(&request) {
                 return reply(
                     &mut stream,
@@ -443,6 +450,15 @@ fn run_execution(
     probe: NodeProbeArgs,
     root: PathBuf,
 ) {
+    // Defense in depth: direct callers must refuse before model invocations,
+    // store access or runtime preparation, not only at the HTTP boundary.
+    if let Err(reason) = crate::dispatch::check_supported_authority(&request) {
+        update_execution(&executions, &request.id, |record| {
+            record.phase = "Refused".into();
+            record.reason = Some(reason);
+        });
+        return;
+    }
     let started_at = crate::dispatch::now_rfc3339();
     let runtime_root = match crate::agent::runtime_root() {
         Ok(path) => path,
@@ -534,11 +550,9 @@ fn run_execution(
         resolved: ResolvedExecution {
             mote,
             tools: vec![program_hash],
-            inputs: request
-                .inputs
-                .iter()
-                .map(|input| input.hash.clone())
-                .collect(),
+            // No input provider exists yet. Never echo requested hashes as
+            // evidence that their bytes were resolved or delivered.
+            inputs: Vec::new(),
         },
         output: stored_output,
         started_at,
@@ -617,6 +631,87 @@ fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    #[test]
+    fn unsupported_forge_authority_is_refused_without_side_effects() {
+        let mut request = request_with_egress(&[]);
+        request.capabilities.workspace = celln_spec::WorkspaceAccess::ReadWrite;
+        let work = tempfile::tempdir().unwrap();
+        let root = work.path().join("must-not-be-created");
+        let executions: Executions = Arc::new(Mutex::new(HashMap::new()));
+        executions.lock().unwrap().insert(
+            request.id.clone(),
+            Entry::new(ExecutionRecord {
+                request_id: request.id.clone(),
+                phase: "Admitting".into(),
+                reason: None,
+                output: None,
+                receipt: None,
+            }),
+        );
+        let probe = NodeProbeArgs {
+            node_name: "test".into(),
+            mote_store: root.join("motes"),
+            tool_store: root.join("tools"),
+            max_cells: 1,
+            memory_bytes: 268435456,
+            egress_slots: 0,
+        };
+        run_execution(
+            request.clone(),
+            Arc::clone(&executions),
+            probe,
+            root.clone(),
+        );
+        let registry = executions.lock().unwrap();
+        let record = &registry[&request.id].value;
+        assert_eq!(record.phase, "Refused");
+        assert!(record
+            .reason
+            .as_deref()
+            .unwrap()
+            .contains("workspace delivery"));
+        assert!(record.receipt.is_none());
+        assert!(!execution_is_active(record));
+        assert!(!root.exists());
+    }
+
+    #[test]
+    fn http_unsupported_authority_returns_422_without_reserving_capacity() {
+        let mut request = request_with_egress(&[]);
+        request.capabilities.workspace = celln_spec::WorkspaceAccess::ReadOnly;
+        let work = tempfile::tempdir().unwrap();
+        let root = work.path().join("unused");
+        let state = State {
+            token: "test-token-at-least-24-bytes".into(),
+            egress_policy: EgressPolicy::new(&[]).unwrap(),
+            root: root.clone(),
+            probe: NodeProbeArgs {
+                node_name: "test".into(),
+                mote_store: root.join("motes"),
+                tool_store: root.join("tools"),
+                max_cells: 1,
+                memory_bytes: 268435456,
+                egress_slots: 0,
+            },
+            executions: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let (server, _) = listener.accept().unwrap();
+        let body = serde_json::to_string(&request).unwrap();
+        write!(client, "POST /v1/executions HTTP/1.1\r\nAuthorization: Bearer {}\r\nContent-Length: {}\r\n\r\n{}", state.token, body.len(), body).unwrap();
+        handle(server, &state).unwrap();
+        let mut response = String::new();
+        client.read_to_string(&mut response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 422"), "{response}");
+        assert!(response.contains("workspace delivery"));
+        assert!(state.executions.lock().unwrap().is_empty());
+        assert!(!root.exists());
+    }
 
     #[test]
     fn receipt_phase_tracks_exit_and_output_storage_independently() {

--- a/crates/celln-cli/src/node.rs
+++ b/crates/celln-cli/src/node.rs
@@ -128,7 +128,9 @@ pub fn admit(request: &ExecutionRequest, node: &NodeEligibility) -> Admission {
             problems,
         };
     }
-    if request.execution.require_hardware_isolation && (!node.kvm || !node.cpu_virtualization) {
+    if crate::dispatch::check_supported_authority(request).is_err()
+        || request.execution.require_hardware_isolation && (!node.kvm || !node.cpu_virtualization)
+    {
         return Admission::Refused {
             request_id: request.id.clone(),
             node: node.clone(),
@@ -176,6 +178,34 @@ fn print_json(value: &impl Serialize) -> Result<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unsupported_workspace_is_not_admitted_on_an_eligible_node() {
+        let mut request: ExecutionRequest =
+            serde_json::from_str(include_str!("../../../examples/execution/forge-task.json"))
+                .unwrap();
+        let node = NodeEligibility {
+            node_name: "test".into(),
+            kvm: true,
+            cpu_virtualization: true,
+            guest_kernel: true,
+            mote_store: true,
+            tool_store: true,
+            live_cells: 0,
+            max_cells: 1,
+            memory_bytes: 268435456,
+            egress_slots: 0,
+        };
+        assert!(matches!(admit(&request, &node), Admission::Accepted { .. }));
+        request.capabilities.workspace = celln_spec::WorkspaceAccess::ReadOnly;
+        assert!(matches!(
+            admit(&request, &node),
+            Admission::Refused {
+                reason: RefusalCode::Unsupported,
+                ..
+            }
+        ));
+    }
 
     #[test]
     fn hardware_requirement_refuses_a_node_without_kvm() {

--- a/docs/DISPATCH_RESULTS.md
+++ b/docs/DISPATCH_RESULTS.md
@@ -50,6 +50,23 @@ agent authorship and revoked-tool refusal. Ordinary host tests cover malformed,
 duplicate and missing frames and output persistence failures. The hardware CI
 job runs the guest proof when KVM is available.
 
-This completes the outcome slice of #13. Declared substrate consumption,
-unsupported input/closure authority, warm spawning and end-to-end cancellation
-remain separate work in that issue.
+## Supported request authority
+
+The transport schema describes more authority than the runtime currently
+delivers. Node admission, HTTP submission, direct bundle resolution and launch
+refuse inputs, read-only/read-write workspace requests, tool closures and
+multiple tools. HTTP returns 422 with `reason: "unsupported"` and a diagnostic
+before reserving capacity or starting model, store or VM work. The worker
+also checks before forging, for callers that bypass HTTP. These are temporary
+runtime restrictions, not removals from the versioned schema.
+
+Receipts contain no input hashes until a provider actually resolves and delivers
+the bytes. `workspace: "none"` means no caller workspace is delivered; it does
+not claim that all guest scratch filesystems are unwritable. Delivery and guest
+enforcement proofs remain in #3/#7; closure loading remains in #6.
+
+This completes the outcome and unsupported-input/closure refusal slices of #13.
+Declared substrate consumption/authentication, warm spawning and end-to-end
+cancellation remain separate work. In particular, bundle resolution currently
+checks artifact integrity but launch still reconstructs the substrate; it is
+not yet proof of execution of the declared mote identity.


### PR DESCRIPTION
## Change

Refuse input delivery, read-only/read-write caller workspace, tool closures and multiple declared tools until their delivery is implemented. Previously these requests could execute while their authority was ignored, and receipts copied unused input hashes into resolved provenance.

The shared support check runs in node admission, HTTP submission, direct resolution and launch. The worker also checks before forging. HTTP returns 422/unsupported with a diagnostic before reserving capacity. Receipts no longer echo requested input hashes.

The versioned schema is unchanged. These are explicit temporary runtime restrictions, not removal of the intended input/closure features. `workspace: none` means no caller workspace delivery, not a claim that guest scratch is unwritable.

## Validation

`make ci` passed, including new tests for all unsupported authority categories, direct resolution/launch refusing before side effects, an otherwise eligible node refusing, a forge worker refusing without invoking the model, and an authenticated HTTP 422 with no capacity reservation or receipt.

Refs #13, #3, #6, #7, #10. Follows merged #56.

Declared substrate consumption/authentication, warm spawning and cancellation remain open in #13. In particular, resolving a bundle is still not proof that launch executed its substrate bytes; this PR does not claim to fix that next slice.
