### PR TITLE
fix(dispatch): fork executions from prepared warm motes

### DIFF
--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -13,6 +13,9 @@ use std::path::Path;
 #[path = "dispatch_substrate.rs"]
 mod substrate;
 pub(crate) use substrate::launch_declared;
+#[cfg(target_os = "linux")]
+#[path = "dispatch_warm.rs"]
+mod warm;
 
 /// The serializable substrate descriptor stored under `ExecutionRequest.mote`.
 /// Each referenced object is resolved by content hash before the VMM is given
@@ -370,7 +373,8 @@ pub fn launch(
                 "CELLN_MANIFEST",
                 assay_root.join("manifest.json").display().to_string(),
             ),
-            ("CELLN_RUN_JSON", run_json.display().to_string()),
+            ("CELLN_WARM_DISPATCH", "1".into()),
+            ("CELLN_RUN_JSON", String::new()),
             (
                 "CELLN_PILOT_DIR",
                 runtime_root.join("pilot").display().to_string(),
@@ -385,7 +389,8 @@ pub fn launch(
     let cfg = BootConfig::new(&kernel)
         .with_pmem(payload.len())
         .with_initrd(&initrd);
-    run_prepared(request, alias, cfg, payload, state_root)
+    let invocation = std::fs::read(run_json).map_err(|e| e.to_string())?;
+    run_prepared(request, alias, cfg, payload, &invocation, state_root)
 }
 
 #[cfg(target_os = "linux")]
@@ -394,13 +399,38 @@ fn run_prepared(
     alias: &str,
     mut cfg: warden::vmm::boot::BootConfig,
     payload: Vec<u8>,
+    invocation: &[u8],
     state_root: &Path,
 ) -> Result<LaunchOutcome, String> {
-    use warden::vmm::boot::LinuxCell;
     if request.capabilities.memory_bytes > 0 {
         cfg.mem_size = request.capabilities.memory_bytes as usize;
     }
     cfg.timeout = std::time::Duration::from_millis(request.capabilities.timeout_ms.max(1));
+
+    let kernel_hash = Hash::of(&std::fs::read(&cfg.kernel).map_err(|e| e.to_string())?);
+    let initrd_hash = Hash::of(
+        &std::fs::read(cfg.initrd.as_ref().ok_or("initrd required")?).map_err(|e| e.to_string())?,
+    );
+    let key = format!(
+        "forge:{kernel_hash}:{initrd_hash}:{}:{}",
+        Hash::of(&payload),
+        cfg.mem_size
+    );
+    let mut cell = warm::fork(key, || Ok((cfg, payload)))?;
+    cell.set_invocation(invocation).map_err(|e| e.to_string())?;
+    run_cell(request, alias, cell, state_root)
+}
+
+#[cfg(target_os = "linux")]
+fn run_cell(
+    request: &ExecutionRequest,
+    alias: &str,
+    mut cell: warden::vmm::boot::LinuxCell,
+    state_root: &Path,
+) -> Result<LaunchOutcome, String> {
+    cell.set_timeout(std::time::Duration::from_millis(
+        request.capabilities.timeout_ms.max(1),
+    ));
 
     let name = truncate_for_description(&request.workload.id);
     let mut record = crate::cells::begin(
@@ -415,15 +445,6 @@ fn run_prepared(
         .map(|record| record.id.clone())
         .unwrap_or_default();
 
-    let mut cell = match LinuxCell::boot(cfg) {
-        Ok(cell) => cell,
-        Err(error) => {
-            if let Some(record) = record.as_mut() {
-                crate::cells::finish(state_root, record, "kvm", Some(error.to_string()));
-            }
-            return Err(error.to_string());
-        }
-    };
     if !request.capabilities.egress.is_empty() {
         let hosts: Vec<String> = request
             .capabilities
@@ -434,14 +455,6 @@ fn run_prepared(
             .collect();
         cell.enable_http_fetch(warden::egress::HttpPolicy::new(hosts));
     }
-    let toolfs_hash = Hash::of(&payload);
-    if let Err(error) = cell.seal_tool(&toolfs_hash, &payload) {
-        if let Some(record) = record.as_mut() {
-            crate::cells::finish(state_root, record, "kvm", Some(error.to_string()));
-        }
-        return Err(error.to_string());
-    }
-
     let report = match cell.run() {
         Ok(report) => report,
         Err(error) => {
@@ -684,6 +697,7 @@ mod tests {
     #[ignore = "requires KVM, guest kernel, musl and built pilot binaries"]
     #[cfg(target_os = "linux")]
     fn dispatch_outcomes_on_real_kvm() {
+        let _proof = super::warm::PROOF_LOCK.lock().unwrap();
         use std::process::Command;
         if !Path::new("/dev/kvm").exists() || warden::vmm::boot::BootConfig::host_kernel().is_none()
         {

--- a/crates/celln-cli/src/dispatch_substrate.rs
+++ b/crates/celln-cli/src/dispatch_substrate.rs
@@ -95,8 +95,8 @@ pub(crate) fn launch_declared(
     authorize(request, state_root)?;
     let resolved = super::resolve_bundle(request, mote_root, tool_root)?;
     let local_agent = local_agent_constraint(&resolved.program_hash, state_root)?;
-    if resolved.format.as_deref() != Some("celln.static-v1") {
-        return Err("unsupported declared mote format; expected celln.static-v1".into());
+    if resolved.format.as_deref() != Some("celln.warm-static-v1") {
+        return Err("unsupported declared mote format; expected celln.warm-static-v1".into());
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -111,7 +111,7 @@ pub(crate) fn launch_declared(
         let kernel = work.path().join("kernel");
         let initrd = work.path().join("initrd");
         if !resolved.initrd_bytes.starts_with(b"070701") {
-            return Err("unsupported initrd: celln.static-v1 requires uncompressed newc".into());
+            return Err("unsupported initrd: warm static format requires uncompressed newc".into());
         }
         let run = serde_json::to_vec(&serde_json::json!({
             "path": "/tools/program", "alias": invocation.alias,
@@ -122,23 +122,28 @@ pub(crate) fn launch_declared(
             "report_output_limit": request.capabilities.output_bytes,
         }))
         .map_err(|e| e.to_string())?;
-        let mut initrd_bytes = resolved.initrd_bytes.clone();
-        while initrd_bytes.len() % 4 != 0 {
-            initrd_bytes.push(0);
-        }
-        initrd_bytes.extend(file_archive("celln/run.json", &run));
-        std::fs::write(&kernel, &resolved.kernel_bytes).map_err(|e| e.to_string())?;
-        std::fs::write(&initrd, &initrd_bytes).map_err(|e| e.to_string())?;
-        let cfg = warden::vmm::boot::BootConfig::new(kernel)
-            .with_initrd(initrd)
-            .with_pmem(resolved.toolfs_bytes.len());
-        let outcome = super::run_prepared(
-            request,
-            &invocation.alias,
-            cfg,
-            resolved.toolfs_bytes.clone(),
-            state_root,
-        )?;
+        let key = format!(
+            "{}:{}",
+            resolved.bundle_hash, request.capabilities.memory_bytes
+        );
+        let mut cell = super::warm::fork(key, || {
+            // The shared template contains no request args, credentials or
+            // egress grant. Only enable the post-fork invocation channel.
+            let mut initrd_bytes = resolved.initrd_bytes.clone();
+            while initrd_bytes.len() % 4 != 0 {
+                initrd_bytes.push(0);
+            }
+            initrd_bytes.extend(file_archive("celln/dispatch-warm", b"pio-v1\n"));
+            std::fs::write(&kernel, &resolved.kernel_bytes).map_err(|e| e.to_string())?;
+            std::fs::write(&initrd, &initrd_bytes).map_err(|e| e.to_string())?;
+            let mut cfg = warden::vmm::boot::BootConfig::new(kernel)
+                .with_initrd(initrd)
+                .with_pmem(resolved.toolfs_bytes.len());
+            cfg.mem_size = request.capabilities.memory_bytes as usize;
+            Ok((cfg, resolved.toolfs_bytes.clone()))
+        })?;
+        cell.set_invocation(&run).map_err(|e| e.to_string())?;
+        let outcome = super::run_cell(request, &invocation.alias, cell, state_root)?;
         Ok((outcome, resolved))
     }
 }
@@ -227,7 +232,7 @@ mod tests {
         let bundle = store
             .put(
                 &serde_json::to_vec(&json!({
-                    "apiVersion": "celln.dev/v1alpha1", "format": "celln.static-v1",
+                    "apiVersion": "celln.dev/v1alpha1", "format": "celln.warm-static-v1",
                     "kernel": kernel.0, "initrd": initrd.0, "toolfs": toolfs.0,
                     "invocation": { "alias": "/tools/program", "toolHash": program.0 }
                 }))
@@ -277,6 +282,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[ignore = "needs real KVM, readable kernel, static pilot, and initramfs toolchain"]
     fn declared_substrate_on_real_kvm() {
+        let _proof = super::super::warm::PROOF_LOCK.lock().unwrap();
         use std::process::Command;
         if !Path::new("/dev/kvm").exists() {
             eprintln!("SKIP: no KVM");
@@ -364,13 +370,16 @@ mod tests {
         let initrd_hash = store.put(&base).unwrap();
         let toolfs_hash = store.put(&std::fs::read(toolfs).unwrap()).unwrap();
         let mut bundle = json!({
-            "apiVersion": "celln.dev/v1alpha1", "format": "celln.static-v1",
+            "apiVersion": "celln.dev/v1alpha1", "format": "celln.warm-static-v1",
             "kernel": kernel_hash.0, "initrd": initrd_hash.0, "toolfs": toolfs_hash.0,
             "invocation": { "alias": "/tools/program", "toolHash": program_hash.0 }
         });
         let bundle_hash = store.put(&serde_json::to_vec(&bundle).unwrap()).unwrap();
         let state = work.path().join("state");
         pin(&state, &bundle_hash);
+        let preparations =
+            super::super::warm::PREPARATIONS.load(std::sync::atomic::Ordering::SeqCst);
+        let cold_started = std::time::Instant::now();
         let (outcome, resolved) = launch_declared(
             &request(&bundle_hash, &program_hash),
             &motes,
@@ -386,6 +395,23 @@ mod tests {
         assert_eq!(resolved.initrd_hash, initrd_hash.0);
         assert_eq!(crate::cells::live_count(&state), 0);
         eprintln!("PASS: declared initrd marker and exact sealed tool execute");
+        let cold_elapsed = cold_started.elapsed();
+        for arg in ["first", "second"] {
+            let mut req = request(&bundle_hash, &program_hash);
+            req.invocation.as_mut().unwrap().args = vec!["warm".into(), arg.into()];
+            let started = std::time::Instant::now();
+            let (outcome, _) = launch_declared(&req, &motes, &tools, &state).unwrap();
+            assert!(outcome.succeeded(), "{outcome:?}");
+            assert_eq!(
+                outcome.output.as_deref(),
+                Some(format!("warm:{arg}\n").as_bytes())
+            );
+            assert_eq!(
+                super::super::warm::PREPARATIONS.load(std::sync::atomic::Ordering::SeqCst),
+                preparations + 1
+            );
+            eprintln!("PASS: warm {arg}, private scratch, distinct args; cold={cold_elapsed:?}, warm={:?}", started.elapsed());
+        }
 
         // A pinned bundle whose selected tool hash differs from the sealed
         // file must refuse in pilot, even if that actual file is manifest-admitted.

--- a/crates/celln-cli/src/dispatch_warm.rs
+++ b/crates/celln-cli/src/dispatch_warm.rs
@@ -1,0 +1,49 @@
+//! A bounded cache of prepared, authority-free motes. Preparation may boot;
+//! every execution, including the first, forks the parked template.
+
+use std::sync::{Arc, Mutex, OnceLock};
+use warden::vmm::boot::{BootConfig, BootEnd, LinuxCell, Mote};
+
+// One retained template bounds idle RAM to one configured guest. In-flight
+// forks keep their own references; aggregate node accounting belongs to #5.
+type Cached = Option<(String, Arc<Mote>)>;
+static CACHE: OnceLock<Mutex<Cached>> = OnceLock::new();
+#[cfg(test)]
+pub(super) static PREPARATIONS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+#[cfg(test)]
+pub(super) static PROOF_LOCK: Mutex<()> = Mutex::new(());
+
+pub(super) fn fork(
+    key: String,
+    prepare: impl FnOnce() -> Result<(BootConfig, Vec<u8>), String>,
+) -> Result<LinuxCell, String> {
+    let mote = {
+        let mut cache = CACHE
+            .get_or_init(|| Mutex::new(None))
+            .lock()
+            .map_err(|_| "warm mote cache poisoned".to_owned())?;
+        if let Some((_, mote)) = cache.as_ref().filter(|(k, _)| k == &key) {
+            Arc::clone(mote)
+        } else {
+            let (cfg, payload) = prepare()?;
+            let mut template = LinuxCell::boot(cfg).map_err(|e| e.to_string())?;
+            template
+                .seal_tool(&celln_manifest::Hash::of(&payload), &payload)
+                .map_err(|e| e.to_string())?;
+            template.stop_when_guest_prints("CELLN:mote=parked");
+            let report = template.run().map_err(|e| e.to_string())?;
+            if report.end != BootEnd::Parked {
+                return Err("substrate did not reach the warm mote park point".into());
+            }
+            let mote = Arc::new(template.park().map_err(|e| e.to_string())?);
+            #[cfg(test)]
+            PREPARATIONS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            // Drop the only shared writable RAM mapping before publishing.
+            drop(template);
+            *cache = Some((key, Arc::clone(&mote)));
+            mote
+        }
+    };
+    LinuxCell::fork_from(&mote).map_err(|e| e.to_string())
+}

--- a/crates/celln-cli/tests/fixtures/dispatch_outcome_probe.rs
+++ b/crates/celln-cli/tests/fixtures/dispatch_outcome_probe.rs
@@ -3,12 +3,30 @@ use std::io::{self, Write};
 unsafe extern "C" {
     fn unshare(flags: i32) -> i32;
     fn write(fd: i32, buf: *const u8, count: usize) -> isize;
+    fn fork() -> i32;
+    fn waitpid(pid: i32, status: *mut i32, options: i32) -> i32;
 }
 
 fn main() {
     match std::env::args().nth(1).as_deref() {
         Some("silent") => {}
         Some("substrate") => print!("{}", std::fs::read_to_string("/substrate-marker").unwrap()),
+        Some("warm") => {
+            // Try the supervisor-only PIO port after exec: it must fault,
+            // proving pilot revoked the I/O bitmap grant before the workload.
+            let child = unsafe { fork() };
+            assert!(child >= 0);
+            if child == 0 {
+                unsafe { std::arch::asm!("in al, dx", in("dx") 0x510u16, out("al") _, options(nomem, nostack)); }
+                std::process::exit(0);
+            }
+            let mut status = 0;
+            assert_eq!(unsafe { waitpid(child, &mut status, 0) }, child);
+            assert_eq!(status & 127, 11, "workload inherited invocation port");
+            assert!(!std::path::Path::new("/celln/work/prior-cell").exists());
+            std::fs::write("/celln/work/prior-cell", b"private cell state").unwrap();
+            println!("warm:{}", std::env::args().nth(2).unwrap());
+        }
         Some("failed") => {
             println!("failure detail");
             std::process::exit(7);

--- a/crates/celln-pilot/src/dispatch_report.rs
+++ b/crates/celln-pilot/src/dispatch_report.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 pub const PREFIX: &str = "CELLN:dispatch=";
-pub const PROTOCOL: &str = "CELLN:dispatch-protocol=2";
+pub const PROTOCOL: &str = "CELLN:dispatch-protocol=3";
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]

--- a/crates/celln-pilot/src/guest.rs
+++ b/crates/celln-pilot/src/guest.rs
@@ -953,7 +953,19 @@ fn main() {
 /// the manifest. A tool swapped after attestation hashes differently and never
 /// runs, which is the only reason a filesystem is safe to exec out of at all.
 fn run_requested(manifest: &Manifest) {
-    let Ok(bytes) = std::fs::read(RUN_REQUEST) else {
+    let bytes = if std::path::Path::new("/celln/dispatch-warm").exists() {
+        match warm_invocation() {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                emit(Frame::Failed {
+                    reason: "warm invocation unavailable".into(),
+                });
+                return;
+            }
+        }
+    } else if let Ok(bytes) = std::fs::read(RUN_REQUEST) {
+        bytes
+    } else {
         return; // nothing asked of this cell
     };
     let file: RunFile = match serde_json::from_slice(&bytes) {
@@ -984,6 +996,36 @@ fn run_requested(manifest: &Manifest) {
         }
         run_one(manifest, &req);
     }
+}
+
+/// One-shot host data, not executable authority. The I/O permission is revoked
+/// before parsing or executing, including on invalid lengths.
+fn warm_invocation() -> io::Result<Vec<u8>> {
+    const PORT: u16 = 0x510; // warden::vmm::boot invocation port
+    unsafe fn read_byte() -> u8 {
+        let byte: u8;
+        std::arch::asm!("in al, dx", in("dx") PORT, out("al") byte,
+            options(nomem, nostack, preserves_flags));
+        byte
+    }
+    if unsafe { libc::ioperm(PORT as libc::c_ulong, 1, 1) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let len = u32::from_le_bytes(unsafe { [read_byte(), read_byte(), read_byte(), read_byte()] })
+        as usize;
+    let result = if (1..=65536).contains(&len) {
+        Ok((0..len).map(|_| unsafe { read_byte() }).collect())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid invocation length",
+        ))
+    };
+    if unsafe { libc::ioperm(PORT as libc::c_ulong, 1, 0) } != 0 {
+        // Never continue if a workload could inherit the supervisor's grant.
+        finish(1);
+    }
+    result
 }
 
 fn run_one(manifest: &Manifest, req: &RunRequest) {

--- a/crates/celln-warden/src/vmm/boot.rs
+++ b/crates/celln-warden/src/vmm/boot.rs
@@ -728,6 +728,7 @@ const SNAPSHOT_MSRS: &[u32] = &[
     0x0000_0176, // IA32_SYSENTER_EIP
     0x0000_0010, // IA32_TSC
     0x0000_01a0, // IA32_MISC_ENABLE
+    0x0000_0da0, // IA32_XSS: supervisor XSAVE components used by XRSTORS
     0xc000_0080, // EFER
     0xc000_0081, // STAR
     0xc000_0082, // LSTAR
@@ -772,7 +773,8 @@ pub struct Mote {
     cpuid: kvm_bindings::CpuId,
     regs: kvm_bindings::kvm_regs,
     sregs: kvm_bindings::kvm_sregs,
-    fpu: kvm_bindings::kvm_fpu,
+    xsave: kvm_bindings::Xsave,
+    xsave_size: usize,
     xcrs: kvm_bindings::kvm_xcrs,
     lapic: kvm_bindings::kvm_lapic_state,
     events: kvm_bindings::kvm_vcpu_events,
@@ -826,6 +828,8 @@ pub struct LinuxCell {
     http: Option<HttpBroker>,
     fetch_request: Vec<u8>,
     fetch_response: VecDeque<u8>,
+    /// Per-cell, one-shot invocation data. Never captured in a mote.
+    invocation: Option<VecDeque<u8>>,
     /// The PCI configuration address latch (port 0xcf8).
     ///
     /// We emulate no PCI devices, but the kernel must still *detect* a type-1
@@ -969,6 +973,7 @@ impl LinuxCell {
             http: None,
             fetch_request: Vec::new(),
             fetch_response: VecDeque::new(),
+            invocation: None,
             pci_cf8: 0,
             revoke_trigger: None,
             stop_marker: None,
@@ -1019,6 +1024,24 @@ impl LinuxCell {
         self.http = Some(HttpBroker::new(policy));
     }
 
+    /// Deliver bounded data to pilot after a warm fork. Port 0x510 returns
+    /// little-endian u32 length followed by opaque JSON bytes, once only.
+    pub fn set_invocation(&mut self, bytes: &[u8]) -> Result<(), VmmError> {
+        if bytes.is_empty() || bytes.len() > 65536 || self.invocation.is_some() {
+            return Err(VmmError::Backend(
+                "invalid or repeated invocation delivery".into(),
+            ));
+        }
+        let mut data: VecDeque<u8> = (bytes.len() as u32).to_le_bytes().into();
+        data.extend(bytes);
+        self.invocation = Some(data);
+        Ok(())
+    }
+
+    pub fn set_timeout(&mut self, timeout: Duration) {
+        self.cfg.timeout = timeout;
+    }
+
     fn dispatch_fetch(&mut self) {
         let request = std::str::from_utf8(&self.fetch_request)
             .map(str::trim)
@@ -1060,7 +1083,29 @@ impl LinuxCell {
     /// Call after a run that stopped at a marker, so the vCPU is at an
     /// instruction boundary with no I/O completion outstanding.
     pub fn park(&self) -> Result<Mote, VmmError> {
+        if self.invocation.is_some() || self.http.is_some() {
+            return Err(VmmError::Backend(
+                "cannot park per-cell invocation or egress authority".into(),
+            ));
+        }
         let vcpu = &self.vcpu;
+        // KVM_GET_FPU is only the legacy subset. A real resumed Linux pilot
+        // needs extended XSAVE state and IA32_XSS as well. Allocate according
+        // to the VM capability, never the fixed 4096-byte legacy ioctl buffer.
+        // https://docs.kernel.org/virt/kvm/api.html#kvm-get-xsave2
+        let xsave_size = self.vm.check_extension_int(kvm_ioctls::Cap::Xsave2);
+        let base = std::mem::size_of::<kvm_bindings::kvm_xsave>();
+        if xsave_size < base as i32 {
+            return Err(VmmError::Unsupported(
+                "warm snapshots require KVM_CAP_XSAVE2".into(),
+            ));
+        }
+        let xsave_size = xsave_size as usize;
+        let mut xsave = kvm_bindings::Xsave::new((xsave_size - base).div_ceil(4))
+            .map_err(|e| VmmError::Backend(format!("allocating XSAVE: {e:?}")))?;
+        // SAFETY: buffer includes exactly the VM-reported extended area;
+        // this runtime never dynamically enables new host XSTATE features.
+        unsafe { vcpu.get_xsave2(&mut xsave) }.map_err(|e| kvm_err("get_xsave2", e))?;
         let ram = self
             ._mem
             .fd
@@ -1111,7 +1156,8 @@ impl LinuxCell {
             cpuid: self.cpuid.clone(),
             regs: vcpu.get_regs().map_err(|e| kvm_err("get_regs", e))?,
             sregs: vcpu.get_sregs().map_err(|e| kvm_err("get_sregs", e))?,
-            fpu: vcpu.get_fpu().map_err(|e| kvm_err("get_fpu", e))?,
+            xsave,
+            xsave_size,
             xcrs: vcpu.get_xcrs().map_err(|e| kvm_err("get_xcrs", e))?,
             lapic: vcpu.get_lapic().map_err(|e| kvm_err("get_lapic", e))?,
             events: vcpu
@@ -1231,15 +1277,26 @@ impl LinuxCell {
                 ..Default::default()
             };
             if let Ok(buf) = kvm_bindings::Msrs::from_entries(&[entry]) {
-                let _ = vcpu.set_msrs(&buf); // best effort, per MSR
+                if vcpu.set_msrs(&buf).map_err(|e| kvm_err("set_msrs", e))? != 1 {
+                    return Err(VmmError::Unsupported(format!(
+                        "cannot restore MSR {index:#x}"
+                    )));
+                }
             }
         }
         vcpu.set_sregs(&mote.sregs)
             .map_err(|e| kvm_err("set_sregs", e))?;
         vcpu.set_regs(&mote.regs)
             .map_err(|e| kvm_err("set_regs", e))?;
-        vcpu.set_fpu(&mote.fpu).map_err(|e| kvm_err("set_fpu", e))?;
-        let _ = vcpu.set_xcrs(&mote.xcrs);
+        vcpu.set_xcrs(&mote.xcrs)
+            .map_err(|e| kvm_err("set_xcrs", e))?;
+        if vm.check_extension_int(kvm_ioctls::Cap::Xsave2) != mote.xsave_size as i32 {
+            return Err(VmmError::Unsupported(
+                "XSAVE size changed since preparation".into(),
+            ));
+        }
+        // SAFETY: checked against this VM's required buffer size above.
+        unsafe { vcpu.set_xsave2(&mote.xsave) }.map_err(|e| kvm_err("set_xsave2", e))?;
         vcpu.set_lapic(&mote.lapic)
             .map_err(|e| kvm_err("set_lapic", e))?;
         vcpu.set_vcpu_events(&mote.events)
@@ -1263,6 +1320,7 @@ impl LinuxCell {
                 http: None,
                 fetch_request: Vec::new(),
                 fetch_response: VecDeque::new(),
+                invocation: None,
                 pci_cf8: 0,
                 revoke_trigger: None,
                 stop_marker: None,
@@ -1414,6 +1472,14 @@ impl LinuxCell {
                                 let v = self.serial.read(port);
                                 for b in data.iter_mut() {
                                     *b = v;
+                                }
+                            } else if port == 0x510 {
+                                for b in data.iter_mut() {
+                                    *b = self
+                                        .invocation
+                                        .as_mut()
+                                        .and_then(|q| q.pop_front())
+                                        .unwrap_or(0xff);
                                 }
                             } else if port == PILOT_FETCH_RX {
                                 for b in data.iter_mut() {
@@ -1630,6 +1696,28 @@ fn set_long_mode(vcpu: &VcpuFd) -> Result<(), VmmError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn invocation_is_bounded_one_shot_and_cannot_be_parked() {
+        let Some(kernel) = kernel_or_skip() else {
+            return;
+        };
+        let mut cell = LinuxCell::boot(BootConfig::new(kernel)).unwrap();
+        assert!(cell.set_invocation(&[]).is_err());
+        assert!(cell.set_invocation(&vec![0; 65537]).is_err());
+        cell.set_invocation(b"{}").unwrap();
+        assert!(cell.set_invocation(b"replacement").is_err());
+        assert!(cell.park().is_err());
+        assert_eq!(
+            cell.invocation
+                .as_ref()
+                .unwrap()
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            b"\x02\x00\x00\x00{}"
+        );
+    }
 
     fn kernel_or_skip() -> Option<PathBuf> {
         if !Path::new("/dev/kvm").exists() {

--- a/docs/DECLARED_SUBSTRATES.md
+++ b/docs/DECLARED_SUBSTRATES.md
@@ -36,7 +36,7 @@ must govern future closure admission; closure loading remains unsupported.
 ```json
 {
   "apiVersion": "celln.dev/v1alpha1",
-  "format": "celln.static-v1",
+  "format": "celln.warm-static-v1",
   "kernel": "blake3:<kernel hash>",
   "initrd": "blake3:<base initrd hash>",
   "toolfs": "blake3:<tool filesystem hash>",
@@ -58,18 +58,22 @@ narrow the embedded grant.
 The approved base initrd is an uncompressed newc archive containing init,
 pilot, pilot-fetch, the reviewed manifest, and all modules needed by the pinned
 kernel. It must provide a normal `/celln` directory and no symlink/hardlink
-trickery involving `/celln/run.json`. The operator must review these properties
+trickery involving `/celln/dispatch-warm`. The operator must review these properties
 when approving the bundle, just as they review privileged init and pilot code.
 This is trusted boot code, not an untrusted filesystem ingestion format.
 
-Per-request invocation JSON is appended in a second newc archive. Only that
-fixed data path is generated: arguments, expected hash, output cap, egress bit
-and lane narrowing. No executable, module or manifest is overlaid. Kernel,
-toolfs and base-initrd identities are unchanged; the boot initrd is explicitly
-the declared base plus this invocation-data archive, not byte-identical to the
-base object alone. Future receipts should record the invocation digest too.
+Preparation appends a fixed `/celln/dispatch-warm` mode flag to the base initrd,
+boots once with sealed tools and no egress grant, and parks at init's
+`CELLN:mote=parked` boundary before pilot executes. Every execution forks this
+template, including the first. Per-request JSON arrives after the fork through
+PIO port `0x510`: four little-endian length bytes followed by at most 64 KiB of
+data. The stream is host-owned and one-shot. Pilot revokes the I/O bitmap grant
+before parsing or executing. No arguments, requested egress authority or output
+from one cell are snapshotted for another. No executable, module or manifest is
+overlaid. Future receipts should record the invocation digest too.
 
-Use pilot dispatch protocol 2, which enforces `expected_hash`. Pinning a bundle
+Use pilot dispatch protocol 3, which enforces `expected_hash` and implements the
+warm invocation channel. Pinning a bundle
 asserts its pilot implements that protocol and its boot code preserves the
 invocation seam. Host and pilot must be upgraded together. Legacy bundle
 descriptors can still be inspected by `resolve-file`, but cannot launch without
@@ -83,6 +87,15 @@ proves a marker unique to the declared initrd, a guest refusal of a mismatched
 tool, and invalid declared kernel refusal without host fallback. Ordinary tests
 prove separate trust admission and preservation of local authority.
 
-This does not complete #13 or the epic: warm mote forks, cancellation/deadlines,
+The process retains one warm template keyed by approved bundle hash and guest
+RAM size. Different arguments share it; a different identity evicts it. Trust
+policy, artifact integrity and local authority are rechecked even on cache hits.
+Requests still pay for hash-verified store reads, and a cache miss pays for
+preparation. Forge dispatch also prepares then forks, but its freshly generated
+substrate may miss the cache; deterministic forge substrate reuse is not claimed.
+The cache is not an aggregate memory scheduler (#5).
+
+This does not complete #13 or the epic: cancellation/deadlines,
 full provenance, input providers and external integration remain outstanding.
-Declared launch still boots per request until the warm-spawn slice lands.
+See [warm dispatch measurements](WARM_DISPATCH_MEASUREMENTS.md) for the current
+end-to-end numbers and guest isolation proof.

--- a/docs/DISPATCH_RESULTS.md
+++ b/docs/DISPATCH_RESULTS.md
@@ -66,7 +66,7 @@ not claim that all guest scratch filesystems are unwritable. Delivery and guest
 enforcement proofs remain in #3/#7; closure loading remains in #6.
 
 This completes the outcome and unsupported-input/closure refusal slices of #13.
-Declared execution now consumes an operator-pinned substrate with a separate
-invocation-data archive; see [Declared substrates](DECLARED_SUBSTRATES.md) for
-the trust root, compatibility requirements and exact artifact semantics. Warm
-spawning and end-to-end cancellation remain separate work.
+Declared execution now forks an operator-pinned warm substrate with a separate
+one-shot invocation channel; see [Declared substrates](DECLARED_SUBSTRATES.md)
+for the trust root, compatibility requirements and exact artifact semantics.
+End-to-end cancellation and deadlines remain separate work.

--- a/docs/WARM_DISPATCH_MEASUREMENTS.md
+++ b/docs/WARM_DISPATCH_MEASUREMENTS.md
@@ -1,0 +1,38 @@
+# Warm dispatch evidence — 2026-09-06
+
+Environment: Intel Core Ultra X7 358H, 16 logical CPUs; host and guest kernel
+`7.1.12-200.fc44.x86_64`; 256 MiB guest RAM, 32 MiB toolfs; local KVM.
+Source: warm-dispatch implementation following substrate revision `9a34b32`.
+
+Command:
+
+```sh
+cargo test -p celln-cli on_real_kvm -- --ignored --nocapture
+```
+
+One observed run, not a percentile distribution or a performance gate:
+
+| Execution | End-to-end time |
+| --- | ---: |
+| Cold preparation, fork and marker workload | 3.01050527 s |
+| Warm fork, first distinct argument | 102.080082 ms |
+| Warm fork, second distinct argument | 82.925468 ms |
+
+These timings include policy/store reads, hash verification, VM setup, guest
+execution, reporting and teardown. They are **not** fork-only timings and do
+not establish a sub-millisecond spawn claim. The test counts exactly one
+preparation across these three declared requests. Guest code proves distinct
+arguments, absence of the preceding cell's scratch file, and a fault when it
+tries to read the supervisor invocation port after exec. Existing outcome
+proofs also pass through the prepare/fork path.
+
+The first actual pilot resume uncovered an incomplete snapshot: restoring only
+legacy FPU registers omitted extended state and IA32_XSS, causing a guest
+XRSTORS fault. Snapshots now preserve the VM-sized XSAVE area and IA32_XSS;
+restoration errors refuse instead of continuing best-effort. XSAVE buffers are
+sized and checked according to the [KVM API](https://docs.kernel.org/virt/kvm/api.html#kvm-get-xsave2).
+Hosts without XSAVE2 support return Unsupported.
+
+Remaining work includes fleet density and aggregate cache accounting, stable
+percentile benchmarks, cancellation during preparation and an end-to-end
+deadline. No claim about those follows from these measurements.

--- a/scripts/mkinitramfs.sh
+++ b/scripts/mkinitramfs.sh
@@ -40,6 +40,9 @@ gcc -static -nostdlib -nostartfiles -ffreestanding -fno-stack-protector \
 # cannot be created without privilege, which is why init mounts devtmpfs.
 mkdir -p "$work/dev" "$work/tools" "$work/modules" "$work/proc" "$work/sys" \
          "$work/celln/tools" "$work/celln/work"
+if [ "${CELLN_WARM_DISPATCH:-0}" = 1 ]; then
+  printf 'pio-v1\n' > "$work/celln/dispatch-warm"
+fi
 # One mount point per additional sealed namespace; see mount_extra_tools().
 for i in 1 2 3 4 5 6 7; do mkdir -p "$work/tools$i"; done
 


### PR DESCRIPTION
## Change

Both declared and forge dispatch now prepare a parked mote and fork it for execution. Declared requests with the same approved bundle identity and RAM size reuse one cached template, including when their arguments differ. A cache miss performs cold preparation; execution itself always starts from a CoW fork.

Invocation data is delivered only after the fork over bounded, one-shot PIO port 0x510. Pilot revokes its I/O permission before parsing/executing. Templates cannot be parked with invocation data or a host egress grant. The cache retains one template; aggregate memory scheduling remains #5.

Real pilot resume exposed an existing snapshot bug: legacy FPU state and the prior MSR list omitted extended XSAVE state and IA32_XSS, causing an XRSTORS guest fault. Snapshot/restore now includes both, sizes XSAVE from the VM capability, and refuses failed restoration instead of continuing best-effort. Hosts without XSAVE2 are Unsupported.

## Validation

- `make ci` passed.
- Both real-KVM dispatcher suites passed: existing outcomes/refusals plus selected substrate, mismatched hash and invalid kernel checks.
- Repeated declared requests prove one preparation, distinct arguments, isolated scratch, and a guest fault when attempting the supervisor PIO port after exec.
- Host test covers invocation size, one-shot delivery and refusal to snapshot per-cell invocation authority.
- `make acceptance-kvm` passed.
- Committed measurements in `docs/WARM_DISPATCH_MEASUREMENTS.md`; end-to-end numbers, not fork-only or percentile claims.

Compatibility: requires pilot dispatch protocol 3 and an explicitly approved `celln.warm-static-v1` bundle. The base is augmented only with a fixed warm-mode flag, never per-request invocation data. Forge preparation remains host-derived and may miss the cache on each newly generated substrate.

Stacked on #58. Refs #13, #2, #5, #11, #12. Cancellation/end-to-end deadlines, aggregate accounting, full provenance, providers and external integration remain open; do not close the epic.
