### PR TITLE
Enforce workspace authority and bounded immutable inputs

### DIFF
--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -13,6 +13,8 @@ use std::path::Path;
 #[path = "dispatch_substrate.rs"]
 mod substrate;
 pub(crate) use substrate::launch_declared;
+#[path = "dispatch_inputs.rs"]
+pub(crate) mod inputs;
 #[cfg(target_os = "linux")]
 #[path = "dispatch_warm.rs"]
 mod warm;
@@ -66,12 +68,7 @@ pub struct ResolvedBundle {
 /// resolved provenance. Remove each refusal only with its delivery proof.
 pub(crate) fn check_supported_authority(request: &ExecutionRequest) -> Result<(), String> {
     celln_control::check().map_err(|e| e.to_string())?;
-    if !request.inputs.is_empty() {
-        return Err("unsupported authority: input delivery is not implemented".into());
-    }
-    if request.capabilities.workspace != celln_spec::WorkspaceAccess::None {
-        return Err("unsupported authority: workspace delivery is not implemented".into());
-    }
+    inputs::validate(request)?;
     if request.tools.iter().any(|tool| tool.closure.is_some()) {
         return Err("unsupported authority: tool closure delivery is not implemented".into());
     }
@@ -165,6 +162,8 @@ pub fn resolve_bundle(
 /// one. The dispatcher builds the receipt from this after the cell is gone.
 #[derive(Debug)]
 pub struct LaunchOutcome {
+    /// Verified inputs acknowledged as staged by pilot, not just requested.
+    pub input_hashes: Vec<String>,
     pub cell_id: String,
     /// Bounded workload bytes, including failure output; may be empty.
     pub output: Option<Vec<u8>>,
@@ -309,6 +308,7 @@ pub fn launch(
     if request.mote.is_some() {
         return Err("declared execution requires the pinned substrate launcher".into());
     }
+    let inputs = inputs::resolve(request, state_root)?;
     if !Path::new("/dev/kvm").exists() {
         return Err("no /dev/kvm — cannot seal a cell on this host".to_owned());
     }
@@ -349,6 +349,8 @@ pub fn launch(
             "allow_fetch": !request.capabilities.egress.is_empty(),
             "report_output_limit": request.capabilities.output_bytes,
             "force_agent_lane": matches!(request.execution.lane, RequestedLane::Agent),
+            "workspace_access": request.capabilities.workspace,
+            "inputs": inputs,
         }))
         .map_err(|error| error.to_string())?,
     )
@@ -405,6 +407,9 @@ fn run_prepared(
     invocation: &[u8],
     state_root: &Path,
 ) -> Result<LaunchOutcome, String> {
+    if invocation.len() > warden::MAX_INVOCATION_BYTES {
+        return Err("invocation exceeds bounded delivery channel".into());
+    }
     if request.capabilities.memory_bytes > 0 {
         cfg.mem_size = request.capabilities.memory_bytes as usize;
     }
@@ -477,6 +482,13 @@ fn run_cell(
     );
     if let Some(reason) = celln_control::current().and_then(|c| c.reason()) {
         outcome.denial = Some(reason.to_string());
+    }
+    let expected: Vec<_> = request.inputs.iter().map(|i| i.hash.clone()).collect();
+    if outcome.input_hashes != expected {
+        outcome.input_hashes.clear();
+        outcome
+            .denial
+            .get_or_insert_with(|| "input delivery report mismatch".into());
     }
     if let Some(record) = record.as_mut() {
         crate::cells::finish(state_root, record, "kvm", outcome.denial.clone());
@@ -574,14 +586,14 @@ mod tests {
             media_type: "text/plain".into(),
             bytes: 4,
         });
-        cases.push((input, "input delivery"));
+        cases.push((input, "inputs require"));
         for access in [
             celln_spec::WorkspaceAccess::ReadOnly,
             celln_spec::WorkspaceAccess::ReadWrite,
         ] {
             let mut workspace = base.clone();
             workspace.capabilities.workspace = access;
-            cases.push((workspace, "workspace delivery"));
+            assert!(check_supported_authority(&workspace).is_ok());
         }
         let mut closure = base.clone();
         closure.tools[0].closure = Some(celln_spec::ImmutableRef {

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -533,6 +533,9 @@ fn run_execution(
         return;
     }
     let started_at = crate::dispatch::now_rfc3339();
+    if let Err(error) = crate::dispatch::inputs::resolve(&request, &root) {
+        return fail_execution(&executions, &request.id, error);
+    }
     let assay_root = root.join("assay");
 
     // Declared launch consumes operator-pinned substrate bytes. Forge remains
@@ -596,9 +599,7 @@ fn run_execution(
         resolved: ResolvedExecution {
             mote,
             tools: vec![program_hash],
-            // No input provider exists yet. Never echo requested hashes as
-            // evidence that their bytes were resolved or delivered.
-            inputs: Vec::new(),
+            inputs: outcome.input_hashes,
         },
         output: stored_output,
         started_at,
@@ -770,6 +771,12 @@ mod tests {
     fn unsupported_forge_authority_is_refused_without_side_effects() {
         let mut request = request_with_egress(&[]);
         request.capabilities.workspace = celln_spec::WorkspaceAccess::ReadWrite;
+        request.inputs.push(celln_spec::ExecutionInput {
+            name: "oversized".into(),
+            hash: celln_manifest::Hash::of(b"data").0,
+            media_type: "text/plain".into(),
+            bytes: 65537,
+        });
         let work = tempfile::tempdir().unwrap();
         let root = work.path().join("must-not-be-created");
         let executions: Executions = Arc::new(Mutex::new(HashMap::new()));
@@ -800,11 +807,7 @@ mod tests {
         let registry = executions.lock().unwrap();
         let record = &registry[&request.id].value;
         assert_eq!(record.phase, "Refused");
-        assert!(record
-            .reason
-            .as_deref()
-            .unwrap()
-            .contains("workspace delivery"));
+        assert!(record.reason.as_deref().unwrap().contains("input budget"));
         assert!(record.receipt.is_none());
         assert!(!execution_is_active(record));
         assert!(!root.exists());
@@ -814,6 +817,12 @@ mod tests {
     fn http_unsupported_authority_returns_422_without_reserving_capacity() {
         let mut request = request_with_egress(&[]);
         request.capabilities.workspace = celln_spec::WorkspaceAccess::ReadOnly;
+        request.inputs.push(celln_spec::ExecutionInput {
+            name: "oversized".into(),
+            hash: celln_manifest::Hash::of(b"data").0,
+            media_type: "text/plain".into(),
+            bytes: 65537,
+        });
         let work = tempfile::tempdir().unwrap();
         let root = work.path().join("unused");
         let state = State {
@@ -842,7 +851,7 @@ mod tests {
         let mut response = String::new();
         client.read_to_string(&mut response).unwrap();
         assert!(response.starts_with("HTTP/1.1 422"), "{response}");
-        assert!(response.contains("workspace delivery"));
+        assert!(response.contains("input budget"));
         assert!(state.executions.lock().unwrap().is_empty());
         assert!(!root.exists());
     }
@@ -851,6 +860,7 @@ mod tests {
     fn receipt_phase_tracks_exit_and_output_storage_independently() {
         let work = tempfile::tempdir().unwrap();
         let mut outcome = crate::dispatch::LaunchOutcome {
+            input_hashes: Vec::new(),
             cell_id: "cell".into(),
             output: Some(vec![]),
             denial: None,

--- a/crates/celln-cli/src/dispatch_inputs.rs
+++ b/crates/celln-cli/src/dispatch_inputs.rs
@@ -1,0 +1,185 @@
+//! Explicit, bounded immutable data delivery. A content hash is identity,
+//! not permission: the host policy must approve it before a store read.
+
+use celln_manifest::Hash;
+use celln_spec::{ExecutionRequest, WorkspaceAccess};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+pub const MAX_INPUT_BYTES: u64 = 65536;
+
+#[derive(Debug, Serialize)]
+pub struct ResolvedInput {
+    pub name: String,
+    pub hash: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Policy {
+    api_version: String,
+    hashes: Vec<String>,
+}
+
+pub fn validate(request: &ExecutionRequest) -> Result<(), String> {
+    if !request.inputs.is_empty() && request.capabilities.workspace == WorkspaceAccess::None {
+        return Err("inputs require read-only or read-write workspace authority".into());
+    }
+    let total = request
+        .inputs
+        .iter()
+        .try_fold(0u64, |n, input| n.checked_add(input.bytes));
+    if total.map_or(true, |n| n > MAX_INPUT_BYTES) || request.inputs.len() > 16 {
+        return Err("input budget exceeded: at most 16 inputs and 65536 bytes total".into());
+    }
+    Ok(())
+}
+
+pub fn resolve(request: &ExecutionRequest, root: &Path) -> Result<Vec<ResolvedInput>, String> {
+    celln_control::check().map_err(|e| e.to_string())?;
+    validate(request)?;
+    if request.inputs.is_empty() {
+        return Ok(Vec::new());
+    }
+    if !request.problems().is_empty() {
+        return Err("invalid input execution request".into());
+    }
+    let policy: Policy = serde_json::from_slice(
+        &std::fs::read(root.join("trusted-inputs.json"))
+            .map_err(|_| "input trust policy is unavailable".to_owned())?,
+    )
+    .map_err(|_| "input trust policy is invalid".to_owned())?;
+    if policy.api_version != "celln.dev/v1alpha1"
+        || request
+            .inputs
+            .iter()
+            .any(|i| !policy.hashes.contains(&i.hash))
+    {
+        return Err("input is not authorized by host policy".into());
+    }
+    let store = celln_store::Store::open(root.join("inputs")).map_err(|e| e.to_string())?;
+    request
+        .inputs
+        .iter()
+        .map(|input| {
+            celln_control::check().map_err(|e| e.to_string())?;
+            let data = store
+                .get_bounded(&Hash(input.hash.clone()), input.bytes as usize)
+                .map_err(|e| e.to_string())?;
+            if data.len() as u64 != input.bytes {
+                return Err("input byte count does not match declaration".into());
+            }
+            Ok(ResolvedInput {
+                name: input.name.clone(),
+                hash: input.hash.clone(),
+                data,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use celln_spec::ExecutionInput;
+    use serde_json::json;
+
+    fn request() -> ExecutionRequest {
+        let mut request: ExecutionRequest =
+            serde_json::from_str(include_str!("../../../examples/execution/forge-task.json"))
+                .unwrap();
+        request.capabilities.workspace = WorkspaceAccess::ReadOnly;
+        request.inputs.push(ExecutionInput {
+            name: "data".into(),
+            hash: Hash::of(b"data").0,
+            media_type: "text/plain".into(),
+            bytes: 4,
+        });
+        request
+    }
+
+    fn policy(root: &Path, hashes: &[String]) {
+        std::fs::write(
+            root.join("trusted-inputs.json"),
+            serde_json::to_vec(&json!({
+                "apiVersion": "celln.dev/v1alpha1", "hashes": hashes,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn identity_is_not_authorization_and_exact_bytes_are_required() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = celln_store::Store::open(dir.path().join("inputs")).unwrap();
+        let hash = store.put(b"data").unwrap();
+        let mut req = request();
+        assert!(resolve(&req, dir.path())
+            .unwrap_err()
+            .contains("unavailable"));
+        policy(dir.path(), &[]);
+        assert!(resolve(&req, dir.path())
+            .unwrap_err()
+            .contains("not authorized"));
+        policy(dir.path(), &[hash.0]);
+        let input = resolve(&req, dir.path()).unwrap().remove(0);
+        assert_eq!(input.data, b"data");
+        assert_eq!(input.name, "data");
+        req.inputs[0].bytes = 3;
+        assert!(resolve(&req, dir.path()).unwrap_err().contains("exceeds"));
+        req.inputs[0].bytes = 5;
+        assert!(resolve(&req, dir.path())
+            .unwrap_err()
+            .contains("byte count"));
+        req.inputs[0].bytes = 4;
+        // A later policy withdrawal must be observed, including on warm dispatch.
+        policy(dir.path(), &[]);
+        assert!(resolve(&req, dir.path())
+            .unwrap_err()
+            .contains("not authorized"));
+    }
+
+    #[test]
+    fn missing_corrupt_and_invalid_inputs_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut req = request();
+        policy(dir.path(), &[req.inputs[0].hash.clone()]);
+        assert!(resolve(&req, dir.path()).unwrap_err().contains("not found"));
+        let store = celln_store::Store::open(dir.path().join("inputs")).unwrap();
+        store.put(b"data").unwrap();
+        let hex = req.inputs[0].hash.strip_prefix("blake3:").unwrap();
+        let object = dir.path().join("inputs/objects").join(&hex[..2]).join(hex);
+        std::fs::write(object, b"evil").unwrap();
+        assert!(resolve(&req, dir.path()).unwrap_err().contains("integrity"));
+        for name in [".", "..", "../escape", "/absolute"] {
+            req.inputs[0].name = name.into();
+            assert!(resolve(&req, dir.path())
+                .unwrap_err()
+                .contains("invalid input"));
+        }
+    }
+
+    #[test]
+    fn budgets_and_workspace_are_checked_without_opening_a_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let absent = dir.path().join("absent");
+        let mut req = request();
+        req.capabilities.workspace = WorkspaceAccess::None;
+        assert!(resolve(&req, &absent)
+            .unwrap_err()
+            .contains("inputs require"));
+        req.capabilities.workspace = WorkspaceAccess::ReadWrite;
+        req.inputs[0].bytes = MAX_INPUT_BYTES + 1;
+        assert!(resolve(&req, &absent).unwrap_err().contains("input budget"));
+        req.inputs = vec![req.inputs[0].clone(); 17];
+        for input in &mut req.inputs {
+            input.bytes = 0;
+        }
+        assert!(resolve(&req, &absent).unwrap_err().contains("input budget"));
+        req.inputs.clear();
+        assert!(resolve(&req, &absent).unwrap().is_empty());
+        assert!(!absent.exists());
+    }
+}

--- a/crates/celln-cli/src/dispatch_outcome.rs
+++ b/crates/celln-cli/src/dispatch_outcome.rs
@@ -17,8 +17,11 @@ pub(super) fn parse_report(
         exit_code: None,
         signal: None,
         timed_out,
+        input_hashes: Vec::new(),
     };
     let mut terminal = false;
+    let mut inputs_seen = false;
+    let mut output_seen = false;
     // An old pilot must not accept a workload's imitation of the new frames.
     // Negotiate at the first supervisor startup, before it reads any request
     // or executes a workload; later imitations cannot repair this check.
@@ -35,7 +38,12 @@ pub(super) fn parse_report(
             continue;
         }
         match serde_json::from_str::<Frame>(json) {
+            Ok(Frame::Inputs { hashes }) if !inputs_seen && !output_seen && hashes.len() <= 16 => {
+                inputs_seen = true;
+                result.input_hashes = hashes;
+            }
             Ok(Frame::Output { bytes }) => {
+                output_seen = true;
                 let output = result.output.as_mut().expect("output buffer");
                 let remaining = limit.saturating_sub(output.len());
                 output.extend(bytes.into_iter().take(remaining));
@@ -63,6 +71,9 @@ pub(super) fn parse_report(
         result.denial = Some("guest execution timed out".into());
     } else if invalid || !terminal || !shutdown {
         result.denial = Some("missing, ambiguous, or incomplete pilot execution report".into());
+    }
+    if invalid {
+        result.input_hashes.clear();
     }
     result
 }
@@ -105,6 +116,35 @@ mod tests {
         assert!(!failed.succeeded());
         assert_eq!(failed.exit_code, Some(7));
         assert_eq!(failed.output.unwrap(), b"failure");
+    }
+
+    #[test]
+    fn input_acknowledgement_is_single_and_precedes_workload_output() {
+        let ack = || Frame::Inputs {
+            hashes: vec![celln_manifest::Hash::of(b"data").0],
+        };
+        let valid = parse_report(
+            &console(&[ack(), Frame::Exit { code: 0 }]),
+            "cell".into(),
+            10,
+            false,
+            true,
+        );
+        assert!(valid.succeeded());
+        assert_eq!(valid.input_hashes.len(), 1);
+        for frames in [
+            vec![ack(), ack(), Frame::Exit { code: 0 }],
+            vec![
+                Frame::Output { bytes: vec![1] },
+                ack(),
+                Frame::Exit { code: 0 },
+            ],
+            vec![Frame::Exit { code: 0 }, ack()],
+        ] {
+            let invalid = parse_report(&console(&frames), "cell".into(), 10, false, true);
+            assert!(!invalid.succeeded());
+            assert!(invalid.input_hashes.is_empty());
+        }
     }
 
     #[test]

--- a/crates/celln-cli/src/dispatch_substrate.rs
+++ b/crates/celln-cli/src/dispatch_substrate.rs
@@ -93,6 +93,7 @@ pub(crate) fn launch_declared(
 ) -> Result<(LaunchOutcome, ResolvedBundle), String> {
     super::check_supported_authority(request)?;
     authorize(request, state_root)?;
+    let inputs = super::inputs::resolve(request, state_root)?;
     let resolved = super::resolve_bundle(request, mote_root, tool_root)?;
     let local_agent = local_agent_constraint(&resolved.program_hash, state_root)?;
     if resolved.format.as_deref() != Some("celln.warm-static-v1") {
@@ -120,8 +121,13 @@ pub(crate) fn launch_declared(
             "force_agent_lane": local_agent || request.execution.lane == celln_spec::RequestedLane::Agent,
             "allow_fetch": !request.capabilities.egress.is_empty(),
             "report_output_limit": request.capabilities.output_bytes,
+            "workspace_access": request.capabilities.workspace,
+            "inputs": inputs,
         }))
         .map_err(|e| e.to_string())?;
+        if run.len() > warden::MAX_INVOCATION_BYTES {
+            return Err("invocation exceeds bounded delivery channel".into());
+        }
         let key = format!(
             "{}:{}",
             resolved.bundle_hash, request.capabilities.memory_bytes
@@ -162,7 +168,7 @@ mod tests {
             "mote": { "hash": mote.0 },
             "tools": [{ "alias": "/tools/program", "hash": program.0 }],
             "invocation": { "alias": "/tools/program", "args": ["substrate"] },
-            "capabilities": { "workspace": "none", "timeoutMs": 8000, "memoryBytes": 268435456, "outputBytes": 1024 },
+            "capabilities": { "workspace": "read-only", "timeoutMs": 8000, "memoryBytes": 268435456, "outputBytes": 1024 },
             "execution": { "lane": "agent", "requireHardwareIsolation": true }
         })).unwrap()
     }
@@ -329,7 +335,7 @@ mod tests {
                 "/tools/program",
                 &program_bytes,
                 false,
-                celln_manifest::Author::Agent,
+                celln_manifest::Author::Host,
             )
             .unwrap();
         let toolfs = work.path().join("toolfs");
@@ -361,7 +367,10 @@ mod tests {
         )
         .unwrap();
         let mut base = std::fs::read(&initrd).unwrap();
-        base.extend(file_archive("substrate-marker", b"selected-substrate-A\n"));
+        base.extend(file_archive(
+            "celln/work/substrate-marker",
+            b"selected-substrate-A\n",
+        ));
         let motes = work.path().join("motes");
         let tools = work.path().join("tools");
         let store = Store::open(&motes).unwrap();
@@ -398,6 +407,7 @@ mod tests {
         let cold_elapsed = cold_started.elapsed();
         for arg in ["first", "second"] {
             let mut req = request(&bundle_hash, &program_hash);
+            req.capabilities.workspace = celln_spec::WorkspaceAccess::ReadWrite;
             req.invocation.as_mut().unwrap().args = vec!["warm".into(), arg.into()];
             let started = std::time::Instant::now();
             let (outcome, _) = launch_declared(&req, &motes, &tools, &state).unwrap();
@@ -411,6 +421,70 @@ mod tests {
                 preparations + 1
             );
             eprintln!("PASS: warm {arg}, private scratch, distinct args; cold={cold_elapsed:?}, warm={:?}", started.elapsed());
+        }
+
+        for (access, name) in [
+            (celln_spec::WorkspaceAccess::None, "none"),
+            (celln_spec::WorkspaceAccess::ReadOnly, "read-only"),
+            (celln_spec::WorkspaceAccess::ReadWrite, "read-write"),
+        ] {
+            let mut req = request(&bundle_hash, &program_hash);
+            req.capabilities.workspace = access;
+            // Host-authored manifest tool: this genuinely exercises the
+            // tool lane, not an agent-authored tool narrowed back to agent.
+            req.execution.lane = celln_spec::RequestedLane::Tool;
+            req.invocation.as_mut().unwrap().args = vec!["workspace".into(), name.into()];
+            let (outcome, _) = launch_declared(&req, &motes, &tools, &state).unwrap();
+            assert!(outcome.succeeded(), "{name}: {outcome:?}");
+            assert_eq!(
+                outcome.output.as_deref(),
+                Some(format!("workspace:{name}\n").as_bytes())
+            );
+            eprintln!("PASS: guest workspace {name}, root reads and scratch execution denied");
+        }
+        let mut fetch = request(&bundle_hash, &program_hash);
+        fetch.capabilities.egress = vec!["https://example.com".into()];
+        fetch.invocation.as_mut().unwrap().args = vec!["fetch-grant".into()];
+        let (outcome, _) = launch_declared(&fetch, &motes, &tools, &state).unwrap();
+        assert!(outcome.succeeded(), "{outcome:?}");
+        assert_eq!(
+            outcome.output.as_deref(),
+            Some(b"fetch-grant:host-refused-http\n".as_slice())
+        );
+        eprintln!("PASS: strict helper grant reaches host broker, which refuses plaintext HTTP");
+        let input_store = Store::open(state.join("inputs")).unwrap();
+        let first = input_store.put(b"first-input").unwrap();
+        let second = input_store.put(b"second-input").unwrap();
+        std::fs::write(
+            state.join("trusted-inputs.json"),
+            serde_json::to_vec(&json!({
+                "apiVersion": "celln.dev/v1alpha1", "hashes": [first.0, second.0]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        for (hash, data) in [(first, "first-input"), (second, "second-input")] {
+            let mut req = request(&bundle_hash, &program_hash);
+            req.capabilities.workspace = celln_spec::WorkspaceAccess::ReadWrite;
+            req.inputs.push(celln_spec::ExecutionInput {
+                name: "data".into(),
+                hash: hash.0.clone(),
+                media_type: "text/plain".into(),
+                bytes: data.len() as u64,
+            });
+            req.invocation.as_mut().unwrap().args = vec!["inputs".into(), data.into()];
+            let (outcome, _) = launch_declared(&req, &motes, &tools, &state).unwrap();
+            assert!(outcome.succeeded(), "{outcome:?}");
+            assert_eq!(outcome.input_hashes, vec![hash.0]);
+            assert_eq!(
+                outcome.output.as_deref(),
+                Some(format!("inputs:{data}\n").as_bytes())
+            );
+            assert_eq!(
+                super::super::warm::PREPARATIONS.load(std::sync::atomic::Ordering::SeqCst),
+                preparations + 1
+            );
+            eprintln!("PASS: immutable named input {data} delivered on same warm mote");
         }
 
         // Stop a real running guest without refreshing the end-to-end timer.

--- a/crates/celln-cli/src/node.rs
+++ b/crates/celln-cli/src/node.rs
@@ -180,7 +180,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn unsupported_workspace_is_not_admitted_on_an_eligible_node() {
+    fn bounded_workspace_modes_are_admitted_on_an_eligible_node() {
         let mut request: ExecutionRequest =
             serde_json::from_str(include_str!("../../../examples/execution/forge-task.json"))
                 .unwrap();
@@ -198,13 +198,9 @@ mod tests {
         };
         assert!(matches!(admit(&request, &node), Admission::Accepted { .. }));
         request.capabilities.workspace = celln_spec::WorkspaceAccess::ReadOnly;
-        assert!(matches!(
-            admit(&request, &node),
-            Admission::Refused {
-                reason: RefusalCode::Unsupported,
-                ..
-            }
-        ));
+        assert!(matches!(admit(&request, &node), Admission::Accepted { .. }));
+        request.capabilities.workspace = celln_spec::WorkspaceAccess::ReadWrite;
+        assert!(matches!(admit(&request, &node), Admission::Accepted { .. }));
     }
 
     #[test]

--- a/crates/celln-cli/tests/fixtures/dispatch_outcome_probe.rs
+++ b/crates/celln-cli/tests/fixtures/dispatch_outcome_probe.rs
@@ -10,7 +10,40 @@ unsafe extern "C" {
 fn main() {
     match std::env::args().nth(1).as_deref() {
         Some("silent") => {}
-        Some("substrate") => print!("{}", std::fs::read_to_string("/substrate-marker").unwrap()),
+        Some("fetch-grant") => {
+            let result = std::process::Command::new("/pilot-fetch")
+                .arg("http://example.com/").output().unwrap();
+            assert_eq!(result.status.code(), Some(1));
+            assert!(String::from_utf8_lossy(&result.stderr).contains("CELLN_FETCH_ERROR:"));
+            println!("fetch-grant:host-refused-http");
+        }
+        Some("workspace") => {
+            let access = std::env::args().nth(2).unwrap();
+            let marker = "/celln/work/substrate-marker";
+            assert_eq!(std::fs::read(marker).is_ok(), access != "none");
+            assert_eq!(std::fs::write("/celln/work/scratch", b"scratch").is_ok(), access == "read-write");
+            assert_eq!(std::fs::OpenOptions::new().write(true).truncate(true).open(marker).is_ok(), access == "read-write");
+            for forbidden in ["/celln/manifest.json", "/pilot", "/dev/console"] {
+                assert!(std::fs::read(forbidden).is_err(), "read {forbidden}");
+            }
+            if access == "read-write" {
+                std::fs::copy("/tools/program", "/celln/work/copied-program").unwrap();
+                assert!(std::process::Command::new("/celln/work/copied-program").arg("silent").status().is_err());
+            }
+            println!("workspace:{access}");
+        }
+        Some("inputs") => {
+            let expected = std::env::args().nth(2).unwrap();
+            assert_eq!(std::fs::read_to_string("/celln/inputs/data").unwrap(), expected);
+            assert!(std::fs::write("/celln/inputs/data", b"mutated").is_err());
+            assert!(std::fs::OpenOptions::new().write(true).truncate(true).open("/celln/inputs/data").is_err());
+            assert!(std::fs::rename("/celln/inputs/data", "/celln/work/moved").is_err());
+            assert!(std::fs::hard_link("/celln/inputs/data", "/celln/work/linked").is_err());
+            assert!(std::fs::read("/celln/inputs/unrequested").is_err());
+            assert!(std::process::Command::new("/celln/inputs/data").status().is_err());
+            println!("inputs:{expected}");
+        }
+        Some("substrate") => print!("{}", std::fs::read_to_string("/celln/work/substrate-marker").unwrap()),
         Some("warm") => {
             // Try the supervisor-only PIO port after exec: it must fault,
             // proving pilot revoked the I/O bitmap grant before the workload.

--- a/crates/celln-pilot/src/dispatch_report.rs
+++ b/crates/celln-pilot/src/dispatch_report.rs
@@ -3,11 +3,12 @@
 use serde::{Deserialize, Serialize};
 
 pub const PREFIX: &str = "CELLN:dispatch=";
-pub const PROTOCOL: &str = "CELLN:dispatch-protocol=3";
+pub const PROTOCOL: &str = "CELLN:dispatch-protocol=4";
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Frame {
+    Inputs { hashes: Vec<String> },
     Output { bytes: Vec<u8> },
     Exit { code: i32 },
     Signal { signal: i32 },

--- a/crates/celln-pilot/src/guest.rs
+++ b/crates/celln-pilot/src/guest.rs
@@ -66,6 +66,7 @@ const LANDLOCK_ACCESS_FS_MAKE_FIFO: u64 = 1 << 10;
 const LANDLOCK_ACCESS_FS_MAKE_BLOCK: u64 = 1 << 11;
 const LANDLOCK_ACCESS_FS_MAKE_SYM: u64 = 1 << 12;
 const LANDLOCK_ACCESS_FS_REFER: u64 = 1 << 13;
+const LANDLOCK_ACCESS_FS_TRUNCATE: u64 = 1 << 14;
 
 // Linux capability UAPI. The v3 capset layout has two 32-bit words and is the
 // current ABI even on 64-bit machines.
@@ -142,7 +143,13 @@ fn enter_root(root: &str) -> io::Result<()> {
 /// initramfs scratch dir; inside one it is the tmpfs the caller mounted over
 /// the image's own `/tmp`, because the image itself is read-only by hardware
 /// and nothing in it can be written to.
-fn enter_agent_lane(workspace: &str, exec_path: &str, allow_fetch: bool) -> io::Result<()> {
+fn enter_agent_lane(
+    workspace: &str,
+    exec_path: &str,
+    allow_fetch: bool,
+    access: Option<WorkspaceAccess>,
+    has_inputs: bool,
+) -> io::Result<()> {
     if allow_fetch {
         // CAP_SYS_RAWIO also authorises legacy device-node interfaces that
         // would bypass the ioperm argument filter. Pilot no longer needs them
@@ -162,7 +169,13 @@ fn enter_agent_lane(workspace: &str, exec_path: &str, allow_fetch: bool) -> io::
             return Err(io::Error::last_os_error());
         }
         let rules = LandlockRulesetAttr {
-            handled_access_fs: FS_ALL,
+            // Strict dispatch requires ABI 3; unsupported kernels fail closed.
+            handled_access_fs: FS_ALL
+                | if access.is_some() {
+                    LANDLOCK_ACCESS_FS_TRUNCATE
+                } else {
+                    0
+                },
         };
         let ruleset = libc::syscall(
             LANDLOCK_CREATE_RULESET,
@@ -209,29 +222,61 @@ fn enter_agent_lane(workspace: &str, exec_path: &str, allow_fetch: bool) -> io::
             exec_path,
             LANDLOCK_ACCESS_FS_EXECUTE | LANDLOCK_ACCESS_FS_READ_FILE,
         )?;
-        // pilot-fetch uses I/O ports to talk to the host broker, not sockets.
-        // On the stock guest kernel, Landlock only authorises execve from this
-        // initramfs when EXECUTE is granted on its root hierarchy; a rule for
-        // the binary or its directory still returns EACCES. The kernel also
-        // requires READ_FILE for this static execve. The image is immutable;
-        // write access remains limited to the workspace, and egress remains
-        // host-authorised by the broker.
-        // READ_DIR as well as READ_FILE: a real tool resolves its own runtime
-        // by walking directories (python locates `encodings` before it can
-        // start), and without it the interpreter dies before running anything.
-        // It grants no reach a READ_FILE on this hierarchy did not already —
-        // inside a chroot the hierarchy is the one image being lent.
-        add(
-            "/",
-            LANDLOCK_ACCESS_FS_EXECUTE | LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR,
-        )?;
-        add(workspace, FS_ALL)?;
+        // Static dispatch needs only the verified executable and, if lent,
+        // pilot-fetch. Do not inherit the legacy runtime's root-wide grant:
+        // interpreter/closure support needs its own explicit admission design.
+        if let Some(access) = access {
+            // Child-process libraries open /dev/null for unused standard
+            // streams. This exact sink/source grants no console or host data.
+            add(
+                "/dev/null",
+                LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_WRITE_FILE,
+            )?;
+            if allow_fetch {
+                add(
+                    "/pilot-fetch",
+                    LANDLOCK_ACCESS_FS_EXECUTE | LANDLOCK_ACCESS_FS_READ_FILE,
+                )?;
+            }
+            let read = LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR;
+            match access {
+                WorkspaceAccess::None => {}
+                WorkspaceAccess::ReadOnly => add(workspace, read)?,
+                WorkspaceAccess::ReadWrite => add(
+                    workspace,
+                    (FS_ALL | LANDLOCK_ACCESS_FS_TRUNCATE)
+                        & !LANDLOCK_ACCESS_FS_EXECUTE
+                        & !LANDLOCK_ACCESS_FS_MAKE_CHAR
+                        & !LANDLOCK_ACCESS_FS_MAKE_BLOCK
+                        & !LANDLOCK_ACCESS_FS_MAKE_SOCK,
+                )?,
+            }
+        } else {
+            // Legacy closure/CLI requests retain their existing root policy.
+            add(
+                "/",
+                LANDLOCK_ACCESS_FS_EXECUTE
+                    | LANDLOCK_ACCESS_FS_READ_FILE
+                    | LANDLOCK_ACCESS_FS_READ_DIR,
+            )?;
+            add(workspace, FS_ALL)?;
+        }
+        if has_inputs {
+            add(
+                "/celln/inputs",
+                LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR,
+            )?;
+        }
         if libc::syscall(LANDLOCK_RESTRICT_SELF, ruleset, 0) != 0 {
             return Err(io::Error::last_os_error());
         }
         libc::close(ruleset);
-        let work =
-            CString::new(workspace).map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+        let work = CString::new(if access == Some(WorkspaceAccess::None) {
+            "/"
+        } else {
+            workspace
+        })
+        .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
         if libc::chdir(work.as_ptr()) != 0 {
             return Err(io::Error::last_os_error());
         }
@@ -516,6 +561,22 @@ const TOOLS_DIR: &str = "/celln/tools";
 /// else regardless of how it arrived.
 const RUN_REQUEST: &str = "/celln/run.json";
 
+#[derive(Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum WorkspaceAccess {
+    None,
+    ReadOnly,
+    ReadWrite,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InputData {
+    name: String,
+    hash: String,
+    data: Vec<u8>,
+}
+
 #[derive(Deserialize)]
 struct RunRequest {
     /// Where the bytes live in the cell — normally on the sealed DAX mount.
@@ -554,6 +615,10 @@ struct RunRequest {
     /// Bind the selected sealed file to the host's declared content identity.
     #[serde(default)]
     expected_hash: Option<String>,
+    #[serde(default)]
+    workspace_access: Option<WorkspaceAccess>,
+    #[serde(default)]
+    inputs: Vec<InputData>,
 }
 
 /// One cell can be asked to run several tools. Each invocation is hash-checked
@@ -582,6 +647,10 @@ struct RunFile {
     force_agent_lane: bool,
     #[serde(default)]
     expected_hash: Option<String>,
+    #[serde(default)]
+    workspace_access: Option<WorkspaceAccess>,
+    #[serde(default)]
+    inputs: Vec<InputData>,
 }
 
 impl RunFile {
@@ -609,6 +678,8 @@ impl RunFile {
                 report_output_limit: self.report_output_limit,
                 force_agent_lane: self.force_agent_lane,
                 expected_hash: self.expected_hash,
+                workspace_access: self.workspace_access,
+                inputs: self.inputs,
             }],
             _ => Vec::new(),
         }
@@ -760,13 +831,19 @@ fn exec_open_file(file: &File, req: &RunRequest, confine: bool) -> io::Result<Ex
                 child_error(error_pipe[1], error);
             }
         }
-        if confine {
+        if confine || req.workspace_access.is_some() {
             let workspace = if req.root.is_some() {
                 "/tmp"
             } else {
                 WORKSPACE
             };
-            if let Err(error) = enter_agent_lane(workspace, &req.path, req.allow_fetch) {
+            if let Err(error) = enter_agent_lane(
+                workspace,
+                &req.path,
+                req.allow_fetch,
+                req.workspace_access,
+                !req.inputs.is_empty(),
+            ) {
                 child_error(error_pipe[1], error);
             }
         }
@@ -1013,7 +1090,7 @@ fn warm_invocation() -> io::Result<Vec<u8>> {
     }
     let len = u32::from_le_bytes(unsafe { [read_byte(), read_byte(), read_byte(), read_byte()] })
         as usize;
-    let result = if (1..=65536).contains(&len) {
+    let result = if (1..=warden::MAX_INVOCATION_BYTES).contains(&len) {
         Ok((0..len).map(|_| unsafe { read_byte() }).collect())
     } else {
         Err(io::Error::new(
@@ -1028,7 +1105,64 @@ fn warm_invocation() -> io::Result<Vec<u8>> {
     result
 }
 
+fn stage_inputs(req: &RunRequest) -> io::Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+    if req.inputs.is_empty() {
+        return Ok(());
+    }
+    let bad = || io::Error::new(io::ErrorKind::InvalidInput, "invalid input delivery");
+    if req.root.is_some()
+        || !matches!(
+            req.workspace_access,
+            Some(WorkspaceAccess::ReadOnly | WorkspaceAccess::ReadWrite)
+        )
+        || req.inputs.len() > 16
+    {
+        return Err(bad());
+    }
+    let mut names = std::collections::BTreeSet::new();
+    let mut total = 0usize;
+    for input in &req.inputs {
+        if input.name.is_empty()
+            || input.name.len() > 64
+            || matches!(input.name.as_str(), "." | "..")
+            || !input.name.bytes().all(|b| {
+                b.is_ascii_lowercase() || b.is_ascii_digit() || matches!(b, b'.' | b'_' | b'-')
+            })
+            || !names.insert(&input.name)
+            || Hash::of(&input.data).0 != input.hash
+        {
+            return Err(bad());
+        }
+        total = total.checked_add(input.data.len()).ok_or_else(bad)?;
+        if total > 65536 {
+            return Err(bad());
+        }
+    }
+    std::fs::create_dir("/celln/inputs")?;
+    for input in &req.inputs {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o444)
+            .open(format!("/celln/inputs/{}", input.name))?;
+        file.write_all(&input.data)?;
+    }
+    Ok(())
+}
+
 fn run_one(manifest: &Manifest, req: &RunRequest) {
+    if stage_inputs(req).is_err() {
+        emit(Frame::Failed {
+            reason: "input delivery refused".into(),
+        });
+        return;
+    }
+    if req.report_output_limit.is_some() {
+        emit(Frame::Inputs {
+            hashes: req.inputs.iter().map(|i| i.hash.clone()).collect(),
+        });
+    }
     // Where pilot itself can read the bytes, which is not where the child will
     // exec them from: the child is chroot'ed, so its `/usr/bin/x` is pilot's
     // `/tools/usr/bin/x`. Open once before any chroot, hash that descriptor,
@@ -1183,6 +1317,8 @@ mod tests {
             report_output_limit: None,
             force_agent_lane: false,
             expected_hash: None,
+            workspace_access: None,
+            inputs: Vec::new(),
         };
         let status = exec_open_file(&verified, &request, false).expect("executes verified fd");
         assert!(

--- a/crates/celln-spec/src/lib.rs
+++ b/crates/celln-spec/src/lib.rs
@@ -495,7 +495,7 @@ impl ExecutionRequest {
                 problems.push(ExecutionProblem {
                     code: ExecutionProblemCode::InvalidInputName,
                     field: format!("{prefix}.name"),
-                    message: "must be a non-empty lowercase name containing only letters, numbers, dots, underscores, or hyphens".into(),
+                    message: "must be a 1–64 byte lowercase name containing only letters, numbers, dots, underscores, or hyphens, other than . or ..".into(),
                 });
             }
             if !is_immutable_hash(&input.hash) {
@@ -708,6 +708,8 @@ fn is_immutable_hash(value: &str) -> bool {
 
 fn is_input_name(value: &str) -> bool {
     !value.is_empty()
+        && value.len() <= 64
+        && !matches!(value, "." | "..")
         && value.bytes().all(|byte| {
             byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
         })

--- a/crates/celln-store/src/lib.rs
+++ b/crates/celln-store/src/lib.rs
@@ -10,10 +10,13 @@
 use celln_manifest::Hash;
 use std::fs;
 use std::io;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, thiserror::Error)]
 pub enum StoreError {
+    #[error("object exceeds the {0}-byte input limit")]
+    TooLarge(usize),
     #[error("io error: {0}")]
     Io(#[from] io::Error),
     #[error("object not found: {0}")]
@@ -87,11 +90,22 @@ impl Store {
 
     /// Fetch bytes by hash, verifying integrity on the way out.
     pub fn get(&self, hash: &Hash) -> Result<Vec<u8>, StoreError> {
+        self.get_bounded(hash, usize::MAX)
+    }
+
+    /// Bound allocation before reading an input, not after trusting its size.
+    pub fn get_bounded(&self, hash: &Hash, limit: usize) -> Result<Vec<u8>, StoreError> {
         let path = self.path_for(hash)?;
         if !path.exists() {
             return Err(StoreError::NotFound(hash.clone()));
         }
-        let bytes = fs::read(&path)?;
+        let mut bytes = Vec::new();
+        fs::File::open(&path)?
+            .take(limit.saturating_add(1) as u64)
+            .read_to_end(&mut bytes)?;
+        if bytes.len() > limit {
+            return Err(StoreError::TooLarge(limit));
+        }
         let actual = Hash::of(&bytes);
         if &actual != hash {
             return Err(StoreError::Integrity {
@@ -119,6 +133,25 @@ mod tests {
         let h = store.put(b"print(1+1)").unwrap();
         assert!(store.has(&h));
         assert_eq!(store.get(&h).unwrap(), b"print(1+1)");
+    }
+
+    #[test]
+    fn bounded_reads_accept_exact_size_and_refuse_excess_before_integrity() {
+        let dir = tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+        let hash = store.put(b"data").unwrap();
+        assert_eq!(store.get_bounded(&hash, 4).unwrap(), b"data");
+        assert!(matches!(
+            store.get_bounded(&hash, 3),
+            Err(StoreError::TooLarge(3))
+        ));
+        fs::write(store.path_for(&hash).unwrap(), [0; 1024]).unwrap();
+        assert!(matches!(
+            store.get_bounded(&hash, 4),
+            Err(StoreError::TooLarge(4))
+        ));
+        let empty = store.put(b"").unwrap();
+        assert!(store.get_bounded(&empty, 0).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/celln-warden/src/lib.rs
+++ b/crates/celln-warden/src/lib.rs
@@ -12,6 +12,8 @@
 pub mod egress;
 pub mod ratchet;
 pub mod vmm;
+/// Maximum one-shot invocation data, including bounded immutable inputs.
+pub const MAX_INVOCATION_BYTES: usize = 1 << 20;
 
 pub use ratchet::{Phase, Ratchet, Verb};
 pub use vmm::{Vmm, VmmError};

--- a/crates/celln-warden/src/vmm/boot.rs
+++ b/crates/celln-warden/src/vmm/boot.rs
@@ -1027,7 +1027,10 @@ impl LinuxCell {
     /// Deliver bounded data to pilot after a warm fork. Port 0x510 returns
     /// little-endian u32 length followed by opaque JSON bytes, once only.
     pub fn set_invocation(&mut self, bytes: &[u8]) -> Result<(), VmmError> {
-        if bytes.is_empty() || bytes.len() > 65536 || self.invocation.is_some() {
+        if bytes.is_empty()
+            || bytes.len() > crate::MAX_INVOCATION_BYTES
+            || self.invocation.is_some()
+        {
             return Err(VmmError::Backend(
                 "invalid or repeated invocation delivery".into(),
             ));
@@ -1713,7 +1716,9 @@ mod tests {
         };
         let mut cell = LinuxCell::boot(BootConfig::new(kernel)).unwrap();
         assert!(cell.set_invocation(&[]).is_err());
-        assert!(cell.set_invocation(&vec![0; 65537]).is_err());
+        assert!(cell
+            .set_invocation(&vec![0; crate::MAX_INVOCATION_BYTES + 1])
+            .is_err());
         cell.set_invocation(b"{}").unwrap();
         assert!(cell.set_invocation(b"replacement").is_err());
         assert!(cell.park().is_err());

--- a/docs/DECLARED_SUBSTRATES.md
+++ b/docs/DECLARED_SUBSTRATES.md
@@ -66,14 +66,15 @@ Preparation appends a fixed `/celln/dispatch-warm` mode flag to the base initrd,
 boots once with sealed tools and no egress grant, and parks at init's
 `CELLN:mote=parked` boundary before pilot executes. Every execution forks this
 template, including the first. Per-request JSON arrives after the fork through
-PIO port `0x510`: four little-endian length bytes followed by at most 64 KiB of
+PIO port `0x510`: four little-endian length bytes followed by at most 1 MiB of
 data. The stream is host-owned and one-shot. Pilot revokes the I/O bitmap grant
 before parsing or executing. No arguments, requested egress authority or output
 from one cell are snapshotted for another. No executable, module or manifest is
 overlaid. Future receipts should record the invocation digest too.
 
-Use pilot dispatch protocol 3, which enforces `expected_hash` and implements the
-warm invocation channel. Pinning a bundle
+Use pilot dispatch protocol 4, which enforces `expected_hash`, implements the
+warm invocation channel and acknowledges staged immutable inputs. Protocol 4
+also applies explicit workspace confinement to every dispatcher lane. Pinning a bundle
 asserts its pilot implements that protocol and its boot code preserves the
 invocation seam. Host and pilot must be upgraded together. Legacy bundle
 descriptors can still be inspected by `resolve-file`, but cannot launch without

--- a/docs/DISPATCH_INPUTS.md
+++ b/docs/DISPATCH_INPUTS.md
@@ -1,0 +1,78 @@
+# Bounded dispatcher inputs and workspace authority
+
+The static dispatcher supports up to 16 immutable named inputs, at most 65,536
+bytes in total. It does not mount a caller's host path or accept a URL as a
+provider. Input names are single lowercase ASCII components of 1–64 bytes,
+using letters, digits, `.`, `_`, or `-`, excluding `.` and `..`.
+
+## Host provisioning
+
+The operator places input bytes in the content-addressed store under
+`<state-root>/inputs` (the ordinary `objects/<prefix>/<digest>` layout) and
+approves hashes in `<state-root>/trusted-inputs.json`:
+
+```json
+{
+  "apiVersion": "celln.dev/v1alpha1",
+  "hashes": ["blake3:<64-lowercase-hex-digits>"]
+}
+```
+
+This is host-owned policy, not request-controlled configuration. A stored hash
+is not permission. Missing/invalid policy, unapproved or missing objects,
+corruption, mismatched byte counts and oversized requests refuse explicitly.
+Reads are bounded before allocation. The policy is re-read for each execution,
+including warm-cache hits; removing an approval prevents future deliveries but
+does not withdraw bytes already lent to a running cell. Inputs are ordinary
+data, not a secret-delivery mechanism. Secret leases and live withdrawal remain
+unimplemented (#7).
+
+An execution declares each input's `name`, `hash`, `mediaType`, and exact `bytes`,
+and requests `read-only` or `read-write` workspace access. Inputs combined with
+`workspace: "none"` are refused. Pilot receives verified bytes over the bounded
+post-fork invocation stream, rehashes them, and creates fresh
+`/celln/inputs/<name>` files. A pre-existing input directory fails closed rather
+than mixing template data with requested data. No input bytes enter the warm
+mote snapshot. Pilot reports the staged hashes before workload output; receipts
+only retain hashes that exactly match the resolved request.
+
+## Guest authority
+
+Every dispatcher lane uses the same filesystem confinement. The lane still
+records tool provenance; choosing the tool lane does not expand filesystem
+authority. Only the verified executable and an explicitly lent `pilot-fetch`
+helper receive executable access. Tool closures and multiple tools remain
+unsupported.
+The exact `/dev/null` node remains readable/writable for child-process standard
+streams; this does not grant access to the console or other device nodes.
+
+| Workspace mode | `/celln/work` | `/celln/inputs` |
+| --- | --- | --- |
+| `none` | No read/write grant; cwd `/` | Inputs refused |
+| `read-only` | Read/list; no creation, write or truncate | Requested inputs read-only |
+| `read-write` | Private scratch read/write/create/truncate | Requested inputs still read-only |
+
+No mode grants execution from workspace or input paths. Root-wide reads,
+device creation, and socket creation are not granted. Landlock ABI 3 is required
+so truncation is mediated; a kernel unable to install confinement refuses
+execution. These are guest-kernel-enforced workload restrictions, not a claim
+that data in writable guest RAM has stage-2 sealing. Tool code retains the
+separate stage-2 guarantee. Legacy non-dispatch CLI/image behavior is unchanged.
+
+## Compatibility and evidence
+
+Dispatcher host and pilot must use protocol 4 together. Repin/rebuild declared
+bundles when upgrading from protocol 3; older reports cannot establish success.
+The invocation transport cap grows from 64 KiB to 1 MiB to accommodate JSON
+encoding of bounded input bytes; the raw input budget remains 64 KiB.
+
+Run `cargo test -p celln-cli declared_substrate_on_real_kvm -- --ignored --nocapture`
+after building the static pilot binaries. The guest actually tries forbidden
+reads, writes, truncation, rename/hard-link and execution; it also checks two
+different inputs across forks of one warm mote. On 2026-09-06 this passed on
+the development KVM host (Linux 7.1.12-200.fc44.x86_64, Rust 1.98.0) alongside existing substrate, isolation, cancellation,
+deadline and mismatch probes. Host tests cover authorization, exact sizes,
+missing/corrupt objects, path names and malformed input acknowledgements.
+The strict helper probe also executes `pilot-fetch`, reaches the host broker,
+and observes its refusal of plaintext HTTP without making an external request.
+This is one part of #3/#7, not completion of the external integration epic.

--- a/docs/DISPATCH_RESULTS.md
+++ b/docs/DISPATCH_RESULTS.md
@@ -54,16 +54,18 @@ job runs the guest proof when KVM is available.
 
 The transport schema describes more authority than the runtime currently
 delivers. Node admission, HTTP submission, direct bundle resolution and launch
-refuse inputs, read-only/read-write workspace requests, tool closures and
-multiple tools. HTTP returns 422 with `reason: "unsupported"` and a diagnostic
+refuse tool closures, multiple tools and input requests outside the bounded
+provider described in [Dispatcher inputs](DISPATCH_INPUTS.md).
+HTTP returns 422 with `reason: "unsupported"` and a diagnostic
 before reserving capacity or starting model, store or VM work. The worker
 also checks before forging, for callers that bypass HTTP. These are temporary
 runtime restrictions, not removals from the versioned schema.
 
-Receipts contain no input hashes until a provider actually resolves and delivers
-the bytes. `workspace: "none"` means no caller workspace is delivered; it does
-not claim that all guest scratch filesystems are unwritable. Delivery and guest
-enforcement proofs remain in #3/#7; closure loading remains in #6.
+Receipts record input hashes only after host resolution and matching pilot
+acknowledgement of staged bytes. Dispatcher workspace modes are now enforced
+by Landlock, including truncation and execution denial; `none` grants no
+filesystem workspace. This does not change the legacy CLI/closure policy.
+Secret providers and live withdrawal remain in #7; closure loading remains in #6.
 
 This completes the outcome and unsupported-input/closure refusal slices of #13.
 Declared execution now forks an operator-pinned warm substrate with a separate


### PR DESCRIPTION
## Summary

Implements the bounded immutable-input and workspace-enforcement slice of #3/#7, stacked on #60. Advances #13 and actual input provenance in #10; does not close the integration epic #2.

- Host-owned input allowlist, bounded content-addressed reads, exact size/hash validation, safe names and a 16-input/64-KiB aggregate budget.
- Per-cell input delivery over the existing post-fork channel, pilot rehash/staging acknowledgement, and receipts recording only matching acknowledged hashes.
- Strict Landlock workspace none/read-only/read-write in both dispatcher lanes. No root-wide read/execute grant; no execution from scratch/input paths. Exact executable, optional fetch helper and /dev/null grants preserve static-tool operation.
- Explicit protocol 4 upgrade, 1-MiB encoded invocation cap, and provisioning/compatibility documentation.

## Evidence

- `make ci`: pass (format, clippy, build, tests).
- Real KVM declared-substrate proof: pass, including guest attempts at forbidden reads, writes, truncation, scratch execution, input mutation/movement/linking/execution; distinct input bytes on one warm mote; host-authored tool-lane confinement; strict fetch-helper broker refusal.
- Real KVM dispatcher outcome suite: pass (silent/nonzero/signal/spoof/flood/timeout/refusal).
- `make acceptance-kvm fetch-proof`: pass on development KVM host.
- Environment: Linux 7.1.12-200.fc44.x86_64, Rust 1.98.0. Hosted CI may skip hardware proofs; local guest attempts are the hardware evidence.

## Scope and migration

Upgrade host and pilot together and repin protocol-4 bundles. Legacy CLI/image policy is unchanged. Inputs are ordinary immutable data, not secrets; removing an input approval prevents future deliveries, not withdrawal from a running cell. Secret providers/live withdrawal (#7), aggregate node resource accounting (#5), full provenance (#10), and integrated conformance/external Sympozium proof (#12/#2) remain open. Tool closures/multiple-tool requests still refuse.
