### PR TITLE
Prove production dispatcher and Kubernetes refusal conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,14 @@ jobs:
           cargo test -p celln-warden --features kvm
           cargo run -p celln-cli -- verify --no-json
           make acceptance-kvm
-          cargo build --release --target x86_64-unknown-linux-musl -p celln-pilot --bin celln-pilot --bin pilot-fetch
-          cargo test -p celln-cli dispatch_outcomes_on_real_kvm -- --ignored --nocapture
-          cargo test -p celln-cli declared_substrate_on_real_kvm -- --ignored --nocapture
+          make conformance-kvm
+      - name: retain dispatcher conformance evidence
+        if: always() && steps.kvm.outputs.have == 'yes'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dispatcher-conformance
+          path: target/dispatch-conformance/
+          if-no-files-found: warn
       - name: no /dev/kvm on this runner
         if: steps.kvm.outputs.have == 'no'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,12 @@ fetch-proof: ## prove a real cell fetches HTTPS through pilot (needs /dev/kvm + 
 	@$(CARGO) run --quiet -p celln-pilot --features kvm --bin celln-fetch-proof -- $(FETCH_URL)
 
 .PHONY: acceptance-kvm
+.PHONY: conformance-kvm
+conformance-kvm: ## production dispatcher HTTP and real guest conformance
+	@$(CARGO) build -p celln-cli
+	@$(CARGO) build --release --target x86_64-unknown-linux-musl -p celln-pilot --bin celln-pilot --bin pilot-fetch
+	@$(CARGO) test -p celln-cli on_real_kvm -- --ignored --nocapture
+
 acceptance-kvm: ## prove setup, agent cell, output, and ps on real KVM
 	@$(CARGO) build --quiet -p celln-cli
 	@./scripts/acceptance-agent-cell.sh

