### PR TITLE
Audit actual grants, execution identities and broker activity

### DIFF
--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -162,6 +162,10 @@ pub fn resolve_bundle(
 /// one. The dispatcher builds the receipt from this after the cell is gone.
 #[derive(Debug)]
 pub struct LaunchOutcome {
+    pub execution: Option<pilot::dispatch_report::ExecutionGrant>,
+    pub substrate: Option<SubstrateIdentity>,
+    pub broker: BrokerActivity,
+    pub lifecycle: Vec<CellEvent>,
     /// Verified inputs acknowledged as staged by pilot, not just requested.
     pub input_hashes: Vec<String>,
     pub cell_id: String,
@@ -172,6 +176,32 @@ pub struct LaunchOutcome {
     pub exit_code: Option<i32>,
     pub signal: Option<i32>,
     pub timed_out: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubstrateIdentity {
+    pub kernel: String,
+    /// Exact loaded initrd including the fixed warm-dispatch marker.
+    pub initrd: String,
+    pub toolfs: String,
+    pub invocation: String,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrokerActivity {
+    pub requests: u64,
+    pub denied: u64,
+    pub response_bytes: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CellEvent {
+    pub phase: String,
+    pub at: String,
+    #[serde(skip)]
+    pub observed: std::time::Instant,
 }
 
 impl LaunchOutcome {
@@ -433,9 +463,29 @@ fn run_prepared(
         Hash::of(&payload),
         cfg.mem_size
     );
-    let mut cell = warm::fork(key, vec![program_hash], || Ok((cfg, payload)))?;
+    let identity = SubstrateIdentity {
+        kernel: kernel_hash.0,
+        initrd: initrd_hash.0,
+        toolfs: Hash::of(&payload).0,
+        invocation: Hash::of(invocation).0,
+    };
+    let mut cell = warm::fork(key, vec![program_hash.clone()], || Ok((cfg, payload)))?;
     cell.set_invocation(invocation).map_err(|e| e.to_string())?;
-    run_cell(request, alias, cell, state_root)
+    let mut outcome = run_cell(request, alias, cell, state_root)?;
+    outcome.substrate = Some(identity);
+    validate_executed_tool(&mut outcome, &program_hash);
+    Ok(outcome)
+}
+
+fn validate_executed_tool(outcome: &mut LaunchOutcome, expected: &str) {
+    if outcome
+        .execution
+        .as_ref()
+        .is_some_and(|grant| grant.tool != expected)
+    {
+        outcome.execution = None;
+        outcome.denial = Some("executed tool report mismatch".into());
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -472,6 +522,8 @@ fn run_cell(
             .collect();
         cell.enable_http_fetch(warden::egress::HttpPolicy::new(hosts));
     }
+    let running_at = now_rfc3339();
+    let running_observed = std::time::Instant::now();
     let report = match cell.run() {
         Ok(report) => report,
         Err(error) => {
@@ -489,16 +541,48 @@ fn run_cell(
         report.end == warden::vmm::boot::BootEnd::TimedOut,
         report.end == warden::vmm::boot::BootEnd::Shutdown,
     );
+    let (requests, denied, response_bytes) = cell.fetch_activity();
+    outcome.broker = BrokerActivity {
+        requests,
+        denied,
+        response_bytes,
+    };
     if let Some(reason) = celln_control::current().and_then(|c| c.reason()) {
         outcome.denial = Some(reason.to_string());
     }
     let expected: Vec<_> = request.inputs.iter().map(|i| i.hash.clone()).collect();
+    if let Some(grant) = &outcome.execution {
+        let workspace = serde_json::to_value(request.capabilities.workspace).unwrap();
+        if grant.workspace.as_deref() != workspace.as_str()
+            || grant.fetch != !request.capabilities.egress.is_empty()
+            || !matches!(grant.lane.as_str(), "agent" | "tool")
+            || (request.execution.lane == RequestedLane::Agent && grant.lane != "agent")
+        {
+            outcome.execution = None;
+            outcome.denial = Some("executed authority report mismatch".into());
+        }
+    } else if outcome.exit_code.is_some() || outcome.signal.is_some() {
+        outcome.denial = Some("missing pilot execution grant report".into());
+    }
     if outcome.input_hashes != expected {
         outcome.input_hashes.clear();
         outcome
             .denial
             .get_or_insert_with(|| "input delivery report mismatch".into());
     }
+    drop(cell);
+    outcome.lifecycle = vec![
+        CellEvent {
+            phase: "CellRunning".into(),
+            at: running_at,
+            observed: running_observed,
+        },
+        CellEvent {
+            phase: "Dissolved".into(),
+            at: now_rfc3339(),
+            observed: std::time::Instant::now(),
+        },
+    ];
     if let Some(record) = record.as_mut() {
         crate::cells::finish(state_root, record, "kvm", outcome.denial.clone());
     }
@@ -810,6 +894,7 @@ mod tests {
         .unwrap();
         assert!(!outcome.succeeded());
         assert_eq!(outcome.denial.as_deref(), Some("pilot exec setup failed"));
+        assert!(outcome.execution.is_none());
         // An agent artifact stays in the agent lane even if a later caller
         // asks for the tool lane. The spoof probe also attempts unshare.
         let assay_root = work.path().join("assay");
@@ -833,6 +918,8 @@ mod tests {
             &work.path().join("preserved-author"),
         )
         .unwrap();
+        assert_eq!(outcome.execution.as_ref().unwrap().lane, "agent");
+        assert_eq!(outcome.execution.as_ref().unwrap().tool, hash.0);
         assert_eq!(outcome.exit_code, Some(9), "{outcome:?}");
         assert_eq!(
             assay::Assayer::open(&assay_root)
@@ -856,6 +943,7 @@ mod tests {
         .unwrap();
         assert!(!outcome.succeeded());
         assert_eq!(outcome.denial.as_deref(), Some("pilot refused execution"));
+        assert!(outcome.execution.is_none());
         eprintln!("PASS: exec setup failure, retained agent lane, and pilot refusal");
     }
 

--- a/crates/celln-cli/src/dispatch_audit.rs
+++ b/crates/celln-cli/src/dispatch_audit.rs
@@ -1,0 +1,201 @@
+//! Additive audit envelope: the strict v1alpha1 receipt stays byte/schema
+//! compatible. No arguments, environment, input bytes or diagnostics here.
+
+use crate::dispatch::{BrokerActivity, LaunchOutcome, SubstrateIdentity};
+use celln_spec::{CapabilityRequest, ExecutionReceipt, ExecutionRequest};
+use serde::Serialize;
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Audit {
+    pub api_version: &'static str,
+    pub request_id: String,
+    pub caller: String,
+    pub workload: String,
+    pub node: String,
+    pub events: Vec<Event>,
+    pub execution: Option<Execution>,
+    pub receipt: Option<ExecutionReceipt>,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Event {
+    pub sequence: usize,
+    pub at: String,
+    pub phase: String,
+    #[serde(skip)]
+    observed: std::time::Instant,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Execution {
+    pub cell_id: String,
+    pub substrate: Option<SubstrateIdentity>,
+    pub pilot: Option<pilot::dispatch_report::ExecutionGrant>,
+    /// Only populated after pilot's installed-grant acknowledgement matches
+    /// host-enforced bounds. A refused setup does not grant requested authority.
+    pub granted: Option<CapabilityRequest>,
+    pub inputs: Vec<String>,
+    pub broker: BrokerActivity,
+    pub exit_code: Option<i32>,
+    pub signal: Option<i32>,
+    pub watchdog_stopped: bool,
+}
+
+impl Audit {
+    pub fn new(request: &ExecutionRequest, node: &str) -> Self {
+        let mut audit = Self {
+            api_version: "celln.dev/audit-v1alpha1",
+            request_id: request.id.clone(),
+            caller: request.workload.caller.clone(),
+            workload: request.workload.id.clone(),
+            node: node.into(),
+            events: Vec::new(),
+            execution: None,
+            receipt: None,
+        };
+        audit.phase("Admitting");
+        audit
+    }
+
+    pub fn phase(&mut self, phase: &str) {
+        if self.events.last().is_some_and(|event| event.phase == phase) {
+            return;
+        }
+        // Lifecycle has a fixed small number of phases; repeated cancellation
+        // polls must not become an unbounded audit-log allocator.
+        if self.events.len() < 32 {
+            self.events.push(Event {
+                sequence: self.events.len(),
+                at: crate::dispatch::now_rfc3339(),
+                phase: phase.into(),
+                observed: std::time::Instant::now(),
+            });
+        }
+    }
+
+    pub fn executed(&mut self, request: &ExecutionRequest, outcome: &LaunchOutcome) {
+        for event in &outcome.lifecycle {
+            if self.events.len() < 32 {
+                self.events.push(Event {
+                    sequence: self.events.len(),
+                    at: event.at.clone(),
+                    phase: event.phase.clone(),
+                    observed: event.observed,
+                });
+            }
+        }
+        // A cancellation can be observed while the VMM is running; its audit
+        // event was inserted before this completed outcome arrived. Order by
+        // monotonic host observations, never by wall-clock adjustment or append time.
+        self.events.sort_by_key(|event| event.observed);
+        for (index, event) in self.events.iter_mut().enumerate() {
+            event.sequence = index;
+        }
+        self.execution = Some(Execution {
+            cell_id: outcome.cell_id.clone(),
+            substrate: outcome.substrate.clone(),
+            pilot: outcome.execution.clone(),
+            granted: outcome
+                .execution
+                .as_ref()
+                .map(|_| request.capabilities.clone()),
+            inputs: outcome.input_hashes.clone(),
+            broker: outcome.broker.clone(),
+            exit_code: outcome.exit_code,
+            signal: outcome.signal,
+            watchdog_stopped: outcome.timed_out,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audit_excludes_request_payloads_and_unacknowledged_authority() {
+        let mut request: ExecutionRequest =
+            serde_json::from_str(include_str!("../../../examples/execution/forge-task.json"))
+                .unwrap();
+        request.forge.as_mut().unwrap().task = "DO_NOT_LOG_TASK_OR_SECRET".into();
+        let mut audit = Audit::new(&request, "node-a");
+        let outcome = LaunchOutcome {
+            execution: None,
+            substrate: None,
+            broker: Default::default(),
+            lifecycle: vec![],
+            input_hashes: vec![],
+            cell_id: "cell-a".into(),
+            output: Some(b"DO_NOT_LOG_OUTPUT".to_vec()),
+            denial: Some("DO_NOT_LOG_DIAGNOSTIC".into()),
+            exit_code: None,
+            signal: None,
+            timed_out: false,
+        };
+        audit.executed(&request, &outcome);
+        audit.phase("Failed");
+        let value = serde_json::to_value(&audit).unwrap();
+        assert!(value["execution"]["granted"].is_null());
+        assert!(value["execution"]["pilot"].is_null());
+        let text = value.to_string();
+        assert!(!text.contains("DO_NOT_LOG"));
+        assert_eq!(value["caller"], request.workload.caller);
+        assert_eq!(value["execution"]["cellId"], "cell-a");
+        for _ in 0..100 {
+            audit.phase("Failed");
+        }
+        assert_eq!(audit.events.len(), 2);
+    }
+
+    #[test]
+    fn delayed_cell_events_are_ordered_before_cancellation_by_observation() {
+        let request: ExecutionRequest =
+            serde_json::from_str(include_str!("../../../examples/execution/forge-task.json"))
+                .unwrap();
+        let mut audit = Audit::new(&request, "node");
+        let running = crate::dispatch::CellEvent {
+            phase: "CellRunning".into(),
+            at: crate::dispatch::now_rfc3339(),
+            observed: std::time::Instant::now(),
+        };
+        audit.phase("Cancelling");
+        let dissolved = crate::dispatch::CellEvent {
+            phase: "Dissolved".into(),
+            at: crate::dispatch::now_rfc3339(),
+            observed: std::time::Instant::now(),
+        };
+        let outcome = LaunchOutcome {
+            execution: None,
+            substrate: None,
+            broker: Default::default(),
+            lifecycle: vec![running, dissolved],
+            input_hashes: vec![],
+            cell_id: "cell".into(),
+            output: None,
+            denial: None,
+            exit_code: None,
+            signal: None,
+            timed_out: true,
+        };
+        audit.executed(&request, &outcome);
+        assert_eq!(
+            audit
+                .events
+                .iter()
+                .map(|event| event.phase.as_str())
+                .collect::<Vec<_>>(),
+            ["Admitting", "CellRunning", "Cancelling", "Dissolved"]
+        );
+        assert_eq!(
+            audit
+                .events
+                .iter()
+                .map(|event| event.sequence)
+                .collect::<Vec<_>>(),
+            [0, 1, 2, 3]
+        );
+    }
+}

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -6,6 +6,8 @@
 //! real sealed cell, and returns a validated `ExecutionReceipt`.
 
 use crate::NodeProbeArgs;
+#[path = "dispatch_audit.rs"]
+mod audit;
 use anyhow::{bail, Context, Result};
 use celln_spec::{
     ExecutionOutput, ExecutionPhase, ExecutionReceipt, ExecutionRequest, ResolvedExecution,
@@ -93,6 +95,7 @@ struct Entry<T> {
     value: T,
     control: Option<celln_control::Control>,
     reservation: Option<Reservation>,
+    audit: Option<audit::Audit>,
 }
 
 impl<T> Entry<T> {
@@ -102,6 +105,7 @@ impl<T> Entry<T> {
             value,
             control: None,
             reservation: None,
+            audit: None,
         }
     }
 }
@@ -506,6 +510,7 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
             let mut entry = Entry::new(record.clone());
             entry.control = Some(control.clone());
             entry.reservation = Some(Reservation::for_request(&request));
+            entry.audit = Some(audit::Audit::new(&request, &state.probe.node_name));
             registry.insert(request.id.clone(), entry);
             drop(registry);
             let worker_executions = Arc::clone(&state.executions);
@@ -559,11 +564,29 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
                 }
                 entry.value.phase = "Cancelling".into();
                 entry.value.reason = Some("cancellation requested; cleanup pending".into());
+                if let Some(audit) = &mut entry.audit {
+                    audit.phase("Cancelling");
+                }
                 // Reservation remains live until the worker has unwound all
                 // subprocesses, VM handles and preparation state.
                 reply(&mut stream, 202, &entry.value)
             } else {
                 reply(&mut stream, 200, &entry.value)
+            }
+        }
+        ("GET", path) if path.starts_with("/v1/executions/") && path.ends_with("/audit") => {
+            let id = &path["/v1/executions/".len()..path.len() - "/audit".len()];
+            let registry = state
+                .executions
+                .lock()
+                .expect("dispatcher registry not poisoned");
+            match registry.get(id).and_then(|entry| entry.audit.as_ref()) {
+                Some(audit) => reply(&mut stream, 200, audit),
+                None => reply(
+                    &mut stream,
+                    404,
+                    &serde_json::json!({"error": "unknown execution audit"}),
+                ),
             }
         }
         ("GET", path) if path.starts_with("/v1/executions/") => {
@@ -609,6 +632,10 @@ fn update_execution(executions: &Executions, id: &str, f: impl FnOnce(&mut Execu
         }
         if !execution_is_active(&entry.value) {
             entry.at = Instant::now();
+        }
+        if let Some(audit) = &mut entry.audit {
+            audit.phase(&entry.value.phase);
+            audit.receipt = entry.value.receipt.clone();
         }
     }
 }
@@ -670,7 +697,7 @@ fn run_execution(
             Err(error) => return fail_execution(&executions, &request.id, error.to_string()),
         };
         update_execution(&executions, &request.id, |record| {
-            record.phase = "Running".into()
+            record.phase = "Preparing".into()
         });
         let outcome = match crate::dispatch::launch(
             &request,
@@ -701,6 +728,14 @@ fn run_execution(
         (Some(resolved.bundle_hash), resolved.program_hash, outcome)
     };
 
+    if let Some(audit) = executions
+        .lock()
+        .expect("dispatcher registry not poisoned")
+        .get_mut(&request.id)
+        .and_then(|entry| entry.audit.as_mut())
+    {
+        audit.executed(&request, &outcome);
+    }
     let output = outcome.output.as_deref().filter(|bytes| !bytes.is_empty());
     let (phase, stored_output, reason) = collect_result(&outcome, &root.join("outputs"));
     let receipt = ExecutionReceipt {
@@ -951,6 +986,64 @@ mod tests {
     }
 
     #[test]
+    fn audit_endpoint_is_authenticated_and_preserves_the_strict_receipt() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = lifecycle_state(dir.path());
+        let request = request_with_egress(&[]);
+        let mut entry = Entry::new(empty_record(&request.id));
+        entry.audit = Some(audit::Audit::new(&request, "test"));
+        state
+            .executions
+            .lock()
+            .unwrap()
+            .insert(request.id.clone(), entry);
+        let mut receipt: ExecutionReceipt = serde_json::from_str(include_str!(
+            "../../../examples/execution/succeeded-receipt.json"
+        ))
+        .unwrap();
+        receipt.request_id = request.id.clone();
+        update_execution(&state.executions, &request.id, |record| {
+            record.phase = "Succeeded".into();
+            record.receipt = Some(receipt.clone());
+        });
+        for (suffix, token, status) in [
+            ("/audit", "wrong", 401),
+            ("/audit", state.token.as_str(), 200),
+            ("", state.token.as_str(), 200),
+        ] {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+            let (server, _) = listener.accept().unwrap();
+            write!(
+                client,
+                "GET /v1/executions/{}{suffix} HTTP/1.1\r\nAuthorization: Bearer {token}\r\n\r\n",
+                request.id
+            )
+            .unwrap();
+            handle(server, &state).unwrap();
+            let mut response = String::new();
+            client.read_to_string(&mut response).unwrap();
+            assert!(response.starts_with(&format!("HTTP/1.1 {status}")));
+            if status == 200 {
+                let body: serde_json::Value =
+                    serde_json::from_str(response.split_once("\r\n\r\n").unwrap().1).unwrap();
+                let decoded: ExecutionReceipt =
+                    serde_json::from_value(body["receipt"].clone()).unwrap();
+                assert_eq!(
+                    serde_json::to_value(decoded).unwrap(),
+                    serde_json::to_value(&receipt).unwrap()
+                );
+                if suffix == "/audit" {
+                    assert_eq!(body["apiVersion"], "celln.dev/audit-v1alpha1");
+                    assert_eq!(body["events"][1]["phase"], "Succeeded");
+                } else {
+                    assert!(body.get("events").is_none());
+                }
+            }
+        }
+    }
+
+    #[test]
     fn cancellation_is_authenticated_idempotent_and_reserves_until_cleanup() {
         let work = tempfile::tempdir().unwrap();
         let state = lifecycle_state(work.path());
@@ -1100,6 +1193,10 @@ mod tests {
     fn receipt_phase_tracks_exit_and_output_storage_independently() {
         let work = tempfile::tempdir().unwrap();
         let mut outcome = crate::dispatch::LaunchOutcome {
+            execution: None,
+            substrate: None,
+            broker: Default::default(),
+            lifecycle: Vec::new(),
             input_hashes: Vec::new(),
             cell_id: "cell".into(),
             output: Some(vec![]),
@@ -1255,6 +1352,7 @@ mod tests {
                 },
                 control: None,
                 reservation: None,
+                audit: None,
             },
         );
         registry.insert("fresh".into(), Entry::new(empty_record("fresh")));
@@ -1265,6 +1363,7 @@ mod tests {
                 value: empty_record("old-active"),
                 control: None,
                 reservation: None,
+                audit: None,
             },
         );
 

--- a/crates/celln-cli/src/dispatch_outcome.rs
+++ b/crates/celln-cli/src/dispatch_outcome.rs
@@ -11,6 +11,10 @@ pub(super) fn parse_report(
     shutdown: bool,
 ) -> LaunchOutcome {
     let mut result = LaunchOutcome {
+        execution: None,
+        substrate: None,
+        broker: Default::default(),
+        lifecycle: Vec::new(),
         cell_id,
         output: Some(Vec::new()),
         denial: None,
@@ -38,7 +42,15 @@ pub(super) fn parse_report(
             continue;
         }
         match serde_json::from_str::<Frame>(json) {
-            Ok(Frame::Inputs { hashes }) if !inputs_seen && !output_seen && hashes.len() <= 16 => {
+            Ok(Frame::Started { grant }) if result.execution.is_none() && !output_seen => {
+                result.execution = Some(grant);
+            }
+            Ok(Frame::Inputs { hashes })
+                if !inputs_seen
+                    && !output_seen
+                    && result.execution.is_none()
+                    && hashes.len() <= 16 =>
+            {
                 inputs_seen = true;
                 result.input_hashes = hashes;
             }
@@ -73,7 +85,10 @@ pub(super) fn parse_report(
         result.denial = Some("missing, ambiguous, or incomplete pilot execution report".into());
     }
     if invalid {
+        result.execution = None;
         result.input_hashes.clear();
+        result.exit_code = None;
+        result.signal = None;
     }
     result
 }
@@ -116,6 +131,59 @@ mod tests {
         assert!(!failed.succeeded());
         assert_eq!(failed.exit_code, Some(7));
         assert_eq!(failed.output.unwrap(), b"failure");
+    }
+
+    #[test]
+    fn execution_grants_cannot_be_duplicated_reordered_or_forged_in_output() {
+        let grant = pilot::dispatch_report::ExecutionGrant {
+            tool: celln_manifest::Hash::of(b"program").0,
+            lane: "agent".into(),
+            workspace: Some("none".into()),
+            fetch: false,
+        };
+        let started = || Frame::Started {
+            grant: grant.clone(),
+        };
+        let valid = parse_report(
+            &console(&[started(), Frame::Exit { code: 0 }]),
+            "cell".into(),
+            1024,
+            false,
+            true,
+        );
+        assert_eq!(valid.execution, Some(grant.clone()));
+        for frames in [
+            vec![started(), started(), Frame::Exit { code: 0 }],
+            vec![
+                Frame::Output { bytes: vec![1] },
+                started(),
+                Frame::Exit { code: 0 },
+            ],
+            vec![Frame::Exit { code: 0 }, started()],
+            vec![
+                started(),
+                Frame::Inputs { hashes: vec![] },
+                Frame::Exit { code: 0 },
+            ],
+        ] {
+            let result = parse_report(&console(&frames), "cell".into(), 1024, false, true);
+            assert!(!result.succeeded());
+            assert!(result.execution.is_none());
+        }
+        let fake = format!("{PREFIX}{}\n", serde_json::to_string(&started()).unwrap());
+        let result = parse_report(
+            &console(&[
+                Frame::Output {
+                    bytes: fake.into_bytes(),
+                },
+                Frame::Exit { code: 0 },
+            ]),
+            "cell".into(),
+            1024,
+            false,
+            true,
+        );
+        assert!(result.execution.is_none());
     }
 
     #[test]

--- a/crates/celln-cli/src/dispatch_substrate.rs
+++ b/crates/celln-cli/src/dispatch_substrate.rs
@@ -132,14 +132,20 @@ pub(crate) fn launch_declared(
             "{}:{}",
             resolved.bundle_hash, request.capabilities.memory_bytes
         );
+        let mut initrd_bytes = resolved.initrd_bytes.clone();
+        while initrd_bytes.len() % 4 != 0 {
+            initrd_bytes.push(0);
+        }
+        initrd_bytes.extend(file_archive("celln/dispatch-warm", b"pio-v1\n"));
+        let identity = super::SubstrateIdentity {
+            kernel: resolved.kernel_hash.clone(),
+            initrd: celln_manifest::Hash::of(&initrd_bytes).0,
+            toolfs: resolved.toolfs_hash.clone(),
+            invocation: celln_manifest::Hash::of(&run).0,
+        };
         let mut cell = super::warm::fork(key, vec![resolved.program_hash.clone()], || {
             // The shared template contains no request args, credentials or
             // egress grant. Only enable the post-fork invocation channel.
-            let mut initrd_bytes = resolved.initrd_bytes.clone();
-            while initrd_bytes.len() % 4 != 0 {
-                initrd_bytes.push(0);
-            }
-            initrd_bytes.extend(file_archive("celln/dispatch-warm", b"pio-v1\n"));
             std::fs::write(&kernel, &resolved.kernel_bytes).map_err(|e| e.to_string())?;
             std::fs::write(&initrd, &initrd_bytes).map_err(|e| e.to_string())?;
             let mut cfg = warden::vmm::boot::BootConfig::new(kernel)
@@ -149,7 +155,9 @@ pub(crate) fn launch_declared(
             Ok((cfg, resolved.toolfs_bytes.clone()))
         })?;
         cell.set_invocation(&run).map_err(|e| e.to_string())?;
-        let outcome = super::run_cell(request, &invocation.alias, cell, state_root)?;
+        let mut outcome = super::run_cell(request, &invocation.alias, cell, state_root)?;
+        outcome.substrate = Some(identity);
+        super::validate_executed_tool(&mut outcome, &resolved.program_hash);
         Ok((outcome, resolved))
     }
 }
@@ -397,6 +405,17 @@ mod tests {
         )
         .unwrap();
         assert!(outcome.succeeded(), "{outcome:?}");
+        assert_eq!(outcome.execution.as_ref().unwrap().tool, program_hash.0);
+        assert_eq!(outcome.execution.as_ref().unwrap().lane, "agent");
+        let identity = outcome.substrate.as_ref().unwrap();
+        assert_eq!(identity.kernel, kernel_hash.0);
+        assert_eq!(identity.toolfs, toolfs_hash.0);
+        let mut loaded_initrd = base.clone();
+        while loaded_initrd.len() % 4 != 0 {
+            loaded_initrd.push(0);
+        }
+        loaded_initrd.extend(file_archive("celln/dispatch-warm", b"pio-v1\n"));
+        assert_eq!(identity.initrd, Hash::of(&loaded_initrd).0);
         assert_eq!(
             outcome.output.as_deref(),
             Some(b"selected-substrate-A\n".as_slice())
@@ -441,6 +460,11 @@ mod tests {
             req.invocation.as_mut().unwrap().args = vec!["workspace".into(), name.into()];
             let (outcome, _) = launch_declared(&req, &motes, &tools, &state).unwrap();
             assert!(outcome.succeeded(), "{name}: {outcome:?}");
+            assert_eq!(outcome.execution.as_ref().unwrap().lane, "tool");
+            assert_eq!(
+                outcome.execution.as_ref().unwrap().workspace.as_deref(),
+                Some(name)
+            );
             assert_eq!(
                 outcome.output.as_deref(),
                 Some(format!("workspace:{name}\n").as_bytes())
@@ -452,6 +476,14 @@ mod tests {
         fetch.invocation.as_mut().unwrap().args = vec!["fetch-grant".into()];
         let (outcome, _) = launch_declared(&fetch, &motes, &tools, &state).unwrap();
         assert!(outcome.succeeded(), "{outcome:?}");
+        assert_eq!(
+            (
+                outcome.broker.requests,
+                outcome.broker.denied,
+                outcome.broker.response_bytes
+            ),
+            (1, 1, 0)
+        );
         assert_eq!(
             outcome.output.as_deref(),
             Some(b"fetch-grant:host-refused-http\n".as_slice())
@@ -555,6 +587,7 @@ mod tests {
             outcome.denial.as_deref(),
             Some("declared program hash mismatch")
         );
+        assert!(outcome.execution.is_none());
         assert!(outcome.output.as_ref().map_or(true, Vec::is_empty));
         assert_eq!(crate::cells::live_count(&state), 0);
         eprintln!("PASS: declared tool mismatch refused by actual guest");

--- a/crates/celln-cli/tests/fixtures/dispatch_outcome_probe.rs
+++ b/crates/celln-cli/tests/fixtures/dispatch_outcome_probe.rs
@@ -5,6 +5,7 @@ unsafe extern "C" {
     fn write(fd: i32, buf: *const u8, count: usize) -> isize;
     fn fork() -> i32;
     fn waitpid(pid: i32, status: *mut i32, options: i32) -> i32;
+    fn syscall(number: i64, ...) -> i64;
 }
 
 fn main() {
@@ -45,6 +46,10 @@ fn main() {
         }
         Some("substrate") => print!("{}", std::fs::read_to_string("/celln/work/substrate-marker").unwrap()),
         Some("warm") => {
+            // x86_64 SYS_syslog, SYSLOG_ACTION_CONSOLE_ON. The workload
+            // cannot restore kernel messages onto pilot's report console.
+            assert_eq!(unsafe { syscall(103, 7i32, 0i32, 0i32) }, -1);
+            assert_eq!(io::Error::last_os_error().raw_os_error(), Some(1));
             // Try the supervisor-only PIO port after exec: it must fault,
             // proving pilot revoked the I/O bitmap grant before the workload.
             let child = unsafe { fork() };

--- a/crates/celln-pilot/src/dispatch_report.rs
+++ b/crates/celln-pilot/src/dispatch_report.rs
@@ -3,11 +3,21 @@
 use serde::{Deserialize, Serialize};
 
 pub const PREFIX: &str = "CELLN:dispatch=";
-pub const PROTOCOL: &str = "CELLN:dispatch-protocol=4";
+pub const PROTOCOL: &str = "CELLN:dispatch-protocol=5";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutionGrant {
+    pub tool: String,
+    pub lane: String,
+    pub workspace: Option<String>,
+    pub fetch: bool,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Frame {
+    Started { grant: ExecutionGrant },
     Inputs { hashes: Vec<String> },
     Output { bytes: Vec<u8> },
     Exit { code: i32 },

--- a/crates/celln-pilot/src/guest.rs
+++ b/crates/celln-pilot/src/guest.rs
@@ -736,7 +736,12 @@ fn child_error(error_fd: i32, error: io::Error) -> ! {
 /// lookup. `execveat(AT_EMPTY_PATH)` binds the exec to this exact file
 /// description even if its old name is replaced between verification and
 /// execution.
-fn exec_open_file(file: &File, req: &RunRequest, confine: bool) -> io::Result<ExitStatus> {
+fn exec_open_file(
+    file: &File,
+    req: &RunRequest,
+    confine: bool,
+    grant: Option<pilot::dispatch_report::ExecutionGrant>,
+) -> io::Result<ExitStatus> {
     let capture = if req.report_output_limit.is_some() {
         let mut fds = [-1; 2];
         if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } != 0 {
@@ -877,6 +882,13 @@ fn exec_open_file(file: &File, req: &RunRequest, confine: bool) -> io::Result<Ex
     };
     unsafe { libc::close(error_pipe[0]) };
     let read_error = (read < 0).then(io::Error::last_os_error);
+    // EOF on the CLOEXEC error pipe acknowledges successful child setup and
+    // exec. Publish before forwarding output, never on an errno/setup failure.
+    if read == 0 && req.report_output_limit.is_some() {
+        if let Some(grant) = grant {
+            emit(Frame::Started { grant });
+        }
+    }
 
     let mut capture_error = None;
     if let Some((mut reader, writer, null)) = capture {
@@ -1152,6 +1164,17 @@ fn stage_inputs(req: &RunRequest) -> io::Result<()> {
 }
 
 fn run_one(manifest: &Manifest, req: &RunRequest) {
+    if req.report_output_limit.is_some() && unsafe { libc::syscall(libc::SYS_syslog, 6, 0, 0) } != 0
+    {
+        // SYSLOG_ACTION_CONSOLE_OFF: kernel trap diagnostics can otherwise
+        // interleave with a supervisor JSON frame on the shared serial tty.
+        // Preserve printk's ring buffer, but reserve the dispatcher console
+        // for pilot. Workload capabilities cannot re-enable kernel logging.
+        emit(Frame::Failed {
+            reason: "exclusive report console unavailable".into(),
+        });
+        return;
+    }
     if stage_inputs(req).is_err() {
         emit(Frame::Failed {
             reason: "input delivery refused".into(),
@@ -1229,7 +1252,20 @@ fn run_one(manifest: &Manifest, req: &RunRequest) {
             // The host slices on them so a cell can be piped like any process.
             println!("CELLN:out-begin");
             let confine = lane != Lane::Tool;
-            let status = exec_open_file(&executable, req, confine);
+            let grant = pilot::dispatch_report::ExecutionGrant {
+                tool: hash.0.clone(),
+                lane: lane.to_string(),
+                workspace: req.workspace_access.map(|access| {
+                    match access {
+                        WorkspaceAccess::None => "none",
+                        WorkspaceAccess::ReadOnly => "read-only",
+                        WorkspaceAccess::ReadWrite => "read-write",
+                    }
+                    .to_owned()
+                }),
+                fetch: req.allow_fetch,
+            };
+            let status = exec_open_file(&executable, req, confine, Some(grant));
             println!("CELLN:out-end");
 
             if req.report_output_limit.is_some() {
@@ -1320,7 +1356,8 @@ mod tests {
             workspace_access: None,
             inputs: Vec::new(),
         };
-        let status = exec_open_file(&verified, &request, false).expect("executes verified fd");
+        let status =
+            exec_open_file(&verified, &request, false, None).expect("executes verified fd");
         assert!(
             status.success(),
             "the opened /bin/true bytes must run, not replacement /bin/false"

--- a/crates/celln-warden/src/vmm/boot.rs
+++ b/crates/celln-warden/src/vmm/boot.rs
@@ -833,6 +833,7 @@ pub struct LinuxCell {
     /// Host-owned egress capability, absent unless explicitly enabled.
     http: Option<HttpBroker>,
     fetch_request: Vec<u8>,
+    fetch_activity: (u64, u64, u64), // attempts, denied, successful response bytes
     fetch_response: VecDeque<u8>,
     /// Per-cell, one-shot invocation data. Never captured in a mote.
     invocation: Option<VecDeque<u8>>,
@@ -978,6 +979,7 @@ impl LinuxCell {
             serial: Serial::default(),
             http: None,
             fetch_request: Vec::new(),
+            fetch_activity: (0, 0, 0),
             fetch_response: VecDeque::new(),
             invocation: None,
             pci_cf8: 0,
@@ -1052,6 +1054,7 @@ impl LinuxCell {
     }
 
     fn dispatch_fetch(&mut self) {
+        self.fetch_activity.0 = self.fetch_activity.0.saturating_add(1);
         let request = std::str::from_utf8(&self.fetch_request)
             .map(str::trim)
             .map(str::to_owned)
@@ -1064,14 +1067,25 @@ impl LinuxCell {
             )),
         };
         let bytes = match body {
-            Ok(body) => body,
-            Err(e) => format!("CELLN_FETCH_ERROR:{e}").into_bytes(),
+            Ok(body) => {
+                self.fetch_activity.2 = self.fetch_activity.2.saturating_add(body.len() as u64);
+                body
+            }
+            Err(e) => {
+                self.fetch_activity.1 = self.fetch_activity.1.saturating_add(1);
+                format!("CELLN_FETCH_ERROR:{e}").into_bytes()
+            }
         };
         // Length framing makes response bytes opaque: HTML, newlines and NULs
         // cross as data, not as a second control protocol.
         self.fetch_response
             .extend((bytes.len() as u32).to_le_bytes());
         self.fetch_response.extend(bytes);
+    }
+
+    /// Host-observed broker counters. No URLs, headers or response values.
+    pub fn fetch_activity(&self) -> (u64, u64, u64) {
+        self.fetch_activity
     }
 
     /// Stop as soon as the guest signals it is doing userspace work, and
@@ -1328,6 +1342,7 @@ impl LinuxCell {
                 },
                 http: None,
                 fetch_request: Vec::new(),
+                fetch_activity: (0, 0, 0),
                 fetch_response: VecDeque::new(),
                 invocation: None,
                 pci_cf8: 0,

--- a/docs/DECLARED_SUBSTRATES.md
+++ b/docs/DECLARED_SUBSTRATES.md
@@ -72,9 +72,10 @@ before parsing or executing. No arguments, requested egress authority or output
 from one cell are snapshotted for another. No executable, module or manifest is
 overlaid. Future receipts should record the invocation digest too.
 
-Use pilot dispatch protocol 4, which enforces `expected_hash`, implements the
+Use pilot dispatch protocol 5, which enforces `expected_hash`, implements the
 warm invocation channel and acknowledges staged immutable inputs. Protocol 4
-also applies explicit workspace confinement to every dispatcher lane. Pinning a bundle
+also applies explicit workspace confinement to every dispatcher lane. Protocol 5
+adds the actual execution-grant acknowledgement described in [audit](DISPATCH_AUDIT.md). Pinning a bundle
 asserts its pilot implements that protocol and its boot code preserves the
 invocation seam. Host and pilot must be upgraded together. Legacy bundle
 descriptors can still be inspected by `resolve-file`, but cannot launch without

--- a/docs/DISPATCH_AUDIT.md
+++ b/docs/DISPATCH_AUDIT.md
@@ -1,0 +1,88 @@
+# Correlated execution audit
+
+`GET /v1/executions/<request-id>/audit` requires the dispatcher bearer token.
+It returns `apiVersion: "celln.dev/audit-v1alpha1"`, request/caller/workload/node
+identities, a bounded lifecycle event list, observed execution evidence, and
+the original terminal receipt when available. Unknown/expired audits return 404.
+Audits share execution-record lifetime and retention; this is not durable
+storage or an OpenTelemetry exporter.
+
+## Compatibility
+
+The existing `celln.dev/v1alpha1` request, receipt and ordinary execution polling
+response are unchanged. Strict receipt readers therefore keep working. Audit
+consumers opt into the separate endpoint and version, and can parse its nested
+`receipt` with the existing strict receipt schema. A caller correlates the
+envelope and receipt by request, node and cell IDs.
+
+Host and pilot must both use dispatch protocol 5. Rebuild and repin older
+declared bundles; protocol 3/4 cannot establish success on this host. Legacy
+non-dispatch CLI behavior is unchanged. The format identifier for the static
+warm bundle is unchanged, but pinning it approves the upgraded pilot protocol.
+
+## Evidence, not requested intent
+
+`execution.pilot` contains the hash of the opened executable, actual selected
+lane, installed workspace mode and fetch-helper grant. Pilot emits this only
+after the CLOEXEC error-pipe handshake acknowledges child setup/exec, before
+forwarding workload output. Failed hash admission or exec setup emits no grant.
+The host checks it against the resolved tool and requested upper bounds; a
+missing, duplicate, reordered or inconsistent report cannot establish success.
+An agent-authored tool requested in the tool lane still reports `agent`.
+
+`execution.granted` contains the host-enforced memory, timeout, output and egress
+bounds plus the acknowledged workspace mode. It is null without a valid pilot
+grant. Bounds are limits, not consumed resources or measured durations.
+`execution.inputs` names hashes pilot actually rehashed and staged; staging can
+precede an exec refusal, so it is distinct from granted workload authority.
+
+`execution.substrate` records hashes of the loaded kernel, loaded initrd,
+sealed toolfs and per-cell invocation bytes. The loaded initrd includes the
+fixed warm-dispatch marker and therefore differs from the base bundle's initrd
+hash; the unchanged receipt still identifies the declared bundle. Forge runs
+have actual substrate hashes but do not invent a declared mote identity.
+These are loader identities, not claims that a refused tool executed.
+
+Broker activity is counted by the host: request attempts, denied requests and
+successful response bytes. It contains no URLs, headers or response bodies.
+Exit code and signal are separate fields. `watchdogStopped` describes a VMM
+watchdog stop, which can be cancellation or deadline; the terminal receipt and
+ordered lifecycle phases distinguish the result.
+
+Lifecycle events include acceptance, preparation/resolution, cell-running,
+dissolution and terminal outcome. Cell-running is the host entering the VMM run
+loop, not proof of exec; use the pilot grant for that. Dissolution is recorded
+after dropping the cell handle. Events are ordered using monotonic host
+observations even when cancellation arrives before the completed cell report.
+Wall-clock timestamps are for correlation, not performance measurement.
+
+## Console integrity and sensitive data
+
+Workload stdout/stderr remains framed output data, never an audit-control frame.
+For dispatcher runs pilot disables kernel console logging before execution:
+a reproduced trap diagnostic had interleaved with a grant frame on the serial
+console. Kernel messages remain in the guest printk buffer, and the narrowed
+workload cannot re-enable console logging. An unavailable exclusive console
+refuses explicitly. Malformed reports still fail closed; they are not repaired
+by searching for a plausible JSON fragment.
+
+The audit excludes task text, argv, environment, input bytes, workload output
+and free-form diagnostics. It carries identifying metadata and content hashes;
+operators must not put secrets into caller/workload IDs. Ordinary inputs are
+not a secret provider. Missing pre-exec evidence remains null rather than being
+filled from the request. Audit data trusts the approved substrate and pilot;
+it is not attestation against a malicious approved kernel.
+
+## Verification and remaining work
+
+Host tests cover receipt compatibility over TCP, authentication, payload
+exclusion, lifecycle ordering, duplicate/reordered/spoofed grants and refused
+setup. Real KVM tests check actual selected lanes, loaded image hashes, broker
+denial counters, and guest failure to re-enable console logging, alongside
+existing warm isolation, input/workspace, cancellation and deadline probes.
+Run both ignored dispatcher suites after building static pilot binaries.
+
+This advances #10's one-node correlation requirement. OpenTelemetry transport,
+durable audit storage, richer pre-admission refusal traces and fleet-revocation
+events remain separate work. #12 must validate the integrated service path and
+#2 must retain fresh external Sympozium evidence before the epic can close.

--- a/docs/DISPATCH_INPUTS.md
+++ b/docs/DISPATCH_INPUTS.md
@@ -61,8 +61,9 @@ separate stage-2 guarantee. Legacy non-dispatch CLI/image behavior is unchanged.
 
 ## Compatibility and evidence
 
-Dispatcher host and pilot must use protocol 4 together. Repin/rebuild declared
-bundles when upgrading from protocol 3; older reports cannot establish success.
+Dispatcher host and pilot must use protocol 5 together. Repin/rebuild declared
+bundles when upgrading from protocol 3/4; older reports cannot establish success.
+Protocol 5 adds an acknowledged execution grant; see [audit](DISPATCH_AUDIT.md).
 The invocation transport cap grows from 64 KiB to 1 MiB to accommodate JSON
 encoding of bounded input bytes; the raw input budget remains 64 KiB.
 

--- a/integrations/kubernetes/README.md
+++ b/integrations/kubernetes/README.md
@@ -51,6 +51,11 @@ reports preflight readiness without exposing cache identities. See
 [input/workspace authority](../../docs/DISPATCH_INPUTS.md) for configuration,
 trust boundaries and compatibility requirements.
 
+For actual granted authority, selected lane, loaded substrate hashes and broker
+activity, opt into authenticated `GET /v1/executions/<id>/audit`. Its separately
+versioned [audit envelope](../../docs/DISPATCH_AUDIT.md) includes the unchanged
+terminal receipt, preserving existing strict receipt consumers.
+
 ## Exercise actual Celln cells on the KVM host
 
 The Kind proof is intentionally a preflight because its node lacks real Celln


### PR DESCRIPTION
## Summary

Advances #10 and epic #2, stacked on #62.

- Add authenticated `/v1/executions/<id>/audit` with `celln.dev/audit-v1alpha1`: correlated caller/workload/node/cell identity, bounded monotonic-ordered lifecycle events, actual execution evidence and the unchanged terminal receipt.
- Preserve strict v1alpha1 receipt and ordinary polling compatibility through a separate opt-in endpoint.
- Pilot protocol 5 acknowledges the actual opened tool hash, selected lane and installed workspace/fetch grant after the exec handshake. Missing/duplicate/reordered/inconsistent grants cannot establish success; setup refusals have no invented grant.
- Record actual loaded kernel/initrd/toolfs and invocation hashes for declared and forge execution, plus host-observed broker attempt/denial/response-byte counters.
- Exclude argv, task text, environment, input/output values, URLs and free-form diagnostics from the audit.
- Fix a reproduced reporting race: kernel trap logs interleaved with pilot grant JSON. Dispatcher pilot disables kernel console printing (retaining the log buffer); a real guest attempts and fails to restore it.

## Verification

- `make ci`: pass.
- TCP audit authentication and legacy strict receipt compatibility: pass.
- Payload exclusion, monotonic cancellation ordering and duplicate/reordered/output-spoofed grants: pass.
- Both real KVM dispatcher suites: pass, including exact substrate hashes, actual tool/agent lanes, retained agent authorship, setup/refusal absence of grants, broker denial counts, and guest denial of console-log re-enabling.
- Five consecutive declared-substrate KVM runs passed after the console-race fix.
- `make acceptance-kvm fetch-proof`: pass.

## Migration and remaining work

Upgrade host/pilot together and rebuild/repin protocol-5 declared bundles. The existing request/receipt API is unchanged. Audit bounds are limits, not consumed resources; loaded artifact identities are distinct from acknowledged workload execution. `watchdogStopped` is a VMM stop, with cancellation/deadline result distinguished by terminal receipt/lifecycle.

This is not durable audit storage, an OpenTelemetry exporter, or attestation against a malicious approved kernel. #10 remains open for its wider transport/trace scope. #12 integrated service conformance and fresh external Sympozium evidence for #2 remain required before closing the epic.
