### PR TITLE
Reserve aggregate node resources and report configured readiness

### DIFF
--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -17,7 +17,7 @@ pub(crate) use substrate::launch_declared;
 pub(crate) mod inputs;
 #[cfg(target_os = "linux")]
 #[path = "dispatch_warm.rs"]
-mod warm;
+pub(crate) mod warm;
 
 /// The serializable substrate descriptor stored under `ExecutionRequest.mote`.
 /// Each referenced object is resolved by content hash before the VMM is given
@@ -395,7 +395,15 @@ pub fn launch(
         .with_pmem(payload.len())
         .with_initrd(&initrd);
     let invocation = std::fs::read(run_json).map_err(|e| e.to_string())?;
-    run_prepared(request, alias, cfg, payload, &invocation, state_root)
+    run_prepared(
+        request,
+        alias,
+        cfg,
+        payload,
+        &invocation,
+        state_root,
+        Hash::of(program_bytes).0,
+    )
 }
 
 #[cfg(target_os = "linux")]
@@ -406,6 +414,7 @@ fn run_prepared(
     payload: Vec<u8>,
     invocation: &[u8],
     state_root: &Path,
+    program_hash: String,
 ) -> Result<LaunchOutcome, String> {
     if invocation.len() > warden::MAX_INVOCATION_BYTES {
         return Err("invocation exceeds bounded delivery channel".into());
@@ -424,7 +433,7 @@ fn run_prepared(
         Hash::of(&payload),
         cfg.mem_size
     );
-    let mut cell = warm::fork(key, || Ok((cfg, payload)))?;
+    let mut cell = warm::fork(key, vec![program_hash], || Ok((cfg, payload)))?;
     cell.set_invocation(invocation).map_err(|e| e.to_string())?;
     run_cell(request, alias, cell, state_root)
 }

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -92,6 +92,7 @@ struct Entry<T> {
     at: Instant,
     value: T,
     control: Option<celln_control::Control>,
+    reservation: Option<Reservation>,
 }
 
 impl<T> Entry<T> {
@@ -100,6 +101,7 @@ impl<T> Entry<T> {
             at: Instant::now(),
             value,
             control: None,
+            reservation: None,
         }
     }
 }
@@ -133,6 +135,60 @@ pub struct ExecutionRecord {
 }
 
 type Executions = Arc<Mutex<HashMap<String, Entry<ExecutionRecord>>>>;
