### PR TITLE
fix(dispatch): execute operator-pinned declared substrates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           make acceptance-kvm
           cargo build --release --target x86_64-unknown-linux-musl -p celln-pilot --bin celln-pilot --bin pilot-fetch
           cargo test -p celln-cli dispatch_outcomes_on_real_kvm -- --ignored --nocapture
+          cargo test -p celln-cli declared_substrate_on_real_kvm -- --ignored --nocapture
       - name: no /dev/kvm on this runner
         if: steps.kvm.outputs.have == 'no'
         run: |

--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -10,6 +10,10 @@ use celln_store::Store;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+#[path = "dispatch_substrate.rs"]
+mod substrate;
+pub(crate) use substrate::launch_declared;
+
 /// The serializable substrate descriptor stored under `ExecutionRequest.mote`.
 /// Each referenced object is resolved by content hash before the VMM is given
 /// any bytes. The in-guest pilot remains responsible for confirming that the
@@ -19,6 +23,8 @@ use std::path::Path;
 struct MoteBundle {
     #[serde(rename = "apiVersion")]
     api_version: String,
+    #[serde(default)]
+    format: Option<String>,
     kernel: String,
     initrd: String,
     toolfs: String,
@@ -42,6 +48,14 @@ pub struct ResolvedBundle {
     pub kernel_hash: String,
     pub initrd_hash: String,
     pub toolfs_hash: String,
+    #[serde(skip)]
+    kernel_bytes: Vec<u8>,
+    #[serde(skip)]
+    initrd_bytes: Vec<u8>,
+    #[serde(skip)]
+    toolfs_bytes: Vec<u8>,
+    #[serde(skip)]
+    format: Option<String>,
 }
 
 /// Runtime support is narrower than the transport schema. Do not silently
@@ -120,13 +134,17 @@ pub fn resolve_bundle(
     tool_store
         .get(&Hash(requested_tool.hash.clone()))
         .map_err(|error| format!("declared program cannot be resolved: {error}"))?;
-    for hash in [&bundle.kernel, &bundle.initrd, &bundle.toolfs] {
+    let read_object = |hash: &str| {
         mote_store
-            .get(&Hash(hash.clone()))
-            .map_err(|error| format!("mote bundle object cannot be resolved: {error}"))?;
-    }
+            .get(&Hash(hash.to_owned()))
+            .map_err(|error| format!("mote bundle object cannot be resolved: {error}"))
+    };
 
     Ok(ResolvedBundle {
+        format: bundle.format,
+        kernel_bytes: read_object(&bundle.kernel)?,
+        initrd_bytes: read_object(&bundle.initrd)?,
+        toolfs_bytes: read_object(&bundle.toolfs)?,
         bundle_hash: mote.hash.clone(),
         program_hash: requested_tool.hash.clone(),
         kernel_hash: bundle.kernel,
@@ -279,9 +297,12 @@ pub fn launch(
     assay_root: &Path,
     state_root: &Path,
 ) -> Result<LaunchOutcome, String> {
-    use warden::vmm::boot::{BootConfig, LinuxCell};
+    use warden::vmm::boot::BootConfig;
 
     check_supported_authority(request)?;
+    if request.mote.is_some() {
+        return Err("declared execution requires the pinned substrate launcher".into());
+    }
     if !Path::new("/dev/kvm").exists() {
         return Err("no /dev/kvm — cannot seal a cell on this host".to_owned());
     }
@@ -361,9 +382,21 @@ pub fn launch(
     let kernel = BootConfig::host_kernel()
         .ok_or_else(|| "no readable /boot/vmlinuz-* with matching /lib/modules".to_owned())?;
     let payload = std::fs::read(&toolfs).map_err(|error| error.to_string())?;
-    let mut cfg = BootConfig::new(&kernel)
+    let cfg = BootConfig::new(&kernel)
         .with_pmem(payload.len())
         .with_initrd(&initrd);
+    run_prepared(request, alias, cfg, payload, state_root)
+}
+
+#[cfg(target_os = "linux")]
+fn run_prepared(
+    request: &ExecutionRequest,
+    alias: &str,
+    mut cfg: warden::vmm::boot::BootConfig,
+    payload: Vec<u8>,
+    state_root: &Path,
+) -> Result<LaunchOutcome, String> {
+    use warden::vmm::boot::LinuxCell;
     if request.capabilities.memory_bytes > 0 {
         cfg.mem_size = request.capabilities.memory_bytes as usize;
     }
@@ -790,7 +823,7 @@ mod tests {
     /// already-built guest pilot binaries. `None` (with an explanatory
     /// `eprintln!`) if the guest pilot binaries haven't been built.
     #[cfg(target_os = "linux")]
-    fn test_runtime_root(work: &Path) -> Option<std::path::PathBuf> {
+    pub(super) fn test_runtime_root(work: &Path) -> Option<std::path::PathBuf> {
         let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."); // crates/celln-cli -> repo root
         let repo_root = repo_root.canonicalize().expect("repo root resolves");
         let pilot_dir = repo_root.join("target/x86_64-unknown-linux-musl/release");
@@ -829,123 +862,6 @@ mod tests {
         )
         .expect("copy pilot-fetch");
         Some(runtime_root)
-    }
-
-    /// Full pipeline, on real hardware: resolve a declared program from a
-    /// content-addressed store, seal it into a cell, boot it, and check the
-    /// output pilot reports. Not run by default — needs /dev/kvm, the
-    /// `x86_64-unknown-linux-musl` target, and a host kernel with matching
-    /// `/lib/modules` (same requirement `make test-kvm`/`acceptance-kvm`
-    /// have). Run explicitly with:
-    ///   cargo test -p celln-cli -- --ignored launch_actually_boots_and_runs_the_resolved_program
-    #[test]
-    #[ignore]
-    #[cfg(target_os = "linux")]
-    fn launch_actually_boots_and_runs_the_resolved_program() {
-        use std::process::Command;
-
-        if !Path::new("/dev/kvm").exists() {
-            eprintln!("skipping: no /dev/kvm on this runner");
-            return;
-        }
-
-        // ── build a tiny static-musl payload, the same shape `celln agent`
-        // would forge, but written here instead of asked of a model ──
-        let work = tempdir().expect("work dir");
-        let src = work.path().join("main.rs");
-        std::fs::write(
-            &src,
-            r#"fn main() { println!("hello from an execution request"); }"#,
-        )
-        .expect("write source");
-        let program_out = work.path().join("program-bin");
-        let rustc = Command::new("rustc")
-            .args([
-                "--edition=2021",
-                "-O",
-                "--target",
-                "x86_64-unknown-linux-musl",
-                "-o",
-            ])
-            .arg(&program_out)
-            .arg(&src)
-            .status();
-        match rustc {
-            Ok(status) if status.success() => {}
-            _ => {
-                eprintln!("skipping: rustc --target x86_64-unknown-linux-musl unavailable");
-                return;
-            }
-        }
-        let program_bytes = std::fs::read(&program_out).expect("read compiled program");
-
-        let Some(runtime_root) = test_runtime_root(work.path()) else {
-            return;
-        };
-
-        // ── a mote bundle and matching tool, resolvable exactly like a real
-        // control plane would declare them ──
-        let motes = tempdir().expect("mote store");
-        let tools = tempdir().expect("tool store");
-        let tool_store = Store::open(tools.path()).expect("open tool store");
-        let tool_hash = tool_store.put(&program_bytes).expect("store program");
-        let mote_store = Store::open(motes.path()).expect("open mote store");
-        let kernel_hash = mote_store.put(b"kernel-placeholder").expect("store kernel");
-        let initrd_hash = mote_store.put(b"initrd-placeholder").expect("store initrd");
-        let toolfs_hash = mote_store.put(b"toolfs-placeholder").expect("store toolfs");
-        let bundle = json!({
-            "apiVersion": "celln.dev/v1alpha1",
-            "kernel": kernel_hash.0,
-            "initrd": initrd_hash.0,
-            "toolfs": toolfs_hash.0,
-            "invocation": { "alias": "/agent/program", "toolHash": tool_hash.0 }
-        });
-        let mote_hash = mote_store
-            .put(&serde_json::to_vec(&bundle).expect("bundle serializes"))
-            .expect("store bundle");
-
-        let request: ExecutionRequest = serde_json::from_value(json!({
-            "apiVersion": "celln.dev/v1alpha1",
-            "id": "launch-smoke-test",
-            "workload": { "id": "smoke-test", "caller": "test:launch" },
-            "mote": { "hash": mote_hash.0 },
-            "tools": [{ "alias": "/agent/program", "hash": tool_hash.0 }],
-            "invocation": { "alias": "/agent/program", "args": [] },
-            "capabilities": { "workspace": "none", "timeoutMs": 20000, "memoryBytes": 268435456, "outputBytes": 65536 },
-            "execution": { "lane": "tool", "requireHardwareIsolation": true }
-        }))
-        .expect("request parses");
-
-        let resolved =
-            resolve_bundle(&request, motes.path(), tools.path()).expect("bundle resolves");
-        assert_eq!(resolved.program_hash, tool_hash.0);
-
-        let assay_root = work.path().join("assay");
-        let state_root = work.path().join("state");
-        std::fs::create_dir_all(&state_root).unwrap();
-
-        let outcome = launch(
-            &request,
-            "/agent/program",
-            &[],
-            &program_bytes,
-            &runtime_root,
-            &assay_root,
-            &state_root,
-        )
-        .expect("cell launches and runs");
-
-        assert!(
-            outcome.denial.is_none(),
-            "pilot denied it: {:?}",
-            outcome.denial
-        );
-        let output = outcome.output.expect("program produced output");
-        let output = String::from_utf8(output).expect("output is utf8");
-        assert!(
-            output.contains("hello from an execution request"),
-            "unexpected output: {output:?}"
-        );
     }
 
     /// Full forge-from-task pipeline, on real hardware: a real,

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -460,18 +460,11 @@ fn run_execution(
         return;
     }
     let started_at = crate::dispatch::now_rfc3339();
-    let runtime_root = match crate::agent::runtime_root() {
-        Ok(path) => path,
-        Err(error) => return fail_execution(&executions, &request.id, error.to_string()),
-    };
     let assay_root = root.join("assay");
 
-    // Resolved authority for the receipt: (mote, program hash, alias, args,
-    // bytes to seal). The declared and forge paths converge here — from this
-    // point on, `launch` doesn't know or care which one produced the bytes.
-    let (mote, program_hash, alias, args, program_bytes) = if let Some(forge_request) =
-        &request.forge
-    {
+    // Declared launch consumes operator-pinned substrate bytes. Forge remains
+    // a separately identified host-prepared path, with no declared mote claim.
+    let (mote, program_hash, outcome) = if let Some(forge_request) = &request.forge {
         update_execution(&executions, &request.id, |record| {
             record.phase = "Forging".into()
         });
@@ -483,60 +476,40 @@ fn run_execution(
             Ok(forged) => forged,
             Err(error) => return fail_execution(&executions, &request.id, error),
         };
-        (
-            None,
-            forged.hash,
-            crate::agent::ALIAS.to_owned(),
-            Vec::new(),
-            forged.bytes,
-        )
+        let runtime_root = match crate::agent::runtime_root() {
+            Ok(path) => path,
+            Err(error) => return fail_execution(&executions, &request.id, error.to_string()),
+        };
+        update_execution(&executions, &request.id, |record| {
+            record.phase = "Running".into()
+        });
+        let outcome = match crate::dispatch::launch(
+            &request,
+            crate::agent::ALIAS,
+            &[],
+            &forged.bytes,
+            &runtime_root,
+            &assay_root,
+            &root,
+        ) {
+            Ok(outcome) => outcome,
+            Err(error) => return fail_execution(&executions, &request.id, error),
+        };
+        (None, forged.hash, outcome)
     } else {
         update_execution(&executions, &request.id, |record| {
             record.phase = "Resolving".into()
         });
-        let resolved =
-            match crate::dispatch::resolve_bundle(&request, &probe.mote_store, &probe.tool_store) {
-                Ok(resolved) => resolved,
-                Err(error) => return fail_execution(&executions, &request.id, error),
-            };
-        let tool_store = match Store::open(&probe.tool_store) {
-            Ok(store) => store,
-            Err(error) => return fail_execution(&executions, &request.id, error.to_string()),
+        let (outcome, resolved) = match crate::dispatch::launch_declared(
+            &request,
+            &probe.mote_store,
+            &probe.tool_store,
+            &root,
+        ) {
+            Ok(result) => result,
+            Err(error) => return fail_execution(&executions, &request.id, error),
         };
-        let program_bytes =
-            match tool_store.get(&celln_manifest::Hash(resolved.program_hash.clone())) {
-                Ok(bytes) => bytes,
-                Err(error) => return fail_execution(&executions, &request.id, error.to_string()),
-            };
-        // Presence already validated by celln_spec's own problems() — a
-        // declared request always has an invocation.
-        let invocation = request
-            .invocation
-            .as_ref()
-            .expect("declared request has an invocation");
-        (
-            Some(resolved.bundle_hash),
-            resolved.program_hash,
-            invocation.alias.clone(),
-            invocation.args.clone(),
-            program_bytes,
-        )
-    };
-
-    update_execution(&executions, &request.id, |record| {
-        record.phase = "Running".into()
-    });
-    let outcome = match crate::dispatch::launch(
-        &request,
-        &alias,
-        &args,
-        &program_bytes,
-        &runtime_root,
-        &assay_root,
-        &root,
-    ) {
-        Ok(outcome) => outcome,
-        Err(error) => return fail_execution(&executions, &request.id, error),
+        (Some(resolved.bundle_hash), resolved.program_hash, outcome)
     };
 
     let output = outcome.output.as_deref().filter(|bytes| !bytes.is_empty());

--- a/crates/celln-cli/src/dispatch_substrate.rs
+++ b/crates/celln-cli/src/dispatch_substrate.rs
@@ -1,0 +1,422 @@
+//! Operator-pinned, immutable declared substrates. Store integrity does not
+//! establish trust: only the separate host-owned policy grants admission.
+
+use super::{LaunchOutcome, ResolvedBundle};
+use celln_spec::ExecutionRequest;
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct TrustedMotes {
+    api_version: String,
+    bundles: Vec<String>,
+}
+
+fn authorize(request: &ExecutionRequest, state_root: &Path) -> Result<(), String> {
+    let hash = &request.mote.as_ref().ok_or("declared mote required")?.hash;
+    let bytes = std::fs::read(state_root.join("trusted-motes.json"))
+        .map_err(|_| "declared mote trust policy is unavailable".to_owned())?;
+    let policy: TrustedMotes = serde_json::from_slice(&bytes)
+        .map_err(|_| "declared mote trust policy is invalid".to_owned())?;
+    if policy.api_version != "celln.dev/v1alpha1" || !policy.bundles.contains(hash) {
+        return Err("declared mote is not authorized by host policy".into());
+    }
+    Ok(())
+}
+
+/// A pinned bundle cannot undo authority already narrowed on this node.
+fn local_agent_constraint(hash: &str, state_root: &Path) -> Result<bool, String> {
+    let path = state_root.join("assay/manifest.json");
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(_) => return Err("local manifest is unreadable".into()),
+    };
+    let manifest: celln_manifest::Manifest =
+        serde_json::from_slice(&bytes).map_err(|_| "local manifest is invalid".to_owned())?;
+    let hash = celln_manifest::Hash(hash.to_owned());
+    if manifest.is_revoked(&hash) {
+        return Err("declared program is locally revoked".into());
+    }
+    Ok(manifest
+        .get(&hash)
+        .is_some_and(|entry| entry.author == celln_manifest::Author::Agent || entry.interpreter))
+}
+
+/// Construct only the host-owned invocation file, never executable content.
+/// Linux unpacks concatenated newc archives in order. The immutable base must
+/// provide a real /celln directory; publisher review of this is part of pinning.
+#[cfg(target_os = "linux")]
+fn file_archive(name: &str, bytes: &[u8]) -> Vec<u8> {
+    fn entry(out: &mut Vec<u8>, name: &str, mode: u32, bytes: &[u8]) {
+        let fields = [
+            1,
+            mode,
+            0,
+            0,
+            1,
+            0,
+            bytes.len() as u32,
+            0,
+            0,
+            0,
+            0,
+            (name.len() + 1) as u32,
+            0,
+        ];
+        out.extend_from_slice(b"070701");
+        for field in fields {
+            out.extend_from_slice(format!("{field:08x}").as_bytes());
+        }
+        out.extend_from_slice(name.as_bytes());
+        out.push(0);
+        while out.len() % 4 != 0 {
+            out.push(0);
+        }
+        out.extend_from_slice(bytes);
+        while out.len() % 4 != 0 {
+            out.push(0);
+        }
+    }
+    let mut archive = Vec::new();
+    entry(&mut archive, name, 0o100644, bytes);
+    entry(&mut archive, "TRAILER!!!", 0, &[]);
+    archive
+}
+
+pub(crate) fn launch_declared(
+    request: &ExecutionRequest,
+    mote_root: &Path,
+    tool_root: &Path,
+    state_root: &Path,
+) -> Result<(LaunchOutcome, ResolvedBundle), String> {
+    super::check_supported_authority(request)?;
+    authorize(request, state_root)?;
+    let resolved = super::resolve_bundle(request, mote_root, tool_root)?;
+    let local_agent = local_agent_constraint(&resolved.program_hash, state_root)?;
+    if resolved.format.as_deref() != Some("celln.static-v1") {
+        return Err("unsupported declared mote format; expected celln.static-v1".into());
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        Err("sealing cells needs Linux with /dev/kvm".into())
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let invocation = request.invocation.as_ref().ok_or("invocation required")?;
+        // Artifact bytes remain in memory after verified reads. No mutable
+        // store path is reopened between verification and VMM loading.
+        let work = crate::agent::tempdir().map_err(|e| e.to_string())?;
+        let kernel = work.path().join("kernel");
+        let initrd = work.path().join("initrd");
+        if !resolved.initrd_bytes.starts_with(b"070701") {
+            return Err("unsupported initrd: celln.static-v1 requires uncompressed newc".into());
+        }
+        let run = serde_json::to_vec(&serde_json::json!({
+            "path": "/tools/program", "alias": invocation.alias,
+            "args": invocation.args, "expected_hash": resolved.program_hash,
+            "agent_authored_input": request.execution.lane == celln_spec::RequestedLane::Agent,
+            "force_agent_lane": local_agent || request.execution.lane == celln_spec::RequestedLane::Agent,
+            "allow_fetch": !request.capabilities.egress.is_empty(),
+            "report_output_limit": request.capabilities.output_bytes,
+        }))
+        .map_err(|e| e.to_string())?;
+        let mut initrd_bytes = resolved.initrd_bytes.clone();
+        while initrd_bytes.len() % 4 != 0 {
+            initrd_bytes.push(0);
+        }
+        initrd_bytes.extend(file_archive("celln/run.json", &run));
+        std::fs::write(&kernel, &resolved.kernel_bytes).map_err(|e| e.to_string())?;
+        std::fs::write(&initrd, &initrd_bytes).map_err(|e| e.to_string())?;
+        let cfg = warden::vmm::boot::BootConfig::new(kernel)
+            .with_initrd(initrd)
+            .with_pmem(resolved.toolfs_bytes.len());
+        let outcome = super::run_prepared(
+            request,
+            &invocation.alias,
+            cfg,
+            resolved.toolfs_bytes.clone(),
+            state_root,
+        )?;
+        Ok((outcome, resolved))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use celln_manifest::Hash;
+    use celln_store::Store;
+    use serde_json::json;
+
+    fn request(mote: &Hash, program: &Hash) -> ExecutionRequest {
+        serde_json::from_value(json!({
+            "apiVersion": "celln.dev/v1alpha1", "id": "substrate-test",
+            "workload": { "id": "test", "caller": "test" },
+            "mote": { "hash": mote.0 },
+            "tools": [{ "alias": "/tools/program", "hash": program.0 }],
+            "invocation": { "alias": "/tools/program", "args": ["substrate"] },
+            "capabilities": { "workspace": "none", "timeoutMs": 8000, "memoryBytes": 268435456, "outputBytes": 1024 },
+            "execution": { "lane": "agent", "requireHardwareIsolation": true }
+        })).unwrap()
+    }
+
+    fn pin(root: &Path, hash: &Hash) {
+        std::fs::create_dir_all(root).unwrap();
+        std::fs::write(
+            root.join("trusted-motes.json"),
+            serde_json::to_vec(&json!({
+                "apiVersion": "celln.dev/v1alpha1", "bundles": [hash.0]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn trust_is_separate_from_store_integrity_and_fails_closed() {
+        let work = tempfile::tempdir().unwrap();
+        let hash = Hash::of(b"bundle");
+        let request = request(&hash, &Hash::of(b"program"));
+        let missing = work.path().join("must-not-be-opened");
+        assert!(launch_declared(&request, &missing, &missing, work.path())
+            .unwrap_err()
+            .contains("policy is unavailable"));
+        pin(work.path(), &Hash::of(b"different bundle"));
+        assert!(launch_declared(&request, &missing, &missing, work.path())
+            .unwrap_err()
+            .contains("not authorized"));
+        std::fs::write(work.path().join("trusted-motes.json"), b"{}").unwrap();
+        assert!(authorize(&request, work.path())
+            .unwrap_err()
+            .contains("invalid"));
+        assert!(!missing.exists());
+        pin(work.path(), &hash);
+        assert!(authorize(&request, work.path()).is_ok());
+    }
+
+    #[test]
+    fn pinned_substrate_cannot_override_local_authority() {
+        let work = tempfile::tempdir().unwrap();
+        let mut assayer = assay::Assayer::open(work.path().join("assay")).unwrap();
+        let hash = assayer
+            .admit_verified_authored(
+                "/tools/program",
+                b"program",
+                false,
+                celln_manifest::Author::Agent,
+            )
+            .unwrap();
+        assert!(local_agent_constraint(&hash.0, work.path()).unwrap());
+        assayer.revoke(&hash);
+        assert!(local_agent_constraint(&hash.0, work.path())
+            .unwrap_err()
+            .contains("revoked"));
+    }
+
+    #[test]
+    fn a_pin_never_bypasses_artifact_integrity() {
+        let work = tempfile::tempdir().unwrap();
+        let store = Store::open(work.path().join("motes")).unwrap();
+        let tools = Store::open(work.path().join("tools")).unwrap();
+        let program = tools.put(b"program").unwrap();
+        let kernel = store.put(b"kernel").unwrap();
+        let initrd = store.put(b"070701-base").unwrap();
+        let toolfs = store.put(b"toolfs").unwrap();
+        let bundle = store
+            .put(
+                &serde_json::to_vec(&json!({
+                    "apiVersion": "celln.dev/v1alpha1", "format": "celln.static-v1",
+                    "kernel": kernel.0, "initrd": initrd.0, "toolfs": toolfs.0,
+                    "invocation": { "alias": "/tools/program", "toolHash": program.0 }
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        pin(work.path(), &bundle);
+        for hash in [&kernel, &initrd, &toolfs, &bundle] {
+            let original = store.get(hash).unwrap();
+            let hex = hash.0.strip_prefix("blake3:").unwrap();
+            let path = work.path().join("motes/objects").join(&hex[..2]).join(hex);
+            std::fs::write(&path, b"altered").unwrap();
+            let error = launch_declared(
+                &request(&bundle, &program),
+                &work.path().join("motes"),
+                &work.path().join("tools"),
+                work.path(),
+            )
+            .unwrap_err();
+            assert!(error.contains("integrity failure"), "{error}");
+            std::fs::write(path, original).unwrap();
+        }
+        assert_eq!(crate::cells::live_count(work.path()), 0);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn declared_request_cannot_use_the_host_rebuilding_launcher() {
+        let work = tempfile::tempdir().unwrap();
+        let request = request(&Hash::of(b"mote"), &Hash::of(b"program"));
+        let missing = work.path().join("unused");
+        assert!(super::super::launch(
+            &request,
+            "/tools/program",
+            &[],
+            b"program",
+            &missing,
+            &missing,
+            &missing
+        )
+        .unwrap_err()
+        .contains("pinned substrate launcher"));
+        assert!(!missing.exists());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    #[ignore = "needs real KVM, readable kernel, static pilot, and initramfs toolchain"]
+    fn declared_substrate_on_real_kvm() {
+        use std::process::Command;
+        if !Path::new("/dev/kvm").exists() {
+            eprintln!("SKIP: no KVM");
+            return;
+        }
+        let Some(kernel) = warden::vmm::boot::BootConfig::host_kernel() else {
+            eprintln!("SKIP: no readable kernel");
+            return;
+        };
+        for tool in ["gcc", "cpio", "mkfs.ext2", "debugfs", "rustc"] {
+            if Command::new("sh")
+                .args(["-c", "command -v \"$1\"", "check", tool])
+                .output()
+                .map_or(true, |o| !o.status.success())
+            {
+                eprintln!("SKIP: missing {tool}");
+                return;
+            }
+        }
+        let work = tempfile::tempdir().unwrap();
+        let Some(runtime) = super::super::tests::test_runtime_root(work.path()) else {
+            return;
+        };
+        let program = work.path().join("program");
+        let source =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/dispatch_outcome_probe.rs");
+        let build = Command::new("rustc")
+            .args(["--edition=2021", "--target", "x86_64-unknown-linux-musl"])
+            .arg(&source)
+            .arg("-o")
+            .arg(&program)
+            .output()
+            .unwrap();
+        assert!(
+            build.status.success(),
+            "{}",
+            String::from_utf8_lossy(&build.stderr)
+        );
+        let program_bytes = std::fs::read(&program).unwrap();
+        let assay_root = work.path().join("assay");
+        let mut assayer = assay::Assayer::open(&assay_root).unwrap();
+        let program_hash = assayer
+            .admit_verified_authored(
+                "/tools/program",
+                &program_bytes,
+                false,
+                celln_manifest::Author::Agent,
+            )
+            .unwrap();
+        let toolfs = work.path().join("toolfs");
+        crate::agent::sh(
+            &runtime,
+            "scripts/mktoolfs.sh",
+            &[
+                toolfs.display().to_string(),
+                "32".into(),
+                program.display().to_string(),
+            ],
+        )
+        .unwrap();
+        let initrd = work.path().join("initrd");
+        crate::agent::sh_env(
+            &runtime,
+            "scripts/mkinitramfs.sh",
+            &[initrd.display().to_string()],
+            &[
+                (
+                    "CELLN_MANIFEST",
+                    assay_root.join("manifest.json").display().to_string(),
+                ),
+                (
+                    "CELLN_PILOT_DIR",
+                    runtime.join("pilot").display().to_string(),
+                ),
+            ],
+        )
+        .unwrap();
+        let mut base = std::fs::read(&initrd).unwrap();
+        base.extend(file_archive("substrate-marker", b"selected-substrate-A\n"));
+        let motes = work.path().join("motes");
+        let tools = work.path().join("tools");
+        let store = Store::open(&motes).unwrap();
+        Store::open(&tools).unwrap().put(&program_bytes).unwrap();
+        let kernel_hash = store.put(&std::fs::read(kernel).unwrap()).unwrap();
+        let initrd_hash = store.put(&base).unwrap();
+        let toolfs_hash = store.put(&std::fs::read(toolfs).unwrap()).unwrap();
+        let mut bundle = json!({
+            "apiVersion": "celln.dev/v1alpha1", "format": "celln.static-v1",
+            "kernel": kernel_hash.0, "initrd": initrd_hash.0, "toolfs": toolfs_hash.0,
+            "invocation": { "alias": "/tools/program", "toolHash": program_hash.0 }
+        });
+        let bundle_hash = store.put(&serde_json::to_vec(&bundle).unwrap()).unwrap();
+        let state = work.path().join("state");
+        pin(&state, &bundle_hash);
+        let (outcome, resolved) = launch_declared(
+            &request(&bundle_hash, &program_hash),
+            &motes,
+            &tools,
+            &state,
+        )
+        .unwrap();
+        assert!(outcome.succeeded(), "{outcome:?}");
+        assert_eq!(
+            outcome.output.as_deref(),
+            Some(b"selected-substrate-A\n".as_slice())
+        );
+        assert_eq!(resolved.initrd_hash, initrd_hash.0);
+        assert_eq!(crate::cells::live_count(&state), 0);
+        eprintln!("PASS: declared initrd marker and exact sealed tool execute");
+
+        // A pinned bundle whose selected tool hash differs from the sealed
+        // file must refuse in pilot, even if that actual file is manifest-admitted.
+        let different = Store::open(&tools)
+            .unwrap()
+            .put(b"different program")
+            .unwrap();
+        bundle["invocation"]["toolHash"] = json!(different.0);
+        let mismatch = store.put(&serde_json::to_vec(&bundle).unwrap()).unwrap();
+        pin(&state, &mismatch);
+        let (outcome, _) =
+            launch_declared(&request(&mismatch, &different), &motes, &tools, &state).unwrap();
+        assert_eq!(
+            outcome.denial.as_deref(),
+            Some("declared program hash mismatch")
+        );
+        assert!(outcome.output.as_ref().map_or(true, Vec::is_empty));
+        assert_eq!(crate::cells::live_count(&state), 0);
+        eprintln!("PASS: declared tool mismatch refused by actual guest");
+
+        // Invalid requested kernel bytes must reach the loader, never fall
+        // back to a readable host kernel.
+        bundle["kernel"] = json!(store.put(b"invalid kernel").unwrap().0);
+        let invalid = store.put(&serde_json::to_vec(&bundle).unwrap()).unwrap();
+        pin(&state, &invalid);
+        assert!(
+            launch_declared(&request(&invalid, &different), &motes, &tools, &state)
+                .unwrap_err()
+                .contains("kernel")
+        );
+        assert_eq!(crate::cells::live_count(&state), 0);
+        eprintln!("PASS: invalid declared kernel never falls back to host");
+    }
+}

--- a/crates/celln-cli/tests/fixtures/dispatch_outcome_probe.rs
+++ b/crates/celln-cli/tests/fixtures/dispatch_outcome_probe.rs
@@ -8,6 +8,7 @@ unsafe extern "C" {
 fn main() {
     match std::env::args().nth(1).as_deref() {
         Some("silent") => {}
+        Some("substrate") => print!("{}", std::fs::read_to_string("/substrate-marker").unwrap()),
         Some("failed") => {
             println!("failure detail");
             std::process::exit(7);

--- a/crates/celln-pilot/src/dispatch_report.rs
+++ b/crates/celln-pilot/src/dispatch_report.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 pub const PREFIX: &str = "CELLN:dispatch=";
-pub const PROTOCOL: &str = "CELLN:dispatch-protocol=1";
+pub const PROTOCOL: &str = "CELLN:dispatch-protocol=2";
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]

--- a/crates/celln-pilot/src/guest.rs
+++ b/crates/celln-pilot/src/guest.rs
@@ -551,6 +551,9 @@ struct RunRequest {
     /// The host may request less authority than the manifest permits.
     #[serde(default)]
     force_agent_lane: bool,
+    /// Bind the selected sealed file to the host's declared content identity.
+    #[serde(default)]
+    expected_hash: Option<String>,
 }
 
 /// One cell can be asked to run several tools. Each invocation is hash-checked
@@ -577,6 +580,8 @@ struct RunFile {
     report_output_limit: Option<usize>,
     #[serde(default)]
     force_agent_lane: bool,
+    #[serde(default)]
+    expected_hash: Option<String>,
 }
 
 impl RunFile {
@@ -603,6 +608,7 @@ impl RunFile {
                 allow_fetch: self.allow_fetch,
                 report_output_limit: self.report_output_limit,
                 force_agent_lane: self.force_agent_lane,
+                expected_hash: self.expected_hash,
             }],
             _ => Vec::new(),
         }
@@ -999,6 +1005,20 @@ fn run_one(manifest: &Manifest, req: &RunRequest) {
         return;
     };
 
+    if req
+        .expected_hash
+        .as_deref()
+        .is_some_and(|expected| expected != hash.0)
+    {
+        report(&format!("pilot_run_{}", req.alias), "hash-mismatch");
+        if req.report_output_limit.is_some() {
+            emit(Frame::Failed {
+                reason: "declared program hash mismatch".into(),
+            });
+        }
+        return;
+    }
+
     // Anything the agent wrote demotes this invocation, per the laundering ban.
     let input = if req.agent_authored_input {
         Input::File(Lane::Data)
@@ -1120,6 +1140,7 @@ mod tests {
             allow_fetch: false,
             report_output_limit: None,
             force_agent_lane: false,
+            expected_hash: None,
         };
         let status = exec_open_file(&verified, &request, false).expect("executes verified fd");
         assert!(

--- a/docs/DECLARED_SUBSTRATES.md
+++ b/docs/DECLARED_SUBSTRATES.md
@@ -1,0 +1,88 @@
+# Declared static substrates
+
+Declared dispatch consumes the exact hash-verified kernel, base initrd and tool
+filesystem referenced by a bundle. It never chooses a host kernel or rebuilds
+those artifacts. Forge dispatch remains a separate host-prepared path and does
+not claim a declared mote identity.
+
+## Trust root
+
+The node operator provisions `trusted-motes.json` under the dispatcher's state
+root, outside the content store and request body:
+
+```json
+{
+  "apiVersion": "celln.dev/v1alpha1",
+  "bundles": ["blake3:<64 hexadecimal characters>"]
+}
+```
+
+No policy, malformed policy, or an unlisted bundle refuses. Provision this file
+and its parent directory with write access restricted to the trusted operator
+and daemon account. Obtain approved bundle hashes through the operator's
+authenticated release channel; do not approve a hash merely because a caller
+submitted it or the object store contains it. Removing a pin prevents future
+launches; it is not fleet or in-flight revocation.
+
+This is explicit local digest-pinned admission. It authenticates the entire
+bundle transitively through the operator's trusted configuration, not through
+publisher signatures. `sign_standin` is a recomputable consistency checksum,
+not a signature. An embedded manifest inherits this bundle approval; it must
+not be promoted to independent publisher authentication. The same policy model
+must govern future closure admission; closure loading remains unsupported.
+
+## Bundle format
+
+```json
+{
+  "apiVersion": "celln.dev/v1alpha1",
+  "format": "celln.static-v1",
+  "kernel": "blake3:<kernel hash>",
+  "initrd": "blake3:<base initrd hash>",
+  "toolfs": "blake3:<tool filesystem hash>",
+  "invocation": {
+    "alias": "/tools/program",
+    "toolHash": "blake3:<static executable hash>"
+  }
+}
+```
+
+The descriptor and its three substrate objects live in the mote store; the
+static executable also lives in the tool store. Hashes are of the exact bytes.
+The tool filesystem exposes the executable at `/tools/program` in the guest,
+regardless of the reporting alias. Pilot verifies the opened file against the
+request's expected hash before execution, then applies the embedded manifest
+and lane rules. Local revocations and agent/interpreter constraints can only
+narrow the embedded grant.
+
+The approved base initrd is an uncompressed newc archive containing init,
+pilot, pilot-fetch, the reviewed manifest, and all modules needed by the pinned
+kernel. It must provide a normal `/celln` directory and no symlink/hardlink
+trickery involving `/celln/run.json`. The operator must review these properties
+when approving the bundle, just as they review privileged init and pilot code.
+This is trusted boot code, not an untrusted filesystem ingestion format.
+
+Per-request invocation JSON is appended in a second newc archive. Only that
+fixed data path is generated: arguments, expected hash, output cap, egress bit
+and lane narrowing. No executable, module or manifest is overlaid. Kernel,
+toolfs and base-initrd identities are unchanged; the boot initrd is explicitly
+the declared base plus this invocation-data archive, not byte-identical to the
+base object alone. Future receipts should record the invocation digest too.
+
+Use pilot dispatch protocol 2, which enforces `expected_hash`. Pinning a bundle
+asserts its pilot implements that protocol and its boot code preserves the
+invocation seam. Host and pilot must be upgraded together. Legacy bundle
+descriptors can still be inspected by `resolve-file`, but cannot launch without
+this format and explicit approval. Output framing is not attestation against a
+compromised approved kernel or deliberately malicious privileged tool.
+
+## Evidence and remaining work
+
+`cargo test -p celln-cli declared_substrate_on_real_kvm -- --ignored --nocapture`
+proves a marker unique to the declared initrd, a guest refusal of a mismatched
+tool, and invalid declared kernel refusal without host fallback. Ordinary tests
+prove separate trust admission and preservation of local authority.
+
+This does not complete #13 or the epic: warm mote forks, cancellation/deadlines,
+full provenance, input providers and external integration remain outstanding.
+Declared launch still boots per request until the warm-spawn slice lands.

--- a/docs/DISPATCH_RESULTS.md
+++ b/docs/DISPATCH_RESULTS.md
@@ -66,7 +66,7 @@ not claim that all guest scratch filesystems are unwritable. Delivery and guest
 enforcement proofs remain in #3/#7; closure loading remains in #6.
 
 This completes the outcome and unsupported-input/closure refusal slices of #13.
-Declared substrate consumption/authentication, warm spawning and end-to-end
-cancellation remain separate work. In particular, bundle resolution currently
-checks artifact integrity but launch still reconstructs the substrate; it is
-not yet proof of execution of the declared mote identity.
+Declared execution now consumes an operator-pinned substrate with a separate
+invocation-data archive; see [Declared substrates](DECLARED_SUBSTRATES.md) for
+the trust root, compatibility requirements and exact artifact semantics. Warm
+spawning and end-to-end cancellation remain separate work.


### PR DESCRIPTION
## Change

Declared dispatch now boots the verified kernel, base initrd and sealed toolfs bytes from the requested bundle. It no longer reconstructs artifacts or chooses a host kernel. The old rebuilding launcher refuses declared requests.

Admission requires an explicit host-owned `trusted-motes.json` allowlist of approved bundle hashes and the `celln.static-v1` format. This is operator-authenticated digest pinning, not publisher signature verification: the existing stand-in signatures are not treated as authentication. See `docs/DECLARED_SUBSTRATES.md` for the trust boundary and provisioning contract.

Per-request invocation data is appended as a separate newc archive at a fixed path. No executable, module or manifest is overlaid. Pilot protocol 2 verifies the opened executable against the declared hash; local revocation and agent/interpreter constraints cannot be promoted away by the bundle. Install matching host and pilot assets and explicitly approve reviewed bundles.

## Validation

- `make ci` passed.
- Real-KVM declared proof: guest reads a marker unique to the chosen initrd; mismatched tool hash is refused by pilot; invalid declared kernel cannot fall back to the host kernel.
- The existing nine-case real-KVM outcome suite passes with protocol 2.
- Ordinary tests cover absent/invalid/unapproved trust policy, corruption of every substrate object and bundle, local authority preservation, and refusal through the old rebuilding launcher.
- New guest proof wired into hardware CI. The old smoke test that used placeholder substrate bytes is replaced by this actual artifact-consumption proof.

Stacked on #57. Refs #13, #6, #10, #12, #2. Do not close the epic: warm mote forks, cancellation/deadlines, input delivery, expanded provenance and integration acceptance remain. Forge remains host-prepared with no declared mote identity. Boot initrd identity is explicitly the pinned base plus invocation data, not the base alone. This is not attestation against malicious operator-approved boot code.