--- a/crates/celln-cli/src/dispatch_conformance.rs
+++ b/crates/celln-cli/src/dispatch_conformance.rs
@@ -1,0 +1,367 @@
+//! Public HTTP → production worker → real KVM → receipt/audit proof.
+//! Called from the ignored declared-substrate proof to reuse its exact fixture.
+
+use celln_spec::ExecutionRequest;
+use serde_json::{json, Value};
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const TOKEN: &str = "isolated-conformance-token-not-a-real-secret";
+
+struct Server {
+    child: Child,
+    address: SocketAddr,
+    evidence: PathBuf,
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Server {
+    fn http(&self, method: &str, path: &str, body: Option<&Value>, token: &str) -> (u16, Value) {
+        let mut socket = TcpStream::connect(self.address).unwrap();
+        socket
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        socket
+            .set_write_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let body = body.map(Value::to_string).unwrap_or_default();
+        write!(socket, "{method} {path} HTTP/1.1\r\nAuthorization: Bearer {token}\r\nContent-Length: {}\r\n\r\n{body}", body.len()).unwrap();
+        let mut response = String::new();
+        socket.read_to_string(&mut response).unwrap();
+        let (header, body) = response.split_once("\r\n\r\n").unwrap();
+        (
+            header.split_whitespace().nth(1).unwrap().parse().unwrap(),
+            serde_json::from_str(body).unwrap(),
+        )
+    }
+
+    fn save(&self, name: &str, value: &Value) {
+        std::fs::write(
+            self.evidence.join(format!("{name}.json")),
+            serde_json::to_vec_pretty(value).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn submit(&self, request: &ExecutionRequest) {
+        let value = serde_json::to_value(request).unwrap();
+        self.save(&format!("{}-request", request.id), &value);
+        let (status, body) = self.http("POST", "/v1/executions", Some(&value), TOKEN);
+        assert_eq!(status, 202, "{body}");
+    }
+
+    fn terminal(&self, request: &ExecutionRequest, expected: &str) -> Value {
+        let started = Instant::now();
+        let result = loop {
+            let (status, body) = self.http(
+                "GET",
+                &format!("/v1/executions/{}", request.id),
+                None,
+                TOKEN,
+            );
+            assert_eq!(status, 200, "{body}");
+            if matches!(
+                body["phase"].as_str(),
+                Some("Succeeded" | "Failed" | "Cancelled" | "Refused")
+            ) {
+                break body;
+            }
+            assert!(
+                started.elapsed() < Duration::from_secs(20),
+                "execution did not terminate: {body}"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        };
+        self.save(&format!("{}-result", request.id), &result);
+        assert_eq!(result["phase"], expected, "{result}");
+        let (status, audit) = self.http(
+            "GET",
+            &format!("/v1/executions/{}/audit", request.id),
+            None,
+            TOKEN,
+        );
+        assert_eq!(status, 200, "{audit}");
+        self.save(&format!("{}-audit", request.id), &audit);
+        assert_eq!(audit["requestId"], request.id);
+        assert_eq!(audit["caller"], request.workload.caller);
+        if let Some(receipt) = result.get("receipt") {
+            let parsed: celln_spec::ExecutionReceipt =
+                serde_json::from_value(receipt.clone()).unwrap();
+            assert!(parsed.problems().is_empty(), "invalid receipt: {receipt}");
+            assert_eq!(audit["receipt"], *receipt);
+            assert_eq!(audit["execution"]["cellId"], receipt["cellId"]);
+            assert!(audit["events"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|event| event["phase"] == "Dissolved"));
+        }
+        let (_, node) = self.http("GET", "/v1/node", None, TOKEN);
+        assert_eq!(node["node"]["live_cells"], 0, "reservation leak: {node}");
+        assert_eq!(node["node"]["memory_bytes"], 268435456u64);
+        assert_eq!(node["node"]["egress_slots"], 1);
+        audit
+    }
+}
+
+pub(crate) fn prove(base: ExecutionRequest, motes: &Path, tools: &Path, root: &Path) {
+    let isolated_root = root.join("http-conformance");
+    std::fs::create_dir(&isolated_root).unwrap();
+    std::fs::copy(
+        root.join("trusted-motes.json"),
+        isolated_root.join("trusted-motes.json"),
+    )
+    .unwrap();
+    let root = isolated_root.as_path();
+    let input = celln_store::Store::open(root.join("inputs"))
+        .unwrap()
+        .put(b"first-input")
+        .unwrap();
+    std::fs::write(
+        root.join("trusted-inputs.json"),
+        serde_json::to_vec(&json!({"apiVersion": "celln.dev/v1alpha1", "hashes": [input.0]}))
+            .unwrap(),
+    )
+    .unwrap();
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let binary = repo.join("target/debug/celln");
+    assert!(
+        binary.is_file(),
+        "build the dispatcher first: cargo build -p celln-cli"
+    );
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let evidence = repo.join(format!(
+        "target/dispatch-conformance/{nonce}-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&evidence).unwrap();
+    let address = TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap();
+    let token = root.join("conformance-token");
+    std::fs::write(&token, TOKEN).unwrap();
+    let log = std::fs::File::create(evidence.join("dispatcher.log")).unwrap();
+    let child = Command::new(&binary)
+        .arg("--root")
+        .arg(root)
+        .arg("dispatcher")
+        .arg("--listen")
+        .arg(address.to_string())
+        .arg("--token-file")
+        .arg(token)
+        .arg("--mote-store")
+        .arg(motes)
+        .arg("--tool-store")
+        .arg(tools)
+        .args([
+            "--node-name",
+            "conformance",
+            "--max-cells",
+            "2",
+            "--memory-bytes",
+            "268435456",
+            "--egress-slots",
+            "1",
+            "--allow-egress-host",
+            "example.com",
+        ])
+        .stdin(Stdio::null())
+        .stdout(log.try_clone().unwrap())
+        .stderr(log)
+        .spawn()
+        .unwrap();
+    let mut server = Server {
+        child,
+        address,
+        evidence,
+    };
+    let started = Instant::now();
+    while TcpStream::connect(address).is_err() {
+        assert!(
+            server.child.try_wait().unwrap().is_none(),
+            "dispatcher exited; see {}",
+            server.evidence.display()
+        );
+        assert!(started.elapsed() < Duration::from_secs(5));
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert_eq!(server.http("GET", "/v1/node", None, "wrong").0, 401);
+    let (_, health) = server.http("GET", "/v1/health", None, "");
+    assert_eq!(health["ok"], true, "{health}");
+    server.save("health", &health);
+    let mut request = base;
+    request.capabilities.timeout_ms = 15000;
+    for (mode, phase, code) in [
+        ("silent", "Succeeded", 0),
+        ("failed", "Failed", 7),
+        ("spoof", "Failed", 9),
+        ("fetch-grant", "Succeeded", 0),
+    ] {
+        request.id = format!("http-{mode}");
+        request.invocation.as_mut().unwrap().args = vec![mode.into()];
+        request.capabilities.egress = if mode == "fetch-grant" {
+            vec!["https://example.com".into()]
+        } else {
+            vec![]
+        };
+        server.submit(&request);
+        let audit = server.terminal(&request, phase);
+        assert_eq!(audit["execution"]["exitCode"], code);
+        assert_eq!(audit["execution"]["pilot"]["tool"], request.tools[0].hash);
+        assert_eq!(audit["execution"]["pilot"]["lane"], "agent");
+        if mode == "silent" {
+            assert!(audit["receipt"]["output"].is_null());
+        }
+        if mode == "fetch-grant" {
+            assert_eq!(audit["execution"]["broker"]["denied"], 1);
+        }
+    }
+    request.capabilities.egress.clear();
+    for (access, name) in [
+        (celln_spec::WorkspaceAccess::None, "none"),
+        (celln_spec::WorkspaceAccess::ReadOnly, "read-only"),
+        (celln_spec::WorkspaceAccess::ReadWrite, "read-write"),
+    ] {
+        request.id = format!("http-workspace-{name}");
+        request.capabilities.workspace = access;
+        request.invocation.as_mut().unwrap().args = vec!["workspace".into(), name.into()];
+        server.submit(&request);
+        let audit = server.terminal(&request, "Succeeded");
+        assert_eq!(audit["execution"]["granted"]["workspace"], name);
+    }
+    request.id = "http-input".into();
+    request.inputs.push(celln_spec::ExecutionInput {
+        name: "data".into(),
+        hash: celln_manifest::Hash::of(b"first-input").0,
+        media_type: "text/plain".into(),
+        bytes: 11,
+    });
+    request.invocation.as_mut().unwrap().args = vec!["inputs".into(), "first-input".into()];
+    server.submit(&request);
+    let audit = server.terminal(&request, "Succeeded");
+    assert_eq!(
+        audit["receipt"]["resolved"]["inputs"],
+        json!([request.inputs[0].hash])
+    );
+    request.inputs.clear();
+    let mut unapproved = request.clone();
+    unapproved.id = "http-unapproved-input".into();
+    unapproved.inputs.push(celln_spec::ExecutionInput {
+        name: "data".into(),
+        hash: celln_manifest::Hash::of(b"unapproved").0,
+        media_type: "text/plain".into(),
+        bytes: 10,
+    });
+    server.submit(&unapproved);
+    let audit = server.terminal(&unapproved, "Refused");
+    assert!(audit["execution"].is_null());
+    assert!(audit["receipt"].is_null());
+    let mut unsupported = request.clone();
+    unsupported.id = "http-unsupported-closure".into();
+    unsupported.tools[0].closure = Some(celln_spec::ImmutableRef {
+        hash: celln_manifest::Hash::of(b"closure").0,
+    });
+    let refusal = server.http(
+        "POST",
+        "/v1/executions",
+        Some(&serde_json::to_value(unsupported).unwrap()),
+        TOKEN,
+    );
+    assert_eq!(refusal.0, 422);
+    assert_eq!(refusal.1["reason"], "unsupported");
+    server.save("unsupported-closure", &refusal.1);
+    request.invocation.as_mut().unwrap().args = vec!["timeout".into()];
+    request.capabilities.egress = vec!["https://example.com".into()];
+    request.id = "http-cancel".into();
+    server.submit(&request);
+    let started = Instant::now();
+    while crate::cells::live_count(root) == 0 {
+        assert!(started.elapsed() < Duration::from_secs(5));
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    std::thread::sleep(Duration::from_millis(300));
+    let (_, busy) = server.http("GET", "/v1/node", None, TOKEN);
+    assert_eq!(busy["node"]["live_cells"], 1);
+    assert_eq!(busy["node"]["memory_bytes"], 0);
+    assert_eq!(busy["node"]["egress_slots"], 0);
+    server.save("busy-capacity", &busy);
+    // Duplicate ID is idempotent; another request cannot overcommit RAM even
+    // though the configured two-cell slot limit has room.
+    server.submit(&request);
+    let mut excess = request.clone();
+    excess.id = "http-excess".into();
+    assert_eq!(
+        server
+            .http(
+                "POST",
+                "/v1/executions",
+                Some(&serde_json::to_value(&excess).unwrap()),
+                TOKEN
+            )
+            .0,
+        503
+    );
+    assert_eq!(
+        server
+            .http("POST", "/v1/executions/http-cancel/cancel", None, "wrong")
+            .0,
+        401
+    );
+    assert_eq!(
+        server
+            .http("POST", "/v1/executions/http-cancel/cancel", None, TOKEN)
+            .0,
+        202
+    );
+    let audit = server.terminal(&request, "Cancelled");
+    assert!(
+        audit["receipt"]["output"].is_object(),
+        "guest must have run before cancellation"
+    );
+    assert_eq!(crate::cells::live_count(root), 0);
+    request.id = "http-deadline".into();
+    request.capabilities.timeout_ms = 700;
+    server.submit(&request);
+    let audit = server.terminal(&request, "Failed");
+    assert_eq!(audit["execution"]["watchdogStopped"], true);
+    assert_eq!(crate::cells::live_count(root), 0);
+    request.id = "http-revoked-tool".into();
+    request.capabilities.timeout_ms = 15000;
+    request.invocation.as_mut().unwrap().args = vec!["silent".into()];
+    let mut assayer = assay::Assayer::open(root.join("assay")).unwrap();
+    let bytes = celln_store::Store::open(tools)
+        .unwrap()
+        .get(&celln_manifest::Hash(request.tools[0].hash.clone()))
+        .unwrap();
+    let tool_hash = assayer
+        .admit_verified("/tools/program", &bytes, false)
+        .unwrap();
+    assayer.revoke(&tool_hash);
+    server.submit(&request);
+    let audit = server.terminal(&request, "Failed");
+    assert!(audit["execution"].is_null());
+    let (_, refusal) = server.http("GET", "/v1/executions/http-revoked-tool", None, TOKEN);
+    assert!(refusal["reason"].as_str().unwrap().contains("revoked"));
+    server.save("summary", &json!({"suite": "dispatcher-real-kvm", "status": "passed", "revision": String::from_utf8(Command::new("git").args(["rev-parse", "HEAD"]).current_dir(&repo).output().unwrap().stdout).unwrap().trim(),
+        "dirty": !Command::new("git").args(["status", "--porcelain"]).current_dir(&repo).output().unwrap().stdout.is_empty(),
+        "binary": celln_manifest::Hash::of(&std::fs::read(&binary).unwrap()).0,
+        "host": String::from_utf8(Command::new("uname").args(["-srmo"]).output().unwrap().stdout).unwrap().trim(),
+        "cases": ["silent", "failed", "spoof", "fetch-grant", "workspace-none", "workspace-read-only", "workspace-read-write", "immutable-input", "unapproved-input", "unsupported-closure", "cancel", "deadline", "aggregate-memory", "revoked-tool", "audit", "authentication"]}));
+    eprintln!(
+        "PASS: production dispatcher HTTP conformance; evidence {}",
+        server.evidence.display()
+    );
+}

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -674,7 +674,13 @@ fn run_execution(
     }
     let started_at = crate::dispatch::now_rfc3339();
     if let Err(error) = crate::dispatch::inputs::resolve(&request, &root) {
-        return fail_execution(&executions, &request.id, error);
+        // Policy/provider admission refused before any program executes. Do
+        // not label this a workload failure or invent a terminal guest receipt.
+        update_execution(&executions, &request.id, |record| {
+            record.phase = "Refused".into();
+            record.reason = Some(error);
+        });
+        return;
     }
     let assay_root = root.join("assay");
 
@@ -1102,48 +1108,50 @@ mod tests {
 
     #[test]
     fn unsupported_forge_authority_is_refused_without_side_effects() {
-        let mut request = request_with_egress(&[]);
-        request.capabilities.workspace = celln_spec::WorkspaceAccess::ReadWrite;
-        request.inputs.push(celln_spec::ExecutionInput {
-            name: "oversized".into(),
-            hash: celln_manifest::Hash::of(b"data").0,
-            media_type: "text/plain".into(),
-            bytes: 65537,
-        });
-        let work = tempfile::tempdir().unwrap();
-        let root = work.path().join("must-not-be-created");
-        let executions: Executions = Arc::new(Mutex::new(HashMap::new()));
-        executions.lock().unwrap().insert(
-            request.id.clone(),
-            Entry::new(ExecutionRecord {
-                request_id: request.id.clone(),
-                phase: "Admitting".into(),
-                reason: None,
-                output: None,
-                receipt: None,
-            }),
-        );
-        let probe = NodeProbeArgs {
-            node_name: "test".into(),
-            mote_store: root.join("motes"),
-            tool_store: root.join("tools"),
-            max_cells: 1,
-            memory_bytes: 268435456,
-            egress_slots: 0,
-        };
-        run_execution(
-            request.clone(),
-            Arc::clone(&executions),
-            probe,
-            root.clone(),
-        );
-        let registry = executions.lock().unwrap();
-        let record = &registry[&request.id].value;
-        assert_eq!(record.phase, "Refused");
-        assert!(record.reason.as_deref().unwrap().contains("input budget"));
-        assert!(record.receipt.is_none());
-        assert!(!execution_is_active(record));
-        assert!(!root.exists());
+        for (bytes, expected) in [(65537, "input budget"), (4, "input trust policy")] {
+            let mut request = request_with_egress(&[]);
+            request.capabilities.workspace = celln_spec::WorkspaceAccess::ReadWrite;
+            request.inputs.push(celln_spec::ExecutionInput {
+                name: "oversized".into(),
+                hash: celln_manifest::Hash::of(b"data").0,
+                media_type: "text/plain".into(),
+                bytes,
+            });
+            let work = tempfile::tempdir().unwrap();
+            let root = work.path().join("must-not-be-created");
+            let executions: Executions = Arc::new(Mutex::new(HashMap::new()));
+            executions.lock().unwrap().insert(
+                request.id.clone(),
+                Entry::new(ExecutionRecord {
+                    request_id: request.id.clone(),
+                    phase: "Admitting".into(),
+                    reason: None,
+                    output: None,
+                    receipt: None,
+                }),
+            );
+            let probe = NodeProbeArgs {
+                node_name: "test".into(),
+                mote_store: root.join("motes"),
+                tool_store: root.join("tools"),
+                max_cells: 1,
+                memory_bytes: 268435456,
+                egress_slots: 0,
+            };
+            run_execution(
+                request.clone(),
+                Arc::clone(&executions),
+                probe,
+                root.clone(),
+            );
+            let registry = executions.lock().unwrap();
+            let record = &registry[&request.id].value;
+            assert_eq!(record.phase, "Refused");
+            assert!(record.reason.as_deref().unwrap().contains(expected));
+            assert!(record.receipt.is_none());
+            assert!(!execution_is_active(record));
+            assert!(!root.exists());
+        }
     }
 
     #[test]

--- a/crates/celln-cli/src/dispatch_substrate.rs
+++ b/crates/celln-cli/src/dispatch_substrate.rs
@@ -524,6 +524,13 @@ mod tests {
             eprintln!("PASS: immutable named input {data} delivered on same warm mote");
         }
 
+        crate::dispatch_conformance::prove(
+            request(&bundle_hash, &program_hash),
+            &motes,
+            &tools,
+            &state,
+        );
+
         // Stop a real running guest without refreshing the end-to-end timer.
         for cancel in [false, true] {
             let control = celln_control::Control::new(std::time::Duration::from_secs(if cancel {

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -4,6 +4,8 @@ mod agent;
 mod cells;
 mod config;
 mod dispatch;
+#[cfg(all(test, target_os = "linux"))]
+mod dispatch_conformance;
 mod dispatch_http;
 mod host;
 mod image;

--- a/crates/celln-cli/tests/fixtures/dispatch_outcome_probe.rs
+++ b/crates/celln-cli/tests/fixtures/dispatch_outcome_probe.rs
@@ -19,6 +19,11 @@ fn main() {
             println!("fetch-grant:host-refused-http");
         }
         Some("workspace") => {
+            // Actual guest attempts, in both tool and agent lanes: ordinary
+            // socket creation and mount-namespace privilege must be denied.
+            assert_eq!(unsafe { syscall(41, 2i32, 1i32, 0i32) }, -1);
+            assert_eq!(io::Error::last_os_error().raw_os_error(), Some(1));
+            assert_eq!(unsafe { unshare(0x0002_0000) }, -1);
             let access = std::env::args().nth(2).unwrap();
             let marker = "/celln/work/substrate-marker";
             assert_eq!(std::fs::read(marker).is_ok(), access != "none");

--- a/crates/celln-pilot/src/guest_seccomp_tests.rs
+++ b/crates/celln-pilot/src/guest_seccomp_tests.rs
@@ -5,7 +5,7 @@ use std::os::fd::FromRawFd;
 const SECCOMP_GET_ACTION_AVAIL: libc::c_uint = 2;
 const SECCOMP_RET_ERRNO: u32 = 0x0005_0000;
 
-type ChildReport = [i64; 7];
+type ChildReport = [i64; 11];
 const SUPPORT_ERRNO: usize = 0;
 const NO_NEW_PRIVS_ERRNO: usize = 1;
 const INSTALL_ERRNO: usize = 2;
@@ -13,6 +13,10 @@ const GETPID_RESULT: usize = 3;
 const SOCKET_ERRNO: usize = 4;
 const SOCKETPAIR_ERRNO: usize = 5;
 const CONNECT_ERRNO: usize = 6;
+const X32_ERRNO: usize = 7;
+const URING_SETUP_ERRNO: usize = 8;
+const URING_ENTER_ERRNO: usize = 9;
+const URING_REGISTER_ERRNO: usize = 10;
 
 fn errno() -> i32 {
     io::Error::last_os_error().raw_os_error().unwrap_or(0)
@@ -39,7 +43,7 @@ unsafe fn write_report_and_exit(fd: libc::c_int, report: &ChildReport) -> ! {
 }
 
 unsafe fn exercise_filter(write_fd: libc::c_int) -> ! {
-    let mut report: ChildReport = [0; 7];
+    let mut report: ChildReport = [0; 11];
 
     // This query lets the parent distinguish a genuinely unavailable seccomp
     // filter API from a malformed production filter. It does not install a
@@ -92,6 +96,23 @@ unsafe fn exercise_filter(write_fd: libc::c_int) -> ! {
     if libc::syscall(libc::SYS_connect, -1, std::ptr::null::<libc::sockaddr>(), 0) < 0 {
         report[CONNECT_ERRNO] = errno() as i64;
     }
+    // x32 shares AUDIT_ARCH_X86_64: its syscall-number tag must be rejected
+    // even when the underlying ordinary syscall (getpid) is allowed.
+    if libc::syscall(libc::SYS_getpid | 0x4000_0000) < 0 {
+        report[X32_ERRNO] = errno() as i64;
+    }
+    // Invalid pointers/fds would ordinarily produce EFAULT/EBADF/ENOSYS.
+    // EPERM proves the production filter intercepts all io_uring entrypoints
+    // before any opcode could provide an alternate socket/network path.
+    for (syscall, index) in [
+        (libc::SYS_io_uring_setup, URING_SETUP_ERRNO),
+        (libc::SYS_io_uring_enter, URING_ENTER_ERRNO),
+        (libc::SYS_io_uring_register, URING_REGISTER_ERRNO),
+    ] {
+        if libc::syscall(syscall, -1i64, 0i64, 0i64, 0i64, 0i64, 0i64) < 0 {
+            report[index] = errno() as i64;
+        }
+    }
 
     write_report_and_exit(write_fd, &report)
 }
@@ -111,7 +132,7 @@ fn actual_network_seccomp_filter_denies_network_but_allows_getpid() {
     }
 
     unsafe { libc::close(pipe_fds[1]) };
-    let mut report: ChildReport = [0; 7];
+    let mut report: ChildReport = [0; 11];
     let report_bytes = unsafe {
         std::slice::from_raw_parts_mut(
             report.as_mut_ptr().cast::<u8>(),
@@ -158,6 +179,10 @@ fn actual_network_seccomp_filter_denies_network_but_allows_getpid() {
         ("socket", report[SOCKET_ERRNO]),
         ("socketpair", report[SOCKETPAIR_ERRNO]),
         ("connect", report[CONNECT_ERRNO]),
+        ("x32 getpid", report[X32_ERRNO]),
+        ("io_uring_setup", report[URING_SETUP_ERRNO]),
+        ("io_uring_enter", report[URING_ENTER_ERRNO]),
+        ("io_uring_register", report[URING_REGISTER_ERRNO]),
     ] {
         assert_eq!(
             got,

--- a/docs/DISPATCH_CONFORMANCE.md
+++ b/docs/DISPATCH_CONFORMANCE.md
@@ -1,0 +1,54 @@
+# One-node execution conformance
+
+`make conformance-kvm` builds the production dispatcher and static pilot, then
+runs both ignored real-KVM dispatcher suites. The declared-substrate fixture
+also starts a separate `celln dispatcher` process on loopback with its own state
+root, host policy and token. Requests go through the public HTTP endpoints,
+not a replacement worker or fake VMM. No model account is required.
+
+## Cases and evidence
+
+- Silent success, output followed by nonzero exit, and output-marker spoofing.
+- Declared mote/tool identities, actual lane/grants and strict receipt/audit correlation.
+- Host-broker denial, with host counters, without depending on public HTTPS availability.
+- All workspace modes; guest read/write/exec/socket/namespace denial attempts.
+- Verified immutable input delivery, unapproved input refusal and unsupported closure refusal.
+- Cancellation after the guest ran, end-to-end deadline, and no residual live cell.
+- Atomic memory/broker reservation observations, duplicate-ID idempotence and capacity refusal.
+- Local tool revocation observed on a warm-cache hit, without executing the revoked tool.
+- Authentication on node/audit/cancellation paths.
+
+Evidence goes to unique `target/dispatch-conformance/<timestamp>-<pid>/`
+directories: requests, results, audits, dispatcher log, configured/busy capacity
+and a summary with revision, dirty-worktree flag, binary digest and host identity.
+Never present a dirty-worktree run as proof of its parent commit. CI uploads
+these artifacts when a KVM runner executes the suite. Missing hardware/kernel/
+toolchain prerequisites can skip; absence of a passing evidence summary is not
+an isolation pass. Invalid code, failed assertions and service errors fail.
+
+The ordinary-host production seccomp test also tries x32-tagged getpid and all
+three io_uring entrypoints. It requires EPERM from the real installed filter,
+not a substitute policy. Existing warden tests remain the hardware proof of
+stage-2 sealing and live unmapping; `make fetch-proof` separately exercises an
+actual public HTTPS request.
+
+## Kubernetes preflight
+
+`integrations/kubernetes/prove.sh` refreshes the unsupported-hardware fixture
+from contributor PR #25 on the current execution stack. It creates its own Kind
+cluster and isolated kubeconfig, loads the actual static CLI, and runs a Job
+without `/dev/kvm`, host mounts, elevated capabilities or service-account token.
+The proof requires both exit 5 and a JSON `unsupported` refusal with `node.kvm`
+false. Evidence is retained under a unique `target/kubernetes-proof/run.*` path.
+Docker and Podman providers are supported; the script never reuses an existing
+cluster or edits the user's Kubernetes context or host kernel/cgroup settings.
+
+## Remaining scope
+
+These proofs cover the one-node milestone, not fresh external Sympozium
+controller behavior. The epic still requires that integration run on the
+intended revision, plus merged-stack validation. Secret leases/live provider
+withdrawal, distributed revocation and multi-node scheduling are not claimed.
+Unsupported closures still refuse; their eventual implementation needs its own
+conformance extension. The existing #25 can be retired once this refreshed
+harness is accepted, retaining its contributor attribution.

--- a/integrations/kubernetes/Dockerfile
+++ b/integrations/kubernetes/Dockerfile
@@ -9,4 +9,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /opt/celln/runtime /var/lib/celln
+COPY celln /usr/local/bin/celln
 ENTRYPOINT ["/usr/local/bin/celln"]

--- a/integrations/kubernetes/README.md
+++ b/integrations/kubernetes/README.md
@@ -23,12 +23,18 @@ the host root filesystem, or an ambient network capability into a cell.
 ./integrations/kubernetes/prove.sh
 ```
 
-The script builds and loads the local image, deploys the DaemonSet, and writes the
-real node report and admission verdict below `target/kubernetes-proof/`. Results
-depend on that cluster's KVM, kernel and configured stores. An unavailable KVM
-boundary is `unsupported`, never silently downgraded. Prepare and authorize the
-requested artifacts before dispatching declared workloads; do not create
-placeholder files to imitate object availability.
+The script builds and loads the local image into a new disposable Kind cluster,
+runs an unprivileged Job without `/dev/kvm`, and requires exit 5 plus a structured
+`unsupported` refusal. It never deploys into your current Kubernetes context:
+kubeconfig is isolated and an existing cluster name is refused. Evidence is kept
+in a unique `target/kubernetes-proof/run.*` directory; the owned cluster is removed
+on exit unless `KEEP_CLUSTER=1` is explicitly set. This refreshes the useful
+unsupported-hardware harness originally contributed in PR #25.
+
+Docker or Podman can provide the containers. `KIND_EXPERIMENTAL_PROVIDER=podman`
+selects Podman; see the [Kind rootless requirements](https://kind.sigs.k8s.io/docs/user/rootless/).
+`CELLN_KIND_BIN` selects a project-local Kind executable. Missing tools/runtime
+fail explicitly; this proof never modifies host cgroup or kernel settings.
 
 The command emits JSON only. `verdict: accepted` means the node admitted the intent;
 it does not claim the request's workload was run. An accepted node now also requires
@@ -36,7 +42,7 @@ a readable loader-compatible guest kernel with matching modules. This remains
 preflight, not a proof that a particular guest boots. The versioned terminal result contract is
 [`examples/execution/succeeded-receipt.json`](../../examples/execution/succeeded-receipt.json);
 it binds a request, node, cell, resolved authority, and optional output to immutable
-BLAKE3 references. `celln dispatch serve` now executes requests and returns terminal
+BLAKE3 references. `celln dispatcher` now executes requests and returns terminal
 results through its authenticated execution endpoints. Declared requests fork an
 operator-pinned warm mote; forge requests build their program before preparing and
 forking a mote. Fresh external Sympozium integration acceptance remains tracked in #2.
@@ -58,10 +64,26 @@ terminal receipt, preserving existing strict receipt consumers.
 
 ## Exercise actual Celln cells on the KVM host
 
-The Kind proof is intentionally a preflight because its node lacks real Celln
-stores. The companion harness exercises the execution path the node will dispatch
-once provisioned: model-authored code is forged twice, sealed, and run in a real
-cell; bounded web tasks use the guest-only `/pilot-fetch` ABI.
+The Kind proof is intentionally an unsupported-hardware preflight. For actual
+production dispatcher HTTP → worker → KVM → receipt/audit conformance, run:
+
+```sh
+make conformance-kvm
+```
+
+The real-KVM fixture starts a separate loopback dispatcher process and submits
+silent success, nonzero exit, output spoofing, broker refusal, all workspace modes,
+immutable input delivery, denied input/closure authority, cancellation, deadline,
+capacity pressure and locally revoked-tool cases through the public HTTP API.
+It validates receipts/audits and reservation release and retains requests/results,
+audit records, binary identity and revision/dirty/environment metadata under
+`target/dispatch-conformance/`. These fixtures do not call a model or mutate
+operator state. Hardware prerequisites may skip; a skipped run is not evidence
+that isolation passed. The broader kernel sealing/hostile-guest proofs remain
+in `celln verify` and the warden suite.
+
+The companion benchmark harness exercises model-authored tasks: code is forged
+twice, sealed and run in a real cell; bounded web tasks use `/pilot-fetch`.
 
 ```sh
 ./scripts/benchmark-kubernetes-agents.sh --runs 10 --parallel 2

--- a/integrations/kubernetes/conformance/unsupported-hardware.yaml
+++ b/integrations/kubernetes/conformance/unsupported-hardware.yaml
@@ -1,0 +1,71 @@
+# Adapted from muddlebee's PR #25; intentionally no KVM device or host mounts.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: celln-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: celln-conformance-unsupported-request
+  namespace: celln-system
+data:
+  request.json: |
+    {
+      "apiVersion": "celln.dev/v1alpha1",
+      "id": "celln-conformance-unsupported",
+      "workload": {"id": "conformance-unsupported", "caller": "celln:conformance"},
+      "mote": {"hash": "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+      "tools": [],
+      "capabilities": {"workspace": "none", "egress": [], "timeoutMs": 30000, "memoryBytes": 268435456, "outputBytes": 65536},
+      "execution": {"lane": "agent", "requireHardwareIsolation": true}
+    }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: celln-conformance-unsupported
+  namespace: celln-system
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: celln-conformance
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      containers:
+      - name: conformance
+        image: celln-node:dev
+        imagePullPolicy: Never
+        command: ["/bin/sh", "-ec"]
+        args:
+        - |
+          set +e
+          output="$(celln node admit /requests/request.json --node-name="$NODE_NAME" --mote-store=/var/lib/celln/motes --tool-store=/var/lib/celln/tools --max-cells=1 --memory-bytes=268435456 2>&1)"
+          status=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$status" -ne 5 ]; then
+            echo "expected unsupported exit 5, got $status" >&2
+            exit 1
+          fi
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: request
+          mountPath: /requests
+          readOnly: true
+      volumes:
+      - name: request
+        configMap:
+          name: celln-conformance-unsupported-request

--- a/integrations/kubernetes/prove.sh
+++ b/integrations/kubernetes/prove.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Refreshed from muddlebee's PR #25: isolated kubeconfig, unique evidence,
+# Docker/Podman providers, and no mutation of any pre-existing cluster.
+set -euo pipefail
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+out="${CELLN_KUBERNETES_PROOF_DIR:-$root/target/kubernetes-proof}"
+cluster="${CELLN_KIND_CLUSTER:-celln-conformance-$$}"
+kind_bin="${CELLN_KIND_BIN:-kind}"
+provider="${KIND_EXPERIMENTAL_PROVIDER:-}"
+if [[ -z "$provider" ]]; then
+  if command -v docker >/dev/null; then provider=docker; else provider=podman; fi
+fi
+[[ "$provider" == docker || "$provider" == podman ]] || { echo 'provider must be docker or podman' >&2; exit 1; }
+[[ "$cluster" =~ ^celln-conformance-[a-z0-9-]+$ ]] || { echo 'use a unique celln-conformance-* cluster name' >&2; exit 1; }
+for tool in cargo jq rg kubectl "$kind_bin" "$provider"; do
+  command -v "$tool" >/dev/null || { echo "missing prerequisite: $tool" >&2; exit 1; }
+done
+[[ "$(uname -m)" == x86_64 ]] || { echo 'requires x86_64' >&2; exit 1; }
+"$provider" info >/dev/null
+export KIND_EXPERIMENTAL_PROVIDER="$provider"
+clusters="$("$kind_bin" get clusters)"
+if rg -Fxq "$cluster" <<< "$clusters"; then
+  echo "refusing to reuse existing cluster: $cluster" >&2; exit 1
+fi
+work="$(mktemp -d /tmp/celln-conformance.XXXXXX)"
+export KUBECONFIG="$work/kubeconfig"
+created=false
+cleanup() {
+  if [[ "$created" == true && "${KEEP_CLUSTER:-0}" != 1 ]]; then
+    "$kind_bin" delete cluster --name "$cluster" >/dev/null 2>&1 || true
+  fi
+  [[ "$work" == /tmp/celln-conformance.* && -d "$work" ]] && rm -rf -- "$work"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+mkdir -p "$out"
+evidence="$(mktemp -d "$out/run.XXXXXX")"
+image="localhost/celln-conformance:$$"
+(
+  cd "$root"
+  cargo build --release --locked --target x86_64-unknown-linux-musl -p celln-cli
+)
+binary="$root/target/x86_64-unknown-linux-musl/release/celln"
+cp "$binary" "$work/celln"
+"$provider" build --tag "$image" --file "$root/integrations/kubernetes/Dockerfile" "$work"
+"$provider" save --output "$work/image.tar" "$image"
+created=true
+"$kind_bin" create cluster --name "$cluster" --wait 120s
+"$kind_bin" load image-archive "$work/image.tar" --name "$cluster"
+sed "s|celln-node:dev|$image|" "$root/integrations/kubernetes/conformance/unsupported-hardware.yaml" |
+  kubectl --context "kind-$cluster" apply -f -
+if ! kubectl --context "kind-$cluster" -n celln-system wait --for=condition=complete job/celln-conformance-unsupported --timeout=120s; then
+  kubectl --context "kind-$cluster" -n celln-system describe job/celln-conformance-unsupported >&2 || true
+  kubectl --context "kind-$cluster" -n celln-system logs job/celln-conformance-unsupported >&2 || true
+  exit 1
+fi
+kubectl --context "kind-$cluster" -n celln-system logs job/celln-conformance-unsupported | tee "$evidence/unsupported-hardware.json"
+jq -e '.verdict == "refused" and .reason == "unsupported" and .request_id == "celln-conformance-unsupported" and .node.kvm == false' "$evidence/unsupported-hardware.json" >/dev/null
+jq -n --slurpfile result "$evidence/unsupported-hardware.json" \
+  --arg revision "$(git -C "$root" rev-parse HEAD)" --arg provider "$provider" \
+  --arg binary "$(sha256sum "$binary" | cut -d ' ' -f 1)" \
+  --arg kind "$("$kind_bin" version)" --arg runtime "$("$provider" --version)" \
+  --arg dirty "$(git -C "$root" status --porcelain)" \
+  '{suite:"celln-kubernetes-conformance",status:"passed",revision:$revision,dirty:($dirty != ""),provider:$provider,kind:$kind,runtime:$runtime,binarySha256:$binary,cases:[{name:"unsupported_hardware",status:"passed",evidence:$result[0]}]}' > "$evidence/summary.json"
+echo "PASS: Kubernetes unsupported-hardware preflight; evidence $evidence"


### PR DESCRIPTION
## Summary

Stacked on #63. Advances #12 and epic #2; neither is closed by this slice.

- Exercise a separate production dispatcher over HTTP on real KVM: outcomes, pinned identities, workspace/input authority, cancellation/deadline teardown, aggregate reservations, authenticated audit, and warm-cache local revocation.
- Return unsupported input policy/provider failures as Refused without a guest receipt.
- Add actual guest socket/namespace denial attempts and production seccomp x32/io_uring regressions.
- Add `make conformance-kvm` and CI evidence upload.
- Refresh the isolated Kind unsupported-hardware proof from #25, preserving contributor attribution; include the missing CLI in the container image and support Podman as well as Docker.

## Verification

Clean revision: `ae5562c9804430a4280dee1666f927a55b0ed782`.

- `make ci`: passed (fmt, clippy, build, tests).
- `make conformance-kvm`: both real-KVM suites passed, including 16 production HTTP conformance case labels. Evidence: `target/dispatch-conformance/1788692248178884672-1073720/summary.json` (dirty=false); requests/results/audits/logs retained alongside it.
- `CELLN_KIND_BIN=target/conformance-tools/kind-v0.33.0/kind-linux-amd64 KIND_EXPERIMENTAL_PROVIDER=podman integrations/kubernetes/prove.sh`: passed; Job returned exit 5 and structured unsupported refusal with node.kvm=false. Evidence: `target/kubernetes-proof/run.xXZHr6/summary.json` (dirty=false).
- Host Linux 7.1.12-200.fc44.x86_64, Kind v0.33.0, Podman 5.8.4. Temporary cluster removed; existing Kubernetes context unchanged.

Local evidence paths are not hosted artifacts. CI hardware checks can skip without prerequisites and are not a substitute for the real-KVM run above.

## Limits

Fresh external Sympozium controller acceptance and merged-stack validation remain. No claim of secret-provider live withdrawal, distributed revocation, multi-node scheduling, or closure support. #25 can be retired after this replacement is accepted.