+
+/// Reserve the full declared guest RAM and one synchronous broker per cell
+/// with egress. Destinations share that broker; they are not concurrent slots.
+#[derive(Clone, Copy)]
+struct Reservation {
+    memory_bytes: u64,
+    egress_slots: u32,
+}
+
+impl Reservation {
+    fn for_request(request: &ExecutionRequest) -> Self {
+        Self {
+            memory_bytes: request.capabilities.memory_bytes,
+            egress_slots: u32::from(!request.capabilities.egress.is_empty()),
+        }
+    }
+}
+
+fn apply_reservations(
+    node: &mut crate::node::NodeEligibility,
+    registry: &HashMap<String, Entry<ExecutionRecord>>,
+    other_live_cells: u32,
+) {
+    node.live_cells = other_live_cells;
+    // Legacy/other-process records do not carry resource declarations. Do
+    // not invent spare capacity when a live owner's usage is unknown.
+    if other_live_cells != 0 {
+        node.memory_bytes = 0;
+        node.egress_slots = 0;
+    }
+    for entry in registry
+        .values()
+        .filter(|entry| execution_is_active(&entry.value))
+    {
+        node.live_cells = node.live_cells.saturating_add(1);
+        if let Some(reservation) = entry.reservation {
+            node.memory_bytes = node.memory_bytes.saturating_sub(reservation.memory_bytes);
+            node.egress_slots = node.egress_slots.saturating_sub(reservation.egress_slots);
+        } else {
+            node.memory_bytes = 0;
+            node.egress_slots = 0;
+        }
+    }
+}
+
+fn current_node(
+    state: &State,
+    registry: &HashMap<String, Entry<ExecutionRecord>>,
+) -> crate::node::NodeEligibility {
+    let mut node = crate::node::NodeEligibility::from_probe(&state.probe, 0);
+    let other = crate::cells::live_count_excluding_pid(&state.root, Some(std::process::id()));
+    apply_reservations(&mut node, registry, other);
+    node
+}
 
 struct State {
     token: String,
@@ -232,6 +288,9 @@ pub fn serve(
     if token.len() < 24 {
         bail!("dispatcher token must contain at least 24 non-whitespace bytes");
     }
+    // Reservations are process-local. Two dispatchers must not independently
+    // advertise the same state root's capacity while neither has a cell yet.
+    let _ownership = own_dispatch_root(&root)?;
     let listener = TcpListener::bind(listen_address)
         .with_context(|| format!("binding dispatcher {listen_address}"))?;
     let state = Arc::new(State {
@@ -263,6 +322,29 @@ pub fn serve(
     Ok(crate::exit::OK)
 }
 
+fn own_dispatch_root(root: &Path) -> Result<std::fs::File> {
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        std::fs::create_dir_all(root)?;
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(root.join("dispatcher.lock"))?;
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+            bail!("dispatcher state root is already owned or cannot be locked");
+        }
+        Ok(file)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = root;
+        bail!("dispatcher ownership locking is unsupported on this host")
+    }
+}
+
 fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
     let mut reader = BufReader::new(stream.try_clone()?);
     let request_line = read_bounded_line(&mut reader, MAX_REQUEST_LINE)?;
@@ -291,18 +373,45 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
         );
     }
     match (method.as_str(), path.as_str()) {
-        ("GET", "/v1/health") => {
-            let has_kvm = Path::new("/dev/kvm").exists();
-            let motes = Path::new("/var/lib/celln/motes");
-            let tools = Path::new("/var/lib/celln/tools");
+        ("GET", "/v1/node") => {
+            let registry = state
+                .executions
+                .lock()
+                .expect("dispatcher registry not poisoned");
+            let node = current_node(state, &registry);
+            #[cfg(target_os = "linux")]
+            let warm = crate::dispatch::warm::availability();
+            #[cfg(not(target_os = "linux"))]
+            let warm: Option<Vec<String>> = None;
             reply(
                 &mut stream,
                 200,
                 &serde_json::json!({
-                    "ok": has_kvm,
-                    "kvm": has_kvm,
-                    "mote_store": motes.exists() && motes.read_dir().map(|mut d| d.next().is_some()).unwrap_or(false),
-                    "tool_store": tools.exists() && tools.read_dir().map(|mut d| d.next().is_some()).unwrap_or(false),
+                    "node": node, "warm": warm, "availability_is_advisory": true,
+                    "preflight_only": true,
+                    "configured_memory_bytes": state.probe.memory_bytes,
+                    "configured_egress_slots": state.probe.egress_slots,
+                }),
+            )
+        }
+        ("GET", "/v1/health") => {
+            let registry = state
+                .executions
+                .lock()
+                .expect("dispatcher registry not poisoned");
+            let node = current_node(state, &registry);
+            reply(
+                &mut stream,
+                200,
+                &serde_json::json!({
+                    "ok": node.eligible(),
+                    "kvm": node.kvm,
+                    "mote_store": node.mote_store,
+                    "tool_store": node.tool_store,
+                    "node": node,
+                    "configured_memory_bytes": state.probe.memory_bytes,
+                    "configured_egress_slots": state.probe.egress_slots,
+                    "preflight_only": true,
                 }),
             )
         }
@@ -376,16 +485,7 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
             // request before any worker has created its cell. Registry entries
             // cover pre-cell work such as forging too, so accepted work cannot
             // overcommit the node while waiting to launch.
-            let reserved_cells: u32 = registry
-                .values()
-                .filter(|entry| execution_is_active(&entry.value))
-                .count()
-                .try_into()
-                .unwrap_or(u32::MAX);
-            let other_live_cells =
-                crate::cells::live_count_excluding_pid(&state.root, Some(std::process::id()));
-            let live_cells = reserved_cells.saturating_add(other_live_cells);
-            let node = crate::node::NodeEligibility::from_probe(&state.probe, live_cells);
+            let node = current_node(state, &registry);
             if let crate::node::Admission::Refused { reason, .. } =
                 crate::node::admit(&request, &node)
             {
@@ -405,12 +505,13 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
             }
             let mut entry = Entry::new(record.clone());
             entry.control = Some(control.clone());
+            entry.reservation = Some(Reservation::for_request(&request));
             registry.insert(request.id.clone(), entry);
             drop(registry);
             let worker_executions = Arc::clone(&state.executions);
             let probe = state.probe.clone();
             let root = state.root.clone();
-            thread::spawn(move || {
+            let worker = thread::Builder::new().spawn(move || {
                 control.scope(|| {
                     let id = request.id.clone();
                     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -425,6 +526,18 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
                     }
                 })
             });
+            if worker.is_err() {
+                fail_execution(
+                    &state.executions,
+                    &record.request_id,
+                    "execution worker unavailable".into(),
+                );
+                return reply(
+                    &mut stream,
+                    503,
+                    &serde_json::json!({"error": "execution worker unavailable"}),
+                );
+            }
             reply(&mut stream, 202, &record)
         }
         ("POST", path) if path.starts_with("/v1/executions/") && path.ends_with("/cancel") => {
@@ -693,6 +806,133 @@ mod tests {
                 egress_slots: 0,
             },
             executions: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    #[test]
+    fn a_state_root_has_one_dispatcher_owner_and_releases_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let owner = own_dispatch_root(dir.path()).unwrap();
+        assert!(own_dispatch_root(dir.path()).is_err());
+        drop(owner);
+        assert!(own_dispatch_root(dir.path()).is_ok());
+    }
+
+    fn eligible_node(memory: u64, egress: u32) -> crate::node::NodeEligibility {
+        crate::node::NodeEligibility {
+            node_name: "test".into(),
+            kvm: true,
+            cpu_virtualization: true,
+            guest_kernel: true,
+            mote_store: true,
+            tool_store: true,
+            live_cells: 0,
+            max_cells: 100,
+            memory_bytes: memory,
+            egress_slots: egress,
+        }
+    }
+
+    #[test]
+    fn concurrent_admission_cannot_overcommit_memory_or_brokers() {
+        for (destinations, expected) in [(vec![], 2), (vec!["https://example.com"], 1)] {
+            let registry: Executions = Arc::new(Mutex::new(HashMap::new()));
+            let barrier = Arc::new(std::sync::Barrier::new(16));
+            let mut workers = Vec::new();
+            for index in 0..16 {
+                let registry = registry.clone();
+                let barrier = barrier.clone();
+                let mut request = request_with_egress(&destinations);
+                request.id = format!("request-{index}");
+                workers.push(thread::spawn(move || {
+                    barrier.wait();
+                    let mut registry = registry.lock().unwrap();
+                    let mut node = eligible_node(2 * 268435456, 1);
+                    apply_reservations(&mut node, &registry, 0);
+                    if matches!(
+                        crate::node::admit(&request, &node),
+                        crate::node::Admission::Accepted { .. }
+                    ) {
+                        let mut entry = Entry::new(empty_record(&request.id));
+                        entry.reservation = Some(Reservation::for_request(&request));
+                        registry.insert(request.id, entry);
+                    }
+                }));
+            }
+            for worker in workers {
+                worker.join().unwrap();
+            }
+            assert_eq!(registry.lock().unwrap().len(), expected);
+        }
+    }
+
+    #[test]
+    fn reservations_survive_cancellation_and_release_on_every_terminal_state() {
+        let req = request_with_egress(&["https://example.com", "https://another.example"]);
+        let mut entry = Entry::new(empty_record("run"));
+        entry.reservation = Some(Reservation::for_request(&req));
+        let mut registry = HashMap::from([("run".into(), entry)]);
+        for phase in ["Admitting", "Forging", "Running", "Cancelling"] {
+            registry.get_mut("run").unwrap().value.phase = phase.into();
+            let mut node = eligible_node(268435456, 1);
+            apply_reservations(&mut node, &registry, 0);
+            assert_eq!(
+                (node.live_cells, node.memory_bytes, node.egress_slots),
+                (1, 0, 0)
+            );
+        }
+        for phase in ["Succeeded", "Failed", "Refused", "Cancelled"] {
+            registry.get_mut("run").unwrap().value.phase = phase.into();
+            let mut node = eligible_node(268435456, 1);
+            apply_reservations(&mut node, &registry, 0);
+            assert_eq!(
+                (node.live_cells, node.memory_bytes, node.egress_slots),
+                (0, 268435456, 1)
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_or_excess_usage_never_wraps_into_available_capacity() {
+        let mut node = eligible_node(1, 1);
+        apply_reservations(&mut node, &HashMap::new(), 1);
+        assert_eq!((node.memory_bytes, node.egress_slots), (0, 0));
+        let mut registry = HashMap::from([("unknown".into(), Entry::new(empty_record("unknown")))]);
+        let mut node = eligible_node(u64::MAX, u32::MAX);
+        apply_reservations(&mut node, &registry, 0);
+        assert_eq!((node.memory_bytes, node.egress_slots), (0, 0));
+        registry.get_mut("unknown").unwrap().reservation = Some(Reservation {
+            memory_bytes: u64::MAX,
+            egress_slots: u32::MAX,
+        });
+        let mut node = eligible_node(1, 1);
+        apply_reservations(&mut node, &registry, 0);
+        assert_eq!((node.memory_bytes, node.egress_slots), (0, 0));
+    }
+
+    #[test]
+    fn health_uses_configured_paths_and_identity_hints_require_authentication() {
+        let work = tempfile::tempdir().unwrap();
+        let state = lifecycle_state(work.path());
+        std::fs::create_dir(&state.probe.mote_store).unwrap();
+        for (path, expected) in [("/v1/health", "HTTP/1.1 200"), ("/v1/node", "HTTP/1.1 401")] {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+            let (server, _) = listener.accept().unwrap();
+            write!(client, "GET {path} HTTP/1.1\r\n\r\n").unwrap();
+            handle(server, &state).unwrap();
+            let mut response = String::new();
+            client.read_to_string(&mut response).unwrap();
+            assert!(response.starts_with(expected), "{response}");
+            if path == "/v1/health" {
+                let body: serde_json::Value =
+                    serde_json::from_str(response.split_once("\r\n\r\n").unwrap().1).unwrap();
+                assert_eq!(body["mote_store"], true);
+                assert_eq!(body["tool_store"], false);
+                assert_eq!(body["ok"], false);
+                assert_eq!(body["configured_memory_bytes"], 268435456u64);
+                assert!(body.get("warm").is_none());
+            }
         }
     }
 
@@ -1014,6 +1254,7 @@ mod tests {
                     ..empty_record("stale")
                 },
                 control: None,
+                reservation: None,
             },
         );
         registry.insert("fresh".into(), Entry::new(empty_record("fresh")));
@@ -1023,6 +1264,7 @@ mod tests {
                 at: Instant::now() - RECORD_TTL - Duration::from_secs(1),
                 value: empty_record("old-active"),
                 control: None,
+                reservation: None,
             },
         );
 

--- a/crates/celln-cli/src/dispatch_substrate.rs
+++ b/crates/celln-cli/src/dispatch_substrate.rs
@@ -132,7 +132,7 @@ pub(crate) fn launch_declared(
             "{}:{}",
             resolved.bundle_hash, request.capabilities.memory_bytes
         );
-        let mut cell = super::warm::fork(key, || {
+        let mut cell = super::warm::fork(key, vec![resolved.program_hash.clone()], || {
             // The shared template contains no request args, credentials or
             // egress grant. Only enable the post-fork invocation channel.
             let mut initrd_bytes = resolved.initrd_bytes.clone();
@@ -404,6 +404,11 @@ mod tests {
         assert_eq!(resolved.initrd_hash, initrd_hash.0);
         assert_eq!(crate::cells::live_count(&state), 0);
         eprintln!("PASS: declared initrd marker and exact sealed tool execute");
+        let hints = super::super::warm::availability().unwrap();
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].mote.as_deref(), Some(bundle_hash.0.as_str()));
+        assert_eq!(hints[0].tools, vec![program_hash.0.clone()]);
+        assert_eq!(hints[0].guest_memory_bytes, 268435456);
         let cold_elapsed = cold_started.elapsed();
         for arg in ["first", "second"] {
             let mut req = request(&bundle_hash, &program_hash);

--- a/crates/celln-cli/src/dispatch_warm.rs
+++ b/crates/celln-cli/src/dispatch_warm.rs
@@ -5,8 +5,23 @@ use std::sync::{Arc, Mutex, OnceLock};
 use warden::vmm::boot::{BootConfig, BootEnd, LinuxCell, Mote};
 
 // One retained template bounds idle RAM to one configured guest. In-flight
-// forks keep their own references; aggregate node accounting belongs to #5.
-type Cached = Option<(String, Arc<Mote>)>;
+// forks keep their own references. This is separate from active guest-RAM
+// reservations; it is not included in a process-RSS guarantee.
+type Cached = Option<(String, Arc<Mote>, Availability)>;
+
+#[derive(Clone, serde::Serialize)]
+pub(crate) struct Availability {
+    pub mote: Option<String>,
+    pub tools: Vec<String>,
+    pub guest_memory_bytes: u64,
+}
+
+/// Advisory identity hints only: never bypass pinning, integrity or policy.
+/// None means the cache is busy/unknown, not proof it is empty.
+pub(crate) fn availability() -> Option<Vec<Availability>> {
+    let cache = CACHE.get_or_init(|| Mutex::new(None)).try_lock().ok()?;
+    Some(cache.iter().map(|(_, _, hint)| hint.clone()).collect())
+}
 static CACHE: OnceLock<Mutex<Cached>> = OnceLock::new();
 #[cfg(test)]
 pub(super) static PREPARATIONS: std::sync::atomic::AtomicUsize =
@@ -16,6 +31,7 @@ pub(super) static PROOF_LOCK: Mutex<()> = Mutex::new(());
 
 pub(super) fn fork(
     key: String,
+    tools: Vec<String>,
     prepare: impl FnOnce() -> Result<(BootConfig, Vec<u8>), String>,
 ) -> Result<LinuxCell, String> {
     let mote = {
@@ -32,10 +48,19 @@ pub(super) fn fork(
                 }
             }
         };
-        if let Some((_, mote)) = cache.as_ref().filter(|(k, _)| k == &key) {
+        if let Some((_, mote, _)) = cache.as_ref().filter(|(k, _, _)| k == &key) {
             Arc::clone(mote)
         } else {
             let (cfg, payload) = prepare()?;
+            let hint = Availability {
+                mote: if key.starts_with("forge:") {
+                    None
+                } else {
+                    key.rsplit_once(':').map(|(hash, _)| hash.to_owned())
+                },
+                tools,
+                guest_memory_bytes: cfg.mem_size as u64,
+            };
             celln_control::check().map_err(|e| e.to_string())?;
             let mut template = LinuxCell::boot(cfg).map_err(|e| e.to_string())?;
             template
@@ -51,7 +76,7 @@ pub(super) fn fork(
             PREPARATIONS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             // Drop the only shared writable RAM mapping before publishing.
             drop(template);
-            *cache = Some((key, Arc::clone(&mote)));
+            *cache = Some((key, Arc::clone(&mote), hint));
             mote
         }
     };
@@ -67,7 +92,7 @@ mod tests {
         let _guard = CACHE.get_or_init(|| Mutex::new(None)).lock().unwrap();
         let worker = std::thread::spawn(|| {
             let c = celln_control::Control::new(std::time::Duration::from_millis(30)).unwrap();
-            c.scope(|| fork("not-prepared".into(), || panic!("must not prepare")))
+            c.scope(|| fork("not-prepared".into(), vec![], || panic!("must not prepare")))
                 .err()
                 .unwrap()
         });

--- a/crates/celln-cli/src/host.rs
+++ b/crates/celln-cli/src/host.rs
@@ -38,16 +38,19 @@ impl Host {
         let mut caps = Vec::new();
 
         let kvm = std::path::Path::new("/dev/kvm").exists();
-        let readable = std::fs::File::open("/dev/kvm").is_ok();
+        #[cfg(target_os = "linux")]
+        let readable = warden::vmm::kvm::KvmVmm::new().is_ok();
+        #[cfg(not(target_os = "linux"))]
+        let readable = false;
         caps.push(cap(
             "kvm",
             kvm && readable,
             if !kvm {
                 String::from("/dev/kvm not present")
             } else if !readable {
-                String::from("/dev/kvm present but not readable by this user")
+                String::from("KVM unavailable or read-only memslots unsupported")
             } else {
-                String::from("/dev/kvm available")
+                String::from("KVM available with read-only memslots")
             },
             if kvm && !readable {
                 "add yourself to the kvm group: sudo usermod -aG kvm $USER (then log out and in)"

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -322,8 +322,10 @@ struct NodeProbeArgs {
     #[arg(long, env = "CELLN_MAX_CELLS", default_value = "1")]
     max_cells: u32,
     #[arg(long, env = "CELLN_MEMORY_BYTES", default_value = "268435456")]
+    /// Aggregate active guest-RAM reservation budget (not a process RSS cap).
     memory_bytes: u64,
     #[arg(long, env = "CELLN_EGRESS_SLOTS", default_value = "0")]
+    /// Maximum simultaneous egress-enabled executions; zero disables egress admission.
     egress_slots: u32,
 }
 

--- a/crates/celln-cli/src/node.rs
+++ b/crates/celln-cli/src/node.rs
@@ -33,17 +33,28 @@ impl NodeEligibility {
             node_name: args.node_name.clone(),
             kvm: host.get("kvm"),
             cpu_virtualization: host.get("cpu-virt"),
-            guest_kernel: host.get("guest-kernel"),
+            guest_kernel: guest_kernel_ready(),
             mote_store: has_entries(&args.mote_store),
             tool_store: has_entries(&args.tool_store),
             live_cells,
             max_cells: args.max_cells,
-            memory_bytes: args.memory_bytes,
-            egress_slots: args.egress_slots,
+            // A standalone probe cannot recover declarations from legacy
+            // live records. The dispatcher starts at zero and applies its
+            // authoritative in-process reservations below this layer.
+            memory_bytes: if live_cells == 0 {
+                args.memory_bytes
+            } else {
+                0
+            },
+            egress_slots: if live_cells == 0 {
+                args.egress_slots
+            } else {
+                0
+            },
         }
     }
 
-    fn eligible(&self) -> bool {
+    pub(crate) fn eligible(&self) -> bool {
         self.kvm
             && self.cpu_virtualization
             && self.guest_kernel
@@ -138,7 +149,10 @@ pub fn admit(request: &ExecutionRequest, node: &NodeEligibility) -> Admission {
             problems: Vec::new(),
         };
     }
-    if node.live_cells >= node.max_cells {
+    if node.live_cells >= node.max_cells
+        || request.capabilities.memory_bytes > node.memory_bytes
+        || (!request.capabilities.egress.is_empty() && node.egress_slots == 0)
+    {
         return Admission::Refused {
             request_id: request.id.clone(),
             node: node.clone(),
@@ -146,7 +160,7 @@ pub fn admit(request: &ExecutionRequest, node: &NodeEligibility) -> Admission {
             problems: Vec::new(),
         };
     }
-    if !node.eligible() || request.capabilities.memory_bytes > node.memory_bytes {
+    if !node.eligible() {
         return Admission::Refused {
             request_id: request.id.clone(),
             node: node.clone(),
@@ -161,10 +175,24 @@ pub fn admit(request: &ExecutionRequest, node: &NodeEligibility) -> Admission {
 }
 
 fn has_entries(path: &Path) -> bool {
-    std::fs::read_dir(path)
-        .ok()
-        .and_then(|mut entries| entries.next())
-        .is_some()
+    // Readiness is access to the configured store, not a claim that every
+    // requested identity is present or trusted. Empty stores are valid for
+    // forge requests; per-object integrity is checked during resolution.
+    path.is_dir() && std::fs::read_dir(path).is_ok()
+}
+
+fn guest_kernel_ready() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        warden::vmm::boot::BootConfig::host_kernel().is_some_and(|path| {
+            warden::vmm::boot::BootConfig::modules_dir_for(&path).is_some()
+                && warden::vmm::boot::kernel_is_loadable(&path)
+        })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
 }
 
 fn print_json(value: &impl Serialize) -> Result<u8> {

--- a/crates/celln-warden/src/vmm/boot.rs
+++ b/crates/celln-warden/src/vmm/boot.rs
@@ -294,6 +294,12 @@ impl BootReport {
     }
 }
 
+/// Check the same kernel image format accepted by the loader without booting
+/// or allocating guest memory. This is preflight, not evidence of guest boot.
+pub fn kernel_is_loadable(path: &Path) -> bool {
+    BzImage::load(path).is_ok()
+}
+
 /// A parsed bzImage.
 struct BzImage {
     bytes: Vec<u8>,

--- a/docs/NODE_CAPACITY.md
+++ b/docs/NODE_CAPACITY.md
@@ -1,0 +1,69 @@
+# Dispatcher capacity and readiness
+
+The dispatcher atomically reserves a cell slot, the request's full
+`memoryBytes`, and one broker slot for any request with nonempty egress.
+Reservation occurs before forging or launching, under the execution-registry
+lock. Multiple destinations share one synchronous per-cell broker. The limits
+are `--max-cells`, `--memory-bytes`, and `--egress-slots` (or their existing
+`CELLN_*` environment variables). The default zero egress slots now means no
+egress-enabled execution can be admitted, even if host destination policy
+allows its hostname. Configure both policy and capacity when enabling fetch.
+
+Memory is an aggregate active guest-RAM commitment, not process RSS or a
+physical host-memory guarantee. The bounded warm cache retains one mote;
+sealed tool pages, old templates referenced by active forks, artifact buffers,
+forge processes and host overhead are additional. Operators must budget these
+separately or use host resource controls. CoW sharing never discounts active
+reservations: every guest can dirty its full private allocation.
+
+Cancellation only signals a worker. It does not release the reservation until
+that worker finishes cleanup and publishes a terminal state. Success, failure,
+refusal, timeout and cancelled cleanup all release capacity. Worker creation
+failure releases the pre-launch reservation too. Finished records retained for
+polling do not consume capacity. Duplicate request IDs return the existing
+record without reserving again.
+
+The service takes an exclusive OS lock for its state root to prevent duplicate
+dispatchers advertising the same process-local budget. The lock is released on
+exit; its persistent file is not a stale-owner signal. Other live process
+records lack reliable memory/broker declarations, so their usage makes available
+memory and egress zero rather than inventing headroom. This is a dispatcher
+budget, not coordination with arbitrary processes using another state root or
+starting independently of this service. Run one managed dispatcher per node.
+
+## Reports
+
+`GET /v1/health` remains public and returns HTTP 200 for a reachable service;
+`ok` describes admission preflight, not merely `/dev/kvm` pathname presence.
+It uses configured mote/tool-store directories, the loader's kernel-format
+check with matching modules, CPU virtualization flags and KVM read-only memslot
+support. Empty readable stores are valid; this does not promise a requested
+object exists. The nested `node` includes current available `memory_bytes`,
+`egress_slots`, `live_cells` and `max_cells`; configured totals are separate.
+Missing resources or exhausted memory/cell slots make `ok` false. Zero egress
+slots do not prevent non-network requests.
+
+`GET /v1/node` requires the dispatcher bearer token and adds warm-mote and
+resolved-tool hash hints from the live cache. `warm: null` means cache state
+is currently unknown/busy; `warm: []` means observed empty. Each hint includes
+the template guest-memory size. Forge templates have no declared mote hash.
+Hints are advisory, not new authority: execution still verifies objects and
+checks current mote/input policy and tool revocation. They are not included in
+the public health response.
+
+Both responses explicitly say `preflight_only: true`. No cheap probe proves a
+guest boots or satisfies a particular declared bundle; real guest conformance
+and execution remain the evidence for those properties. Standalone
+`celln node probe` cannot see a dispatcher's pre-cell reservations: use the
+authenticated live endpoint for scheduling. When it observes legacy live cells,
+it conservatively advertises zero available memory and egress.
+
+## Verification
+
+Unit tests race 16 admissions against aggregate memory/broker limits, cover
+unknown/excess usage and every active/terminal phase, check exclusive ownership,
+and exercise configured health paths and authentication over actual TCP.
+The real KVM declared-substrate test checks cache hints against the exact
+resolved mote/tool identities and continues to exercise warm isolation,
+workspace/input denial, cancellation and timeout. `make ci` includes the host
+regressions; the ignored guest proof must also be run on a KVM host.

--- a/integrations/kubernetes/README.md
+++ b/integrations/kubernetes/README.md
@@ -10,7 +10,7 @@ Do not implement Celln as a `RuntimeClass`/CRI handler. CRI owns a pod filesyste
 and process lifecycle; Celln must instead receive explicit content hashes and
 capabilities, then let `warden` make a sealed cell from a warm mote. The node agent
 is the narrow Kubernetes seam: it reports eligibility and admits or refuses a
-request. A future Sympozium controller adapter should translate `AgentRun` policy
+request. The Sympozium controller adapter must translate `AgentRun` policy
 into this request and persist the returned verdict in `AgentRun.status.conditions`.
 
 The included DaemonSet has only the privileged access required to inspect `/dev/kvm`
@@ -24,22 +24,32 @@ the host root filesystem, or an ambient network capability into a cell.
 ```
 
 The script builds and loads the local image, deploys the DaemonSet, and writes the
-real node report and admission verdict below `target/kubernetes-proof/`. The current
-kind node exposes `/dev/kvm`, so an unavailable KVM boundary would be reported as
-`unsupported`, never silently downgraded. It does not contain a prepared Celln mote
-or tool store, so this fresh cluster truthfully returns `no_eligible_node`. Populate
-signed mote and tool stores on the node before a node is eligible; do not create
-placeholder files just to make the report pass.
+real node report and admission verdict below `target/kubernetes-proof/`. Results
+depend on that cluster's KVM, kernel and configured stores. An unavailable KVM
+boundary is `unsupported`, never silently downgraded. Prepare and authorize the
+requested artifacts before dispatching declared workloads; do not create
+placeholder files to imitate object availability.
 
 The command emits JSON only. `verdict: accepted` means the node admitted the intent;
 it does not claim the request's workload was run. An accepted node now also requires
-a bootable guest kernel: KVM visibility and non-empty directories are not a truthful
-execution capability. The versioned terminal result contract is
+a readable loader-compatible guest kernel with matching modules. This remains
+preflight, not a proof that a particular guest boots. The versioned terminal result contract is
 [`examples/execution/succeeded-receipt.json`](../../examples/execution/succeeded-receipt.json);
 it binds a request, node, cell, resolved authority, and optional output to immutable
-BLAKE3 references. It is a contract for the dispatcher, not evidence that a dispatcher
-exists yet. Executing a workload through the node agent and writing that receipt back
-to Sympozium remains the next slice.
+BLAKE3 references. `celln dispatch serve` now executes requests and returns terminal
+results through its authenticated execution endpoints. Declared requests fork an
+operator-pinned warm mote; forge requests build their program before preparing and
+forking a mote. Fresh external Sympozium integration acceptance remains tracked in #2.
+
+For live scheduling, use authenticated `GET /v1/node`, not a standalone node-probe
+process that cannot see the service's pre-cell reservations. The dispatcher now
+reserves aggregate guest memory and broker slots atomically; zero egress slots
+refuses network-enabled requests. Public `/v1/health` uses configured stores and
+reports preflight readiness without exposing cache identities. See
+[capacity and readiness](../../docs/NODE_CAPACITY.md),
+[declared substrates](../../docs/DECLARED_SUBSTRATES.md), and
+[input/workspace authority](../../docs/DISPATCH_INPUTS.md) for configuration,
+trust boundaries and compatibility requirements.
 
 ## Exercise actual Celln cells on the KVM host
 


### PR DESCRIPTION
## Summary

Advances #5 and epic #2, stacked on #61.

- Reserve aggregate declared guest RAM and synchronous broker slots under the same lock as cell admission, including pre-cell forging/preparation.
- Keep reservations through cancellation cleanup; terminal records release capacity, unknown live usage refuses headroom, and arithmetic saturates rather than wrapping.
- Handle worker-spawn failure and enforce one dispatcher owner per state root with an OS lock.
- Replace hardcoded health paths with configured readiness, loader-compatible kernel/matching modules and actual KVM read-only memslot support.
- Add authenticated `/v1/node` with advisory live warm-mote/resolved-tool identities. Public health does not expose identities. Cache busy/unknown is distinct from empty.
- Document available versus configured capacity, zero-egress migration, standalone probe limitations, and guest RAM versus total host memory. Remove obsolete admission-only dispatcher claims from Kubernetes README.

## Verification

- `make ci`: pass.
- Race 16 admissions against memory and egress limits; exact bounded acceptance counts.
- Reservation lifecycle, unknown/overflow usage, exclusive ownership and configured-path/authentication TCP regressions: pass.
- Both real KVM dispatcher suites: pass, including cache identities, warm isolation, input/workspace denial, actual outcomes, cancellation and deadlines.
- `make acceptance-kvm fetch-proof`: pass on local KVM host.

## Explicit boundaries

Memory capacity means aggregate active guest-RAM commitments, not RSS; warm templates, tool pages, artifact buffers and host/build overhead are additional. Operator host controls are still required for a physical-memory budget. Readiness is labeled preflight, not boot attestation. External processes/different state roots are not a global allocator. Cache hints never authorize execution or bypass resolution/pinning/revocation. #5 stays open until integrated conformance validates the merged stack; #10/#12 and fresh external Sympozium acceptance remain next.
