### PR TITLE
Exercise an external controller against the real KVM fixture

### DIFF
--- a/crates/celln-cli/src/dispatch_conformance.rs
+++ b/crates/celln-cli/src/dispatch_conformance.rs
@@ -161,7 +161,7 @@ pub(crate) fn prove(base: ExecutionRequest, motes: &Path, tools: &Path, root: &P
         .arg("--listen")
         .arg(address.to_string())
         .arg("--token-file")
-        .arg(token)
+        .arg(&token)
         .arg("--mote-store")
         .arg(motes)
         .arg("--tool-store")
@@ -338,6 +338,46 @@ pub(crate) fn prove(base: ExecutionRequest, motes: &Path, tools: &Path, root: &P
     let audit = server.terminal(&request, "Failed");
     assert_eq!(audit["execution"]["watchdogStopped"], true);
     assert_eq!(crate::cells::live_count(root), 0);
+    // Optional full external-controller proof. The operator explicitly opts
+    // into a local executable; ordinary CI never creates a Kubernetes cluster.
+    // It receives only this isolated fixture's address/token and pinned request.
+    if let Some(proof) = std::env::var_os("CELLN_SYMPOZIUM_PROOF") {
+        let mut reference = request.clone();
+        reference.capabilities.timeout_ms = 15000;
+        reference.capabilities.egress.clear();
+        reference.capabilities.workspace = celln_spec::WorkspaceAccess::ReadOnly;
+        reference.execution.lane = celln_spec::RequestedLane::Tool;
+        reference.invocation.as_mut().unwrap().args = vec!["silent".into()];
+        reference.inputs = vec![celln_spec::ExecutionInput {
+            name: "data".into(),
+            hash: celln_manifest::Hash::of(b"first-input").0,
+            media_type: "text/plain".into(),
+            bytes: 11,
+        }];
+        server.save(
+            "external-reference",
+            &serde_json::to_value(reference).unwrap(),
+        );
+        let status = Command::new("timeout")
+            .args(["--signal=TERM", "--kill-after=10s", "600s"])
+            .arg(proof)
+            .env("CELLN_ROUTER_URL", format!("http://{}", server.address))
+            .env("CELLN_TOKEN_FILE", &token)
+            .env("CELLN_PROOF_ROOT", root)
+            .env("CELLN_PROOF_BINARY", &binary)
+            .env(
+                "CELLN_PROOF_REQUEST",
+                server.evidence.join("external-reference.json"),
+            )
+            .env("CELLN_PROOF_EVIDENCE", server.evidence.join("sympozium"))
+            .status()
+            .expect("start explicitly configured external proof");
+        assert!(
+            status.success(),
+            "external Sympozium proof failed: {status}"
+        );
+        assert_eq!(crate::cells::live_count(root), 0);
+    }
     request.id = "http-revoked-tool".into();
     request.capabilities.timeout_ms = 15000;
     request.invocation.as_mut().unwrap().args = vec!["silent".into()];

--- a/docs/DISPATCH_CONFORMANCE.md
+++ b/docs/DISPATCH_CONFORMANCE.md
@@ -43,6 +43,31 @@ false. Evidence is retained under a unique `target/kubernetes-proof/run.*` path.
 Docker and Podman providers are supported; the script never reuses an existing
 cluster or edits the user's Kubernetes context or host kernel/cgroup settings.
 
+## External Sympozium controller proof
+
+An explicit `CELLN_SYMPOZIUM_PROOF` executable extends the real-KVM fixture
+before local revocation. The fixture passes its isolated loopback URL, test
+credential file, pinned request and evidence directory. It does not pass a
+production credential or existing cluster context. The external process has a
+600-second bound and a 10-second termination grace period.
+
+Sympozium's `test/integration/test-celln-real-controller.sh` creates its own
+Kind/Podman cluster and kubeconfig, installs the real CRDs, builds and runs the
+production controller, and submits actual AgentRuns. It verifies immutable
+execution, outcomes, guest restrictions, refusal, timeout and deletion-driven
+cancellation, retaining statuses, dispatcher records, audits and binary/revision
+metadata. No model account is needed for this static reference program.
+
+```sh
+CELLN_KIND_BIN=/absolute/path/to/kind \
+CELLN_SYMPOZIUM_PROOF=/absolute/path/to/sympozium/test/integration/test-celln-real-controller.sh \
+make conformance-kvm
+```
+
+Opting in runs the specified local script with the user's permissions; inspect
+it first. Ordinary `make ci` and `make conformance-kvm` do not create this cluster.
+External evidence lives in the conformance run's `sympozium/` subdirectory.
+
 ## Remaining scope
 
 These proofs cover the one-node milestone, not fresh external Sympozium


### PR DESCRIPTION
## Summary

Advances epic #2 with an optional external-controller proof hook in the existing real-KVM fixture.

The explicitly configured executable receives only the isolated fixture's loopback URL, test token path, immutable request, cell registry root and evidence directory. It is bounded by timeout 600s plus a 10s termination grace. Ordinary CI never creates a Kubernetes cluster.

The companion Sympozium proof runs the production controller, actual Kubernetes AgentRuns and this real dispatcher/KVM. Eleven cases passed: outcomes, immutable inputs/workspaces, refusals, timeout and deletion cancellation, correlated receipts and released reservations. Initial evidence `target/dispatch-conformance/1788702349148555697-1156057/sympozium/` is a dirty implementation run; clean and merged revision evidence follows.

`make ci` passed with the hook disabled. The external process is opt-in user code, not an untrusted request field. Docs explain permissions, topology, artifacts and commands. This PR does not close the epic before the final external merged-stack acceptance.
