### PR TITLE
feat(dispatch): cancellation and end-to-end deadlines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ version = "0.5.7"
 dependencies = [
  "anyhow",
  "celln-assay",
+ "celln-control",
  "celln-forge",
  "celln-manifest",
  "celln-pilot",
@@ -141,9 +142,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "celln-control"
+version = "0.5.7"
+dependencies = [
+ "libc",
+ "tempfile",
+]
+
+[[package]]
 name = "celln-forge"
 version = "0.5.7"
 dependencies = [
+ "celln-control",
  "celln-manifest",
  "serde",
  "thiserror",
@@ -198,10 +208,12 @@ dependencies = [
 name = "celln-warden"
 version = "0.5.7"
 dependencies = [
+ "celln-control",
  "celln-manifest",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
+ "tempfile",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/celln-control",
     "crates/celln-manifest",
     "crates/celln-spec",
     "crates/celln-cli",
@@ -20,6 +21,7 @@ repository = "https://github.com/sympozium-ai/celln"
 
 # Pinned to versions that build on Rust 1.75 (edition 2021).
 [workspace.dependencies]
+celln-control = { version = "0.5.7", path = "crates/celln-control" }
 # Inter-crate versions track `workspace.package.version` exactly, and
 # `scripts/release.sh --bump` moves them together. A pin left behind at an
 # older version is not a stale nicety: publishing a crate whose sibling has not

--- a/crates/celln-cli/Cargo.toml
+++ b/crates/celln-cli/Cargo.toml
@@ -13,6 +13,7 @@ name = "celln"
 path = "src/main.rs"
 
 [dependencies]
+celln-control.workspace = true
 celln-spec.workspace = true
 celln-manifest.workspace = true
 celln-store.workspace = true

--- a/crates/celln-cli/src/agent.rs
+++ b/crates/celln-cli/src/agent.rs
@@ -110,12 +110,8 @@ fn authenticated(has_api_key: bool, cli_status_ok: bool) -> bool {
 }
 
 fn cli_login_ok(program: &str, args: &[&str]) -> bool {
-    Command::new(program)
-        .args(args)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|status| status.success())
+    celln_control::process::output(Command::new(program).args(args))
+        .is_ok_and(|out| out.status.success())
 }
 
 impl Backend {
@@ -214,13 +210,11 @@ impl Backend {
             Backend::Local => {
                 // ollama needs the daemon running. Quick check: does `ollama list`
                 // exit successfully?
-                let out = std::process::Command::new("ollama")
-                    .args(["list"])
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .status();
+                let out = celln_control::process::output(
+                    std::process::Command::new("ollama").args(["list"]),
+                );
                 match out {
-                    Ok(s) if s.success() => Ok(()),
+                    Ok(s) if s.status.success() => Ok(()),
                     _ => Err("ollama daemon is not running — start it with `ollama serve`".into()),
                 }
             }
@@ -632,23 +626,24 @@ fn bootstrap_runtime() -> Result<PathBuf> {
     if !found {
         // Try building them from the workspace
         eprintln!("  · building pilot binaries (one-time)...");
-        let status = std::process::Command::new("cargo")
-            .args([
-                "build",
-                "--release",
-                "--target",
-                "x86_64-unknown-linux-musl",
-                "-p",
-                "celln-pilot",
-                "--bin",
-                "celln-pilot",
-                "--bin",
-                "pilot-fetch",
-            ])
-            .current_dir(workspace)
-            .status()
-            .context("building pilot binaries")?;
-        if !status.success() {
+        let output = celln_control::process::output(
+            std::process::Command::new("cargo")
+                .args([
+                    "build",
+                    "--release",
+                    "--target",
+                    "x86_64-unknown-linux-musl",
+                    "-p",
+                    "celln-pilot",
+                    "--bin",
+                    "celln-pilot",
+                    "--bin",
+                    "pilot-fetch",
+                ])
+                .current_dir(workspace),
+        )
+        .context("building pilot binaries")?;
+        if !output.status.success() {
             anyhow::bail!("cargo build of pilot binaries failed");
         }
         let dir = workspace.join("target/x86_64-unknown-linux-musl/release");
@@ -1171,6 +1166,12 @@ fn output_deadline(
     limit: Duration,
     term_first: bool,
 ) -> Result<std::process::Output> {
+    if celln_control::current().is_some() {
+        return Ok(celln_control::process::output_with_timeout(
+            &mut cmd,
+            Some(limit),
+        )?);
+    }
     let mut child = cmd
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -1462,9 +1463,7 @@ fn guest_pilot_binaries_present(dir: &Path) -> bool {
 
 /// Ask rustup, the same way `mkinitramfs.sh` does, so the two cannot disagree.
 fn musl_target_installed() -> bool {
-    Command::new("rustup")
-        .args(["target", "list", "--installed"])
-        .output()
+    celln_control::process::output(Command::new("rustup").args(["target", "list", "--installed"]))
         .is_ok_and(|o| {
             o.status.success()
                 && String::from_utf8_lossy(&o.stdout)
@@ -1488,7 +1487,8 @@ pub(crate) fn sh_env(
     for (k, v) in env {
         c.env(k, v);
     }
-    let out = c.output().with_context(|| format!("running {script}"))?;
+    let out =
+        celln_control::process::output(&mut c).with_context(|| format!("running {script}"))?;
     if !out.status.success() {
         bail!("{script}: {}", String::from_utf8_lossy(&out.stderr).trim());
     }

--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -65,6 +65,7 @@ pub struct ResolvedBundle {
 /// discard requested authority or describe requested-but-unused objects as
 /// resolved provenance. Remove each refusal only with its delivery proof.
 pub(crate) fn check_supported_authority(request: &ExecutionRequest) -> Result<(), String> {
+    celln_control::check().map_err(|e| e.to_string())?;
     if !request.inputs.is_empty() {
         return Err("unsupported authority: input delivery is not implemented".into());
     }
@@ -211,6 +212,7 @@ pub fn forge(
     timeout_secs: u64,
 ) -> Result<ForgedProgram, String> {
     use crate::agent::{ask_model, discover_backend, Backend, ALIAS, AVAILABLE_RUNTIMES, BRIEF};
+    celln_control::check().map_err(|e| e.to_string())?;
 
     let backend = match forge_request.backend.as_deref() {
         Some(name) => Backend::from_saved_name(name).ok_or_else(|| {
@@ -257,6 +259,7 @@ pub fn forge(
             Err(error) => return Err(error.to_string()),
         };
 
+    celln_control::check().map_err(|e| e.to_string())?;
     let mut assayer = assay::Assayer::open(assay_root).map_err(|error| error.to_string())?;
     let hash = assayer
         .admit_forged_authored(ALIAS, &code, false, celln_manifest::Author::Agent, &proof)
@@ -465,13 +468,16 @@ fn run_cell(
         }
     };
 
-    let outcome = parse_report(
+    let mut outcome = parse_report(
         &report.console,
         cell_id,
         request.capabilities.output_bytes as usize,
         report.end == warden::vmm::boot::BootEnd::TimedOut,
         report.end == warden::vmm::boot::BootEnd::Shutdown,
     );
+    if let Some(reason) = celln_control::current().and_then(|c| c.reason()) {
+        outcome.denial = Some(reason.to_string());
+    }
     if let Some(record) = record.as_mut() {
         crate::cells::finish(state_root, record, "kvm", outcome.denial.clone());
     }

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -91,6 +91,7 @@ fn read_headers(reader: &mut impl BufRead) -> Result<(usize, Option<String>)> {
 struct Entry<T> {
     at: Instant,
     value: T,
+    control: Option<celln_control::Control>,
 }
 
 impl<T> Entry<T> {
@@ -98,13 +99,16 @@ impl<T> Entry<T> {
         Entry {
             at: Instant::now(),
             value,
+            control: None,
         }
     }
 }
 
-fn evict_expired<T>(registry: &mut HashMap<String, Entry<T>>) {
+fn evict_expired(registry: &mut HashMap<String, Entry<ExecutionRecord>>) {
     let now = Instant::now();
-    registry.retain(|_, entry| now.duration_since(entry.at) < RECORD_TTL);
+    registry.retain(|_, entry| {
+        execution_is_active(&entry.value) || now.duration_since(entry.at) < RECORD_TTL
+    });
 }
 
 /// One `celln.dev/v1alpha1` execution in flight or finished on this node.
@@ -205,7 +209,10 @@ fn validate_listen(listen: &str, unsafe_non_loopback: bool) -> Result<(SocketAdd
 }
 
 fn execution_is_active(record: &ExecutionRecord) -> bool {
-    !matches!(record.phase.as_str(), "Succeeded" | "Failed" | "Refused")
+    !matches!(
+        record.phase.as_str(),
+        "Succeeded" | "Failed" | "Refused" | "Cancelled"
+    )
 }
 
 pub fn serve(
@@ -335,6 +342,9 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
                     &serde_json::json!({"error": "request refused", "reason": "unsupported", "detail": reason}),
                 );
             }
+            let control = celln_control::Control::new(Duration::from_millis(
+                request.capabilities.timeout_ms,
+            ))?;
             if let Err(error) = state.egress_policy.check(&request) {
                 return reply(
                     &mut stream,
@@ -393,13 +403,55 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
                     }),
                 );
             }
-            registry.insert(request.id.clone(), Entry::new(record.clone()));
+            let mut entry = Entry::new(record.clone());
+            entry.control = Some(control.clone());
+            registry.insert(request.id.clone(), entry);
             drop(registry);
             let worker_executions = Arc::clone(&state.executions);
             let probe = state.probe.clone();
             let root = state.root.clone();
-            thread::spawn(move || run_execution(request, worker_executions, probe, root));
+            thread::spawn(move || {
+                control.scope(|| {
+                    let id = request.id.clone();
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        run_execution(request, Arc::clone(&worker_executions), probe, root)
+                    }));
+                    if result.is_err() {
+                        fail_execution(
+                            &worker_executions,
+                            &id,
+                            "execution worker panicked during cleanup".into(),
+                        );
+                    }
+                })
+            });
             reply(&mut stream, 202, &record)
+        }
+        ("POST", path) if path.starts_with("/v1/executions/") && path.ends_with("/cancel") => {
+            let id = &path["/v1/executions/".len()..path.len() - "/cancel".len()];
+            let mut registry = state
+                .executions
+                .lock()
+                .expect("dispatcher registry not poisoned");
+            let Some(entry) = registry.get_mut(id) else {
+                return reply(
+                    &mut stream,
+                    404,
+                    &serde_json::json!({"error": "unknown execution"}),
+                );
+            };
+            if execution_is_active(&entry.value) {
+                if let Some(control) = &entry.control {
+                    control.cancel();
+                }
+                entry.value.phase = "Cancelling".into();
+                entry.value.reason = Some("cancellation requested; cleanup pending".into());
+                // Reservation remains live until the worker has unwound all
+                // subprocesses, VM handles and preparation state.
+                reply(&mut stream, 202, &entry.value)
+            } else {
+                reply(&mut stream, 200, &entry.value)
+            }
         }
         ("GET", path) if path.starts_with("/v1/executions/") => {
             let id = path.trim_start_matches("/v1/executions/");
@@ -427,6 +479,24 @@ fn update_execution(executions: &Executions, id: &str, f: impl FnOnce(&mut Execu
         .get_mut(id)
     {
         f(&mut entry.value);
+        if let Some(reason) = entry.control.as_ref().and_then(|c| c.reason()) {
+            if !execution_is_active(&entry.value) {
+                let phase = match reason {
+                    celln_control::Stopped::Cancelled => ExecutionPhase::Cancelled,
+                    celln_control::Stopped::Deadline => ExecutionPhase::Failed,
+                };
+                entry.value.phase = format!("{phase:?}");
+                entry.value.reason = Some(reason.to_string());
+                if let Some(receipt) = &mut entry.value.receipt {
+                    receipt.phase = phase;
+                }
+            } else if reason == celln_control::Stopped::Cancelled {
+                entry.value.phase = "Cancelling".into();
+            }
+        }
+        if !execution_is_active(&entry.value) {
+            entry.at = Instant::now();
+        }
     }
 }
 
@@ -450,6 +520,9 @@ fn run_execution(
     probe: NodeProbeArgs,
     root: PathBuf,
 ) {
+    if let Err(error) = celln_control::check() {
+        return fail_execution(&executions, &request.id, error.to_string());
+    }
     // Defense in depth: direct callers must refuse before model invocations,
     // store access or runtime preparation, not only at the HTTP boundary.
     if let Err(reason) = crate::dispatch::check_supported_authority(&request) {
@@ -471,7 +544,7 @@ fn run_execution(
         let forged = match crate::dispatch::forge(
             forge_request,
             &assay_root,
-            request.capabilities.timeout_ms / 1000,
+            request.capabilities.timeout_ms.div_ceil(1000),
         ) {
             Ok(forged) => forged,
             Err(error) => return fail_execution(&executions, &request.id, error),
@@ -604,6 +677,94 @@ fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    fn lifecycle_state(root: &Path) -> State {
+        State {
+            token: "test-token-at-least-24-bytes".into(),
+            egress_policy: EgressPolicy::new(&[]).unwrap(),
+            root: root.into(),
+            probe: NodeProbeArgs {
+                node_name: "test".into(),
+                mote_store: root.join("motes"),
+                tool_store: root.join("tools"),
+                max_cells: 1,
+                memory_bytes: 268435456,
+                egress_slots: 0,
+            },
+            executions: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn cancel_http(state: &State, id: &str, token: &str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let (server, _) = listener.accept().unwrap();
+        write!(client, "POST /v1/executions/{id}/cancel HTTP/1.1\r\nAuthorization: Bearer {token}\r\nContent-Length: 0\r\n\r\n").unwrap();
+        handle(server, state).unwrap();
+        let mut response = String::new();
+        client.read_to_string(&mut response).unwrap();
+        response
+    }
+
+    #[test]
+    fn cancellation_is_authenticated_idempotent_and_reserves_until_cleanup() {
+        let work = tempfile::tempdir().unwrap();
+        let state = lifecycle_state(work.path());
+        let control = celln_control::Control::new(Duration::from_secs(60)).unwrap();
+        let mut entry = Entry::new(empty_record("running"));
+        entry.control = Some(control.clone());
+        state
+            .executions
+            .lock()
+            .unwrap()
+            .insert("running".into(), entry);
+        assert!(cancel_http(&state, "running", "wrong").starts_with("HTTP/1.1 401"));
+        assert!(control.reason().is_none());
+        for _ in 0..2 {
+            let response = cancel_http(&state, "running", &state.token);
+            assert!(response.starts_with("HTTP/1.1 202"));
+            assert!(response.contains("Cancelling"));
+            assert!(execution_is_active(
+                &state.executions.lock().unwrap()["running"].value
+            ));
+        }
+        assert_eq!(control.reason(), Some(celln_control::Stopped::Cancelled));
+        // Worker cleanup, not the HTTP request, publishes the terminal state.
+        fail_execution(&state.executions, "running", "worker unwound".into());
+        assert!(!execution_is_active(
+            &state.executions.lock().unwrap()["running"].value
+        ));
+        let response = cancel_http(&state, "running", &state.token);
+        assert!(response.starts_with("HTTP/1.1 200"));
+        assert!(response.contains("Cancelled"));
+        assert!(cancel_http(&state, "absent", &state.token).starts_with("HTTP/1.1 404"));
+    }
+
+    #[test]
+    fn deadline_wins_a_terminal_success_race() {
+        let work = tempfile::tempdir().unwrap();
+        let state = lifecycle_state(work.path());
+        let mut entry = Entry::new(empty_record("expired"));
+        entry.control = Some(celln_control::Control::new(Duration::ZERO).unwrap());
+        state
+            .executions
+            .lock()
+            .unwrap()
+            .insert("expired".into(), entry);
+        update_execution(&state.executions, "expired", |record| {
+            record.phase = "Succeeded".into()
+        });
+        let registry = state.executions.lock().unwrap();
+        let record = &registry["expired"].value;
+        assert_eq!(record.phase, "Failed");
+        assert_eq!(
+            record.reason.as_deref(),
+            Some("execution deadline exceeded")
+        );
+    }
 
     #[test]
     fn unsupported_forge_authority_is_refused_without_side_effects() {
@@ -838,15 +999,28 @@ mod tests {
             "stale".into(),
             Entry {
                 at: Instant::now() - RECORD_TTL - Duration::from_secs(1),
-                value: empty_record("stale"),
+                value: ExecutionRecord {
+                    phase: "Succeeded".into(),
+                    ..empty_record("stale")
+                },
+                control: None,
             },
         );
         registry.insert("fresh".into(), Entry::new(empty_record("fresh")));
+        registry.insert(
+            "old-active".into(),
+            Entry {
+                at: Instant::now() - RECORD_TTL - Duration::from_secs(1),
+                value: empty_record("old-active"),
+                control: None,
+            },
+        );
 
         evict_expired(&mut registry);
 
         assert!(!registry.contains_key("stale"));
         assert!(registry.contains_key("fresh"));
+        assert!(registry.contains_key("old-active"));
     }
 
     #[test]

--- a/crates/celln-cli/src/dispatch_substrate.rs
+++ b/crates/celln-cli/src/dispatch_substrate.rs
@@ -413,6 +413,54 @@ mod tests {
             eprintln!("PASS: warm {arg}, private scratch, distinct args; cold={cold_elapsed:?}, warm={:?}", started.elapsed());
         }
 
+        // Stop a real running guest without refreshing the end-to-end timer.
+        for cancel in [false, true] {
+            let control = celln_control::Control::new(std::time::Duration::from_secs(if cancel {
+                60
+            } else {
+                1
+            }))
+            .unwrap();
+            let signal = control.clone();
+            let timer = cancel.then(|| {
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_secs(1));
+                    signal.cancel();
+                })
+            });
+            let mut req = request(&bundle_hash, &program_hash);
+            req.invocation.as_mut().unwrap().args = vec!["timeout".into()];
+            let started = std::time::Instant::now();
+            let (outcome, _) = control
+                .scope(|| launch_declared(&req, &motes, &tools, &state))
+                .unwrap();
+            if let Some(timer) = timer {
+                timer.join().unwrap();
+            }
+            assert!(outcome.timed_out && !outcome.succeeded(), "{outcome:?}");
+            assert!(String::from_utf8_lossy(outcome.output.as_deref().unwrap())
+                .contains("before timeout"));
+            assert!(started.elapsed() < std::time::Duration::from_secs(4));
+            assert_eq!(crate::cells::live_count(&state), 0);
+            assert_eq!(
+                control.reason(),
+                Some(if cancel {
+                    celln_control::Stopped::Cancelled
+                } else {
+                    celln_control::Stopped::Deadline
+                })
+            );
+            eprintln!("PASS: real guest stopped, cancel={cancel}, no live cell remains");
+        }
+        let mut cold = request(&bundle_hash, &program_hash);
+        cold.capabilities.memory_bytes = 320 << 20; // different cache key
+        let control = celln_control::Control::new(std::time::Duration::from_millis(150)).unwrap();
+        let result = control.scope(|| launch_declared(&cold, &motes, &tools, &state));
+        assert!(result.is_err());
+        assert_eq!(control.reason(), Some(celln_control::Stopped::Deadline));
+        assert_eq!(crate::cells::live_count(&state), 0);
+        eprintln!("PASS: deadline stops cold preparation before cell launch");
+
         // A pinned bundle whose selected tool hash differs from the sealed
         // file must refuse in pilot, even if that actual file is manifest-admitted.
         let different = Store::open(&tools)

--- a/crates/celln-cli/src/dispatch_warm.rs
+++ b/crates/celln-cli/src/dispatch_warm.rs
@@ -19,14 +19,24 @@ pub(super) fn fork(
     prepare: impl FnOnce() -> Result<(BootConfig, Vec<u8>), String>,
 ) -> Result<LinuxCell, String> {
     let mote = {
-        let mut cache = CACHE
-            .get_or_init(|| Mutex::new(None))
-            .lock()
-            .map_err(|_| "warm mote cache poisoned".to_owned())?;
+        let mutex = CACHE.get_or_init(|| Mutex::new(None));
+        let mut cache = loop {
+            celln_control::check().map_err(|e| e.to_string())?;
+            match mutex.try_lock() {
+                Ok(cache) => break cache,
+                Err(std::sync::TryLockError::Poisoned(_)) => {
+                    return Err("warm mote cache poisoned".into())
+                }
+                Err(std::sync::TryLockError::WouldBlock) => {
+                    std::thread::sleep(std::time::Duration::from_millis(10))
+                }
+            }
+        };
         if let Some((_, mote)) = cache.as_ref().filter(|(k, _)| k == &key) {
             Arc::clone(mote)
         } else {
             let (cfg, payload) = prepare()?;
+            celln_control::check().map_err(|e| e.to_string())?;
             let mut template = LinuxCell::boot(cfg).map_err(|e| e.to_string())?;
             template
                 .seal_tool(&celln_manifest::Hash::of(&payload), &payload)
@@ -45,5 +55,22 @@ pub(super) fn fork(
             mote
         }
     };
+    celln_control::check().map_err(|e| e.to_string())?;
     LinuxCell::fork_from(&mote).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn deadline_interrupts_waiting_for_another_preparation() {
+        let _guard = CACHE.get_or_init(|| Mutex::new(None)).lock().unwrap();
+        let worker = std::thread::spawn(|| {
+            let c = celln_control::Control::new(std::time::Duration::from_millis(30)).unwrap();
+            c.scope(|| fork("not-prepared".into(), || panic!("must not prepare")))
+                .err()
+                .unwrap()
+        });
+        assert!(worker.join().unwrap().contains("deadline"));
+    }
 }

--- a/crates/celln-control/Cargo.toml
+++ b/crates/celln-control/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "celln-control"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Host execution deadlines, cancellation and owned process cleanup."
+
+[dependencies]
+libc.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/celln-control/src/lib.rs
+++ b/crates/celln-control/src/lib.rs
@@ -1,0 +1,119 @@
+//! Host-only cooperative execution control. Context carries no grants: it can
+//! only stop work or shorten its lifetime. Scoped installation is thread-local.
+
+use std::cell::RefCell;
+use std::io;
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Arc,
+};
+use std::time::{Duration, Instant};
+
+pub mod process;
+
+#[derive(Clone, Debug)]
+pub struct Control(Arc<Inner>);
+#[derive(Debug)]
+struct Inner {
+    deadline: Instant,
+    stop: AtomicU8,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Stopped {
+    Cancelled,
+    Deadline,
+}
+impl std::fmt::Display for Stopped {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Cancelled => "execution cancelled",
+            Self::Deadline => "execution deadline exceeded",
+        })
+    }
+}
+
+thread_local! { static CURRENT: RefCell<Option<Control>> = const { RefCell::new(None) }; }
+
+impl Control {
+    pub fn new(timeout: Duration) -> io::Result<Self> {
+        let deadline = Instant::now()
+            .checked_add(timeout)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "deadline overflow"))?;
+        Ok(Self(Arc::new(Inner {
+            deadline,
+            stop: AtomicU8::new(0),
+        })))
+    }
+    pub fn reason(&self) -> Option<Stopped> {
+        if Instant::now() >= self.0.deadline {
+            let _ = self
+                .0
+                .stop
+                .compare_exchange(0, 2, Ordering::SeqCst, Ordering::SeqCst);
+        }
+        match self.0.stop.load(Ordering::SeqCst) {
+            1 => Some(Stopped::Cancelled),
+            2 => Some(Stopped::Deadline),
+            _ => None,
+        }
+    }
+    pub fn cancel(&self) {
+        self.reason();
+        let _ = self
+            .0
+            .stop
+            .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst);
+    }
+    pub fn check(&self) -> io::Result<()> {
+        match self.reason() {
+            Some(reason) => Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                reason.to_string(),
+            )),
+            None => Ok(()),
+        }
+    }
+    pub fn remaining(&self) -> Duration {
+        self.0.deadline.saturating_duration_since(Instant::now())
+    }
+    pub fn scope<T>(&self, f: impl FnOnce() -> T) -> T {
+        struct Restore(Option<Control>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                CURRENT.with(|c| *c.borrow_mut() = self.0.take());
+            }
+        }
+        let _restore = Restore(CURRENT.with(|c| c.replace(Some(self.clone()))));
+        f()
+    }
+}
+
+pub fn current() -> Option<Control> {
+    CURRENT.with(|c| c.borrow().clone())
+}
+pub fn check() -> io::Result<()> {
+    current().map_or(Ok(()), |c| c.check())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn cancellation_is_sticky_and_scope_is_restored() {
+        let c = Control::new(Duration::from_secs(10)).unwrap();
+        c.scope(|| {
+            assert!(current().is_some());
+            c.cancel();
+            assert!(check().is_err());
+        });
+        assert!(current().is_none());
+        assert_eq!(c.reason(), Some(Stopped::Cancelled));
+    }
+    #[test]
+    fn elapsed_deadline_cannot_be_relabelled_as_cancellation() {
+        let c = Control::new(Duration::ZERO).unwrap();
+        c.cancel();
+        assert_eq!(c.reason(), Some(Stopped::Deadline));
+    }
+}

--- a/crates/celln-control/src/process.rs
+++ b/crates/celln-control/src/process.rs
@@ -1,0 +1,198 @@
+//! Drain bounded output without reader threads that can outlive a child. On
+//! Linux each subprocess gets its own process group, terminated before reaping
+//! the leader so its PID cannot be recycled under the cleanup operation.
+
+use std::io;
+use std::process::{Command, Output};
+
+pub fn output(command: &mut Command) -> io::Result<Output> {
+    output_with_timeout(command, None)
+}
+
+pub fn output_with_timeout(
+    command: &mut Command,
+    limit: Option<std::time::Duration>,
+) -> io::Result<Output> {
+    crate::check()?;
+    #[cfg(target_os = "linux")]
+    {
+        unix_output(command, limit)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        if crate::current().is_some() || limit.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "controlled process groups require Linux",
+            ));
+        }
+        command.output()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn unix_output(command: &mut Command, limit: Option<std::time::Duration>) -> io::Result<Output> {
+    use std::io::Read;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::process::CommandExt;
+    use std::process::{Child, Stdio};
+    use std::time::Duration;
+    struct Owned(Child, bool);
+    impl Drop for Owned {
+        fn drop(&mut self) {
+            if !self.1 {
+                return;
+            }
+            // The leader has not been reaped, so this is still our PGID.
+            unsafe {
+                libc::kill(-(self.0.id() as i32), libc::SIGKILL);
+            }
+            let _ = self.0.kill(); // also stop a leader that changed its group
+            let _ = self.0.wait();
+        }
+    }
+    fn nonblocking(fd: i32) -> io::Result<()> {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+    fn drain(reader: &mut impl Read, dest: &mut Vec<u8>) -> io::Result<bool> {
+        let mut buf = [0; 8192];
+        // Bound each pass as well as total capture so a flooding child cannot
+        // starve cancellation polling.
+        for _ in 0..32 {
+            match reader.read(&mut buf) {
+                Ok(0) => return Ok(true),
+                Ok(n) => {
+                    if dest.len() + n > 8 * 1024 * 1024 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "subprocess output exceeded 8 MiB",
+                        ));
+                    }
+                    dest.extend_from_slice(&buf[..n]);
+                }
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => return Ok(true),
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(false)
+    }
+    command
+        .process_group(0)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = Owned(command.spawn()?, true);
+    let started = std::time::Instant::now();
+    let mut stdout = child.0.stdout.take().expect("piped stdout");
+    let mut stderr = child.0.stderr.take().expect("piped stderr");
+    nonblocking(stdout.as_raw_fd())?;
+    nonblocking(stderr.as_raw_fd())?;
+    let (mut out, mut err) = (Vec::new(), Vec::new());
+    loop {
+        crate::check()?;
+        if limit.is_some_and(|limit| started.elapsed() >= limit) {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "subprocess deadline exceeded",
+            ));
+        }
+        drain(&mut stdout, &mut out)?;
+        drain(&mut stderr, &mut err)?;
+        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                child.0.id(),
+                &mut info,
+                libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+            )
+        };
+        if rc < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if unsafe { info.si_pid() } != 0 {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    // Stop background children even when the leader finished normally.
+    unsafe {
+        libc::kill(-(child.0.id() as i32), libc::SIGKILL);
+    }
+    while !drain(&mut stdout, &mut out)? {
+        crate::check()?;
+    }
+    while !drain(&mut stderr, &mut err)? {
+        crate::check()?;
+    }
+    let status = child.0.wait()?;
+    // Reaped already; do not signal a now-reusable PGID in Drop.
+    child.1 = false;
+    crate::check()?;
+    Ok(Output {
+        status,
+        stdout: out,
+        stderr: err,
+    })
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    fn not_running(pid: &str) -> bool {
+        std::fs::read_to_string(format!("/proc/{}/stat", pid.trim()))
+            .map(|s| s.split_once(") ").unwrap().1.starts_with('Z'))
+            .unwrap_or(true)
+    }
+
+    #[test]
+    fn deadline_terminates_owned_descendants_and_reaps_leader() {
+        let dir = tempfile::tempdir().unwrap();
+        let pidfile = dir.path().join("pid");
+        let c = crate::Control::new(Duration::from_millis(150)).unwrap();
+        let started = Instant::now();
+        let result = c.scope(|| {
+            output(
+                Command::new("sh")
+                    .args(["-c", "sleep 60 & echo $! > \"$1\"; wait", "test"])
+                    .arg(&pidfile),
+            )
+        });
+        assert!(result.is_err());
+        assert!(started.elapsed() < Duration::from_secs(3));
+        let pid = std::fs::read_to_string(pidfile).unwrap();
+        for _ in 0..100 {
+            if not_running(&pid) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("descendant remained running");
+    }
+
+    #[test]
+    fn successful_leader_cannot_leave_a_pipe_holding_background_process() {
+        let started = Instant::now();
+        let result = output(Command::new("sh").args(["-c", "sleep 60 & printf done"])).unwrap();
+        assert!(result.status.success());
+        assert_eq!(result.stdout, b"done");
+        assert!(started.elapsed() < Duration::from_secs(3));
+    }
+
+    #[test]
+    fn cancellation_stops_a_process_before_its_command_deadline() {
+        let c = crate::Control::new(Duration::from_secs(60)).unwrap();
+        let cancel = c.clone();
+        let worker =
+            std::thread::spawn(move || c.scope(|| output(Command::new("sleep").arg("60"))));
+        cancel.cancel();
+        assert!(worker.join().unwrap().is_err());
+    }
+}

--- a/crates/celln-forge/Cargo.toml
+++ b/crates/celln-forge/Cargo.toml
@@ -11,6 +11,7 @@ description = "The build plane: rebuilds an artifact from source and proves the 
 name = "forge"
 
 [dependencies]
+celln-control.workspace = true
 celln-manifest.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/celln-forge/src/lib.rs
+++ b/crates/celln-forge/src/lib.rs
@@ -61,9 +61,7 @@ pub enum ForgeError {
 }
 
 pub fn toolchain() -> Result<String, ForgeError> {
-    let out = Command::new("rustc")
-        .arg("-V")
-        .output()
+    let out = celln_control::process::output(Command::new("rustc").arg("-V"))
         .map_err(|e| ForgeError::Toolchain(e.to_string()))?;
     if !out.status.success() {
         return Err(ForgeError::Toolchain(
@@ -84,13 +82,15 @@ fn compile_in(dir: &Path, source: &[u8], args: &[String]) -> Result<Vec<u8>, For
         .iter()
         .map(|a| a.replace("%BUILD_DIR%", &dir.display().to_string()))
         .collect();
-    let out = Command::new("rustc")
-        .args(&concrete)
-        .arg("-o")
-        .arg(&bin)
-        .arg(&src)
-        .env("CARGO_NET_OFFLINE", "true")
-        .output()?;
+    celln_control::check()?;
+    let out = celln_control::process::output(
+        Command::new("rustc")
+            .args(&concrete)
+            .arg("-o")
+            .arg(&bin)
+            .arg(&src)
+            .env("CARGO_NET_OFFLINE", "true"),
+    )?;
     if !out.status.success() {
         return Err(ForgeError::Build(
             String::from_utf8_lossy(&out.stderr).trim().into(),

--- a/crates/celln-warden/Cargo.toml
+++ b/crates/celln-warden/Cargo.toml
@@ -19,6 +19,8 @@ mock = []
 kvm = ["dep:kvm-ioctls", "dep:kvm-bindings", "dep:libc"]
 
 [dependencies]
+tempfile.workspace = true
+celln-control.workspace = true
 celln-manifest.workspace = true
 thiserror.workspace = true
 kvm-ioctls = { workspace = true, optional = true }

--- a/crates/celln-warden/src/egress.rs
+++ b/crates/celln-warden/src/egress.rs
@@ -83,10 +83,31 @@ impl HttpBroker {
         {
             return Err(FetchDenied::Host(host));
         }
-        let ip = (host.as_str(), 443)
-            .to_socket_addrs()
-            .map_err(|_| FetchDenied::Address)?
-            .find_map(|a| match a.ip() {
+        let addresses: Vec<IpAddr> = if celln_control::current().is_some() {
+            // NSS resolution can block. Keep it in an owned subprocess under
+            // the same execution deadline, never an abandoned resolver thread.
+            let out = celln_control::process::output_with_timeout(
+                Command::new("getent").args(["--", "ahostsv4", &host]),
+                Some(self.policy.timeout),
+            )
+            .map_err(|e| FetchDenied::Fetch(e.to_string()))?;
+            if !out.status.success() {
+                return Err(FetchDenied::Address);
+            }
+            String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .filter_map(|line| line.split_whitespace().next()?.parse().ok())
+                .collect()
+        } else {
+            (host.as_str(), 443)
+                .to_socket_addrs()
+                .map_err(|_| FetchDenied::Address)?
+                .map(|a| a.ip())
+                .collect()
+        };
+        let ip = addresses
+            .into_iter()
+            .find_map(|a| match a {
                 IpAddr::V4(v) if is_public_v4(v.octets()) => Some(IpAddr::V4(v)),
                 _ => None,
             })
@@ -105,33 +126,31 @@ impl HttpBroker {
             }
             let (host, ip) = self.authorize(&url)?;
             self.used += 1;
-            let header = std::env::temp_dir().join(format!(
-                "celln-fetch-{}-{}",
-                std::process::id(),
-                self.used
-            ));
-            let out = Command::new("curl")
-                .args([
-                    "--silent",
-                    "--show-error",
-                    "--proto",
-                    "=https",
-                    "--max-redirs",
-                    "0",
-                ])
-                .arg("--max-time")
-                .arg(self.policy.timeout.as_secs().to_string())
-                .arg("--max-filesize")
-                .arg(self.policy.max_response_bytes.to_string())
-                .arg("--resolve")
-                .arg(format!("{host}:443:{ip}"))
-                .arg("--dump-header")
-                .arg(&header)
-                .arg(&url)
-                .output()
-                .map_err(|e| FetchDenied::Fetch(e.to_string()))?;
-            let headers = std::fs::read_to_string(&header).unwrap_or_default();
-            let _ = std::fs::remove_file(&header);
+            let header =
+                tempfile::NamedTempFile::new().map_err(|e| FetchDenied::Fetch(e.to_string()))?;
+            let out = celln_control::process::output_with_timeout(
+                Command::new("curl")
+                    .args([
+                        "--silent",
+                        "--show-error",
+                        "--proto",
+                        "=https",
+                        "--max-redirs",
+                        "0",
+                    ])
+                    .arg("--max-time")
+                    .arg(self.policy.timeout.as_secs().to_string())
+                    .arg("--max-filesize")
+                    .arg(self.policy.max_response_bytes.to_string())
+                    .arg("--resolve")
+                    .arg(format!("{host}:443:{ip}"))
+                    .arg("--dump-header")
+                    .arg(header.path())
+                    .arg(&url),
+                Some(self.policy.timeout),
+            )
+            .map_err(|e| FetchDenied::Fetch(e.to_string()))?;
+            let headers = std::fs::read_to_string(header.path()).unwrap_or_default();
             if !out.status.success() {
                 return Err(FetchDenied::Fetch(
                     String::from_utf8_lossy(&out.stderr).trim().into(),

--- a/crates/celln-warden/src/vmm/boot.rs
+++ b/crates/celln-warden/src/vmm/boot.rs
@@ -1360,6 +1360,8 @@ impl LinuxCell {
     /// Run the guest until it shuts down or the watchdog fires, collecting
     /// console output.
     pub fn run(&mut self) -> Result<BootReport, VmmError> {
+        let control = celln_control::current();
+        celln_control::check().map_err(|e| VmmError::Backend(e.to_string()))?;
         install_wake_handler();
         let stop = Arc::new(AtomicBool::new(false));
         // `pthread_t` is opaque and may be pointer-shaped, so it cannot cross
@@ -1368,12 +1370,16 @@ impl LinuxCell {
         let tid = unsafe { libc::pthread_self() as usize };
         let watchdog = {
             let stop = stop.clone();
+            let control = control.clone();
             let timeout = self.cfg.timeout;
             std::thread::spawn(move || {
                 let deadline = Instant::now() + timeout;
                 while Instant::now() < deadline {
                     if stop.load(Ordering::Relaxed) {
                         return;
+                    }
+                    if control.as_ref().is_some_and(|c| c.reason().is_some()) {
+                        break;
                     }
                     std::thread::sleep(Duration::from_millis(20));
                 }
@@ -1393,6 +1399,9 @@ impl LinuxCell {
         let mut stop_at_marker = false;
         let mut live_signal_at: Option<Instant> = None;
         let end = loop {
+            if control.as_ref().is_some_and(|c| c.reason().is_some()) {
+                stop.store(true, Ordering::Relaxed);
+            }
             if stop.load(Ordering::Relaxed) {
                 break BootEnd::TimedOut;
             }

--- a/docs/DECLARED_SUBSTRATES.md
+++ b/docs/DECLARED_SUBSTRATES.md
@@ -95,7 +95,8 @@ preparation. Forge dispatch also prepares then forks, but its freshly generated
 substrate may miss the cache; deterministic forge substrate reuse is not claimed.
 The cache is not an aggregate memory scheduler (#5).
 
-This does not complete #13 or the epic: cancellation/deadlines,
-full provenance, input providers and external integration remain outstanding.
+Cancellation/deadlines use the shared [execution control](DISPATCH_LIFECYCLE.md).
+This does not complete the epic: full provenance, input providers and external
+integration remain outstanding.
 See [warm dispatch measurements](WARM_DISPATCH_MEASUREMENTS.md) for the current
 end-to-end numbers and guest isolation proof.

--- a/docs/DISPATCH_LIFECYCLE.md
+++ b/docs/DISPATCH_LIFECYCLE.md
@@ -1,0 +1,60 @@
+# Dispatcher cancellation and deadlines
+
+`POST /v1/executions/{id}/cancel` uses the same bearer authentication as submit
+and status. Unknown IDs return 404. Active executions return 202 and remain in
+`Cancelling` while cleanup runs. Repeating the request is safe. A terminal
+execution returns 200 with its existing terminal result; cancellation never
+rewrites completed work.
+
+The registry retains capacity while cancellation is pending. Only the worker,
+after unwinding its VM and owned subprocesses, publishes `Cancelled` and
+releases the reservation. Terminal receipts are marked Cancelled when a cell
+was created; cancellation before a cell exists has a status record but no
+invented cell ID or receipt. Active records are not evicted by the history TTL.
+
+## One deadline
+
+After parsing and validating a submission, `timeoutMs` creates one monotonic
+deadline. The same control object spans worker scheduling, provider discovery
+and model invocation, both reproducibility builds, image preparation, cache
+waiting, cold mote preparation, guest execution, DNS/HTTPS requests and final
+result publication. Starting a new phase does not renew the budget. The
+terminal registry update checks the control under the same lock as cancel.
+Deadline expiry is Failed with `execution deadline exceeded`; cancellation is
+Cancelled. The first observed stop cause is sticky.
+
+Cancellation is cooperative and OS-mediated, not a hard real-time guarantee.
+Process and cache loops poll at 10 ms; KVM's watchdog polls at 20 ms and wakes
+blocked KVM_RUN. Synchronous local filesystem/kernel operations must return
+before their owner can unwind. Reservations stay held during that cleanup,
+rather than claiming resources have been released prematurely.
+
+## Subprocess ownership
+
+The shared `celln-control` crate scopes control to one worker thread and restores
+the previous context on exit or unwind. Helpers inherit that context, not a new
+timer. Provider, compiler/linker, image-build and fetch commands run in owned
+Linux process groups. Nonblocking bounded pipe reads avoid leaked reader threads
+or a background child holding output pipes open indefinitely. Cleanup signals
+the group before reaping the leader, retaining its PID until the signal is sent;
+the leader is also killed directly if it changed groups. Capture is capped at
+8 MiB per stream. This is process supervision for trusted host tools, not a
+sandbox against a malicious host tool deliberately escaping into another group.
+
+Controlled DNS uses `getent ahostsv4` under the same deadline before curl receives
+the pinned public address. Install `getent` with the node runtime; its absence
+refuses fetches, with no unbounded resolver-thread fallback. Temporary response
+headers are unique per fetch and removed on success, failure or cancellation.
+
+## Evidence
+
+- `make ci`: sticky stop reasons, scope restoration, process-group cleanup,
+  pipe-holding background processes, authenticated/idempotent cancel, terminal
+  success races, TTL retention and cancellation while waiting for preparation.
+- `cargo test -p celln-cli on_real_kvm -- --ignored --nocapture`: actual guest
+  output before cancellation/deadline, cold-preparation expiry and no live cell
+  after teardown, alongside the existing outcome and substrate proofs.
+
+This completes the first lifecycle implementation, not the epic. Aggregate
+resource accounting, granted/executed provenance, input/closure delivery and
+external Sympozium conformance still need their own implementation and proofs.

--- a/docs/DISPATCH_RESULTS.md
+++ b/docs/DISPATCH_RESULTS.md
@@ -69,4 +69,5 @@ This completes the outcome and unsupported-input/closure refusal slices of #13.
 Declared execution now forks an operator-pinned warm substrate with a separate
 one-shot invocation channel; see [Declared substrates](DECLARED_SUBSTRATES.md)
 for the trust root, compatibility requirements and exact artifact semantics.
-End-to-end cancellation and deadlines remain separate work.
+Cancellation and end-to-end deadlines are described in
+[Dispatcher lifecycle](DISPATCH_LIFECYCLE.md).


### PR DESCRIPTION
## Change

Add authenticated, idempotent `POST /v1/executions/{id}/cancel`. Active work stays Cancelling and reserves capacity until the worker has unwound. Terminal work is unchanged; unknown IDs return 404. Cancelled work with a cell retains a Cancelled receipt, while pre-cell cancellation invents neither a cell ID nor a receipt.

One monotonic execution control spans worker scheduling, provider/model calls, both reproducibility builds, image preparation, cache waiting, cold mote preparation, guest execution and DNS/HTTPS work. The final registry update checks the same control under the cancellation lock, so late success cannot overwrite expiry. Active records cannot expire out of the registry while owning capacity.

The new small host-only `celln-control` crate owns deadline/cancellation context and process supervision. Linux subprocess groups are terminated before reaping the leader; nonblocking bounded capture avoids pipe-reader leaks. KVM's watchdog observes the same control. DNS runs through controlled `getent ahostsv4` before curl gets a pinned public address. Fetch header files are unique and RAII-cleaned.

## Validation

- `make ci` passed.
- Real-KVM suites passed: running-guest cancellation, running-guest deadline, cold-preparation deadline, no live cell after teardown, and previous substrate/outcome cases.
- Host tests cover authentication, repeated cancellation, retained reservations, terminal races, cache-lock waiting, process-group cleanup and pipe-holding background children.
- `make acceptance-kvm` and `make fetch-proof` passed.

See `docs/DISPATCH_LIFECYCLE.md` for semantics and limits. Controlled fetch requires `getent`; unavailable controlled process-group support refuses. This is cooperative OS-mediated cancellation, not hard real-time cleanup of uninterruptible kernel operations or a sandbox against malicious host tools escaping their process group.

Stacked on #59. Refs #13, #2, #5, #12. Do not close the epic: aggregate resource accounting, executed/granted provenance, providers/closures and external integration acceptance remain outstanding.
