### PR TITLE
Record verified one-node Sympozium acceptance and remaining scope

### DIFF
--- a/docs/DISPATCH_CONFORMANCE.md
+++ b/docs/DISPATCH_CONFORMANCE.md
@@ -70,10 +70,10 @@ External evidence lives in the conformance run's `sympozium/` subdirectory.
 
 ## Remaining scope
 
-These proofs cover the one-node milestone, not fresh external Sympozium
-controller behavior. The epic still requires that integration run on the
-intended revision, plus merged-stack validation. Secret leases/live provider
+The optional external proof covers the actual Sympozium controller, not just an
+HTTP client substitute. A complete acceptance run requires passing summaries
+for both repositories on the intended clean revisions. Secret leases/live provider
 withdrawal, distributed revocation and multi-node scheduling are not claimed.
 Unsupported closures still refuse; their eventual implementation needs its own
-conformance extension. The existing #25 can be retired once this refreshed
-harness is accepted, retaining its contributor attribution.
+conformance extension. Contributor PR #25 was superseded by merged #64, with
+its attribution retained.

--- a/docs/SYMPOZIUM_ACCEPTANCE.md
+++ b/docs/SYMPOZIUM_ACCEPTANCE.md
@@ -1,0 +1,66 @@
+# One-node Sympozium acceptance — 2026-09-06
+
+The one-node milestone in [epic #2](https://github.com/sympozium-ai/celln/issues/2)
+passed on merged Celln `c4a2c9670a088a00d7d7353dd0a669403fd26b29` and merged
+Sympozium `aabe054989aec9db5ae29b3b76da8bfbdc8a0509`. Both worktrees were clean.
+The final real-KVM suites passed (2 tests, 165.82 seconds), including all 11
+external-controller cases. This is a tested one-node execution seam, not a claim
+that arbitrary agents, closures or a production cluster deployment are supported.
+
+## Environment and retained evidence
+
+- Linux `7.1.12-200.fc44.x86_64`, actual `/dev/kvm`, readable kernel and static musl pilot/tool fixtures.
+- Kind v0.33.0 with Podman 5.8.4. Kind supplied a real Kubernetes API and CRDs;
+  the production Sympozium controller and Celln dispatcher ran on the host.
+- The controller used its configured bearer credential over isolated loopback.
+  It created no fallback Jobs. Both temporary clusters were removed and the
+  original `kubernetes-admin@kubernetes` context was unchanged.
+- [Committed evidence](evidence/2026-09-06-one-node.json) retains revisions,
+  binary digests, requests, validated persisted receipts, actual grants and
+  loaded substrate identities, audits, refusals and final capacity.
+
+Full local artifacts (including controller/dispatcher logs and Kubernetes status):
+`target/dispatch-conformance/1788703099494392717-1182367/`, with external cases in
+`sympozium/`. The separate unsupported-hardware proof is under
+`target/kubernetes-proof/run.rtuTap/`. Local paths are not hosted artifacts; the
+committed evidence is the portable acceptance record. The cancellation status
+snapshot precedes deletion; its audit proves the resulting terminal state.
+
+## Requirement-by-requirement result
+
+| Requirement | Evidence |
+| --- | --- |
+| Versioned control-plane contract | Production controller submits `celln.dev/v1alpha1`; original request is frozen before dispatch, then correlated with the receipt. |
+| Truthful outcomes (#13) | Silent exit 0 succeeds; output + exit 7 fails; spoofed success markers + exit 9 fail. Separate real-KVM forge-mode runtime cases cover signals, output bounds and pilot refusal. |
+| Pinned substrate and warm spawn (#13) | Declared kernel/initrd/toolfs are actually loaded; altered/invalid substrates cannot substitute the host default. Repeated warm forks preserve private scratch and do not increment preparation count. |
+| Input/workspace authority (#3/#7) | Actual guest reads the declared immutable input, attempts mutation/rename/link/exec, and checks all three workspace modes. Guest socket/namespace/root-read/scratch-exec attempts are denied. |
+| Explicit refusal | Unsupported closure and unapproved input produce failed/refused control-plane results without guest receipts; no alternate backend Job is created. A no-KVM Kubernetes Job returns exit 5 with structured `unsupported`. |
+| Capacity/readiness (#5) | HTTP conformance observes atomic cell/guest-RAM/broker reservations and capacity refusal; terminal paths restore 256MiB guest RAM and one broker slot. Cache hints remain advisory. |
+| Actual provenance (#10) | Controller persists the validated full receipt, including null/empty fields. Authenticated audit records the executed tool/lane/input hashes, loaded substrate hashes, grants and broker counts, correlated to AgentRun UID/caller and cell. |
+| Cancellation/deadline (#13/#12) | Deleting an AgentRun cancels the exact observed live cell; its nonempty output proves guest execution. Finalizers wait for teardown. Deadline watchdog stops the guest; all reservations return. |
+| Hardware/conformance (#12) | Both real-KVM suites pass; `celln verify` passes hostile ring-0 sealing and live revocation attempts; x32/io_uring production seccomp regressions pass in `make ci`. |
+
+Also passed: `make ci`, `make fetch-proof` (actual brokered HTTPS), and
+`scripts/acceptance-agent-cell.sh` (deterministic model-response fixture with real
+build/reproduce/seal/execute/history, not an external model-service test).
+Sympozium PR checks passed formatting, vet, build, tests and generated-code/CRD sync;
+local controller/API tests passed with the race detector.
+
+## Reproduce
+
+Follow [conformance setup and commands](DISPATCH_CONFORMANCE.md). The external
+proof needs Sympozium's `test/integration/test-celln-real-controller.sh`, Kind and
+Podman in addition to the normal KVM prerequisites. No model account is needed.
+Missing prerequisites are not an isolation pass. Hosted Celln CI lacked KVM and
+skipped hardware proofs; the acceptance evidence above comes from real local KVM.
+
+## Deliberate boundaries
+
+The reference program is static: #6's closure implementation is not needed for
+this milestone and closures still refuse. Operator-pinned content is the trust
+root here; no asymmetric publisher-signature guarantee is claimed. Secret leases
+and live provider withdrawal (#7), OpenTelemetry/durable audit transport (#10),
+extended distributed conformance (#12), fleet revocation (#8), persistence (#9)
+and broad comparative benchmarks (#11) remain separate work. Guest-RAM accounting
+is not total host RSS; this is not CRI replacement, whole-AgentRun sidecar parity,
+multi-node scheduling, or an upgrade of legacy deployed installer images.

--- a/docs/SYMPOZIUM_ENSEMBLE_INTEGRATION.md
+++ b/docs/SYMPOZIUM_ENSEMBLE_INTEGRATION.md
@@ -41,7 +41,7 @@ an agent-to-agent, delegation, or shared-memory participant.
 4. The shim writes the canonical Celln request from immutable policy-selected hashes. It must not derive an executable tool/mote hash from prompt text, pod image tags, mutable ConfigMaps, or a shared-memory record.
 5. The Celln node agent validates the request then checks KVM, a bootable guest kernel, and resolved signed substrate/tool artifacts. It returns `accepted`, `invalid_request`, `unsupported`, or `no_eligible_node`.
 6. Only an accepted request may reach a per-cell warden. One accepted request maps to one warden, one microVM, and one sealed cell. `warden` emits an execution receipt containing the Celln request ID, lifecycle timestamps, and content-addressed output/artifact hashes.
-7. The Sympozium controller writes that receipt to `AgentRun.status.conditions`; it retains the existing human result/status behavior and uses the output hashes to create the next edge's `inputs[]`.
+7. The Sympozium controller retains the validated receipt in `AgentRun.status.cellnReceipt`; it keeps human-readable result/status separate and uses output hashes, not mutable result text, to create a future edge's `inputs[]`.
 
 ## Information-flow rules
 
@@ -51,68 +51,50 @@ an agent-to-agent, delegation, or shared-memory participant.
 - A source cell's output is harvested only after it has dissolved. The output reference has no path, tag, or arbitrary URL that the guest can reinterpret as code.
 - Egress remains the Celln pilot ABI: named HTTPS destinations only, brokered by the host. Ensemble shared memory does not add ambient network access.
 
-## Current Celln evidence (2026-09-06)
+## Verified one-node integration
 
-The implementation stack through [PR #64](https://github.com/sympozium-ai/celln/pull/64),
-revision `ae5562c9804430a4280dee1666f927a55b0ed782`, passed `make ci` and both
-real-KVM dispatcher suites from a clean worktree. These are branch results,
-not a claim that the stack has merged or that an external controller ran it.
+The fresh production-controller proof passed on merged Celln
+`c4a2c9670a088a00d7d7353dd0a669403fd26b29` and Sympozium
+`aabe054989aec9db5ae29b3b76da8bfbdc8a0509`, both clean. See
+[the acceptance record](SYMPOZIUM_ACCEPTANCE.md) for all requirements, commands,
+environment, binary identities and committed evidence.
 
-- The production dispatcher was exercised over authenticated HTTP, executing
-  the operator-approved declared kernel/initrd/tool bytes from warm mote forks.
-  The earlier limitation of ignoring the declared kernel is fixed in this stack.
-- Silent success, nonzero failure, forged output markers, guest workspace
-  restrictions, immutable inputs and unsupported authority were tested.
-- Cancellation and end-to-end deadlines stopped execution and released cell,
-  aggregate guest-memory and egress-broker reservations. Guest-memory accounting
-  is not a total host-RSS bound.
-- Receipt/audit correlation records executed substrate identities, actual grants
-  and broker counters. Local tool revocation refuses a warm-cache execution.
-- An isolated Kind Job without KVM returned exit 5 and a structured unsupported
-  refusal. This is refusal evidence, not a successful Kubernetes-to-KVM proof.
+The production Sympozium controller ran against actual Kubernetes CRDs and
+AgentRuns in a disposable Kind cluster, speaking the authenticated versioned
+contract to an isolated host Celln dispatcher. Celln executed real KVM cells from
+the approved declared substrate. Eleven external cases covered silent success,
+nonzero failure, marker spoofing, immutable inputs, workspace restrictions,
+unsupported authority, timeout and deletion cancellation. No fallback Jobs were
+created, and terminal paths released their reservations.
 
-The commands, coverage and evidence format are in
-[`DISPATCH_CONFORMANCE.md`](DISPATCH_CONFORMANCE.md). Clean-revision local
-summaries are under `target/dispatch-conformance/1788692248178884672-1073720/`
-and `target/kubernetes-proof/run.xXZHr6/`; these paths are not hosted artifacts.
-Earlier reported Kubernetes/AgentRun demonstrations are historical only and
-do not establish compatibility with the current authenticated dispatcher.
+The controller gaps previously identified at Sympozium
+`fa1bc53a828fae3ec644bdafdc9ed061135c6eb1` were repaired in
+[PRs #421](https://github.com/sympozium-ai/sympozium/pull/421),
+[#422](https://github.com/sympozium-ai/sympozium/pull/422),
+[#423](https://github.com/sympozium-ai/sympozium/pull/423) and
+[#424](https://github.com/sympozium-ai/sympozium/pull/424):
 
-## External controller gap
+- Operator-mounted bearer authentication, rotation, redirect refusal and explicit
+  transport configuration; no credential is derived from task text.
+- Explicit immutable `spec.celln` requests, independent of a model task, frozen
+  in `status.cellnRequest` before first dispatch.
+- Complete receipt validation and correlation against the frozen request, with
+  canonical null/empty fields retained in `status.cellnReceipt`.
+- Authenticated remote cancellation and finalizers that wait for terminal
+  teardown on deletion or controller deadline.
 
-Read-only inspection of Sympozium main at
-`fa1bc53a828fae3ec644bdafdc9ed061135c6eb1` found the following in
-[`internal/controller/agentrun_celln.go`](https://github.com/sympozium-ai/sympozium/blob/fa1bc53a828fae3ec644bdafdc9ed061135c6eb1/internal/controller/agentrun_celln.go):
+The Kind node did not provide nested KVM: the real controller and dispatcher
+ran on the host, and Kind supplied the Kubernetes API. A separate unprivileged
+Kind Job proved the no-KVM unsupported refusal. Neither proof deployed into the
+existing cluster or upgraded legacy installer images.
 
-- POST and polling requests carry no bearer token. Direct calls to the current
-  authenticated dispatcher therefore refuse; disabling authentication is not
-  an acceptable integration fix.
-- The request type supports forge only, not a predeclared immutable mote/tool/
-  input request. It cannot express the static pinned reference proof yet.
-- A `Succeeded` record is accepted without validating a complete receipt or
-  correlating its request identity. Only bounded output is persisted as the
-  result; selected receipt fields are logged, not retained as provenance.
-- Its backstop deadline fails the AgentRun locally without calling Celln's
-  cancellation endpoint. That path does not prove remote teardown.
+## Boundaries and next work
 
-These findings are source inspection, not a fresh external runtime test. The
-controller integration must be repaired and tested before the epic's full-path
-acceptance can pass. No changes to Sympozium or an existing cluster are implied
-by this document.
+The static reference does not require dependency closures; unsupported closures
+still refuse. Secret-provider live withdrawal, distributed revocation, persistent
+execution, multi-node scheduling and broader tracing remain outside this
+one-node milestone. See the acceptance record for the issue ownership.
 
-## Next acceptance run
-
-Use an isolated test environment and record both repository revisions, dirty
-flags, node prerequisites and binary/image identities. Provision the dispatcher
-token through operator configuration, never through task text. Submit one
-operator-pinned static program and bounded immutable input through the actual
-Sympozium controller using the versioned contract; retain the original request,
-AgentRun status, terminal receipt and authenticated audit.
-
-Check silent success and nonzero failure, unsupported authority refusal,
-cancellation and timeout teardown, guest denial attempts, exact identities and
-released reservations. A missing/invalid/mismatched receipt must not become
-success, and refusal must not fall back to a different backend. Repeat on the
-merged stack before closing [epic #2](https://github.com/sympozium-ai/celln/issues/2).
-Live availability gating for the UI and broader agent/ensemble integration
-remain separate from this first hermetic-action proof.
+Full agent/ensemble/sidecar integration and live UI availability policy remain
+separate from the verified hermetic-action seam. Historical demonstrations are
+not evidence for those broader features.

--- a/docs/evidence/2026-09-06-one-node.json
+++ b/docs/evidence/2026-09-06-one-node.json
@@ -1,0 +1,1506 @@
+{
+  "dispatcher": {
+    "binary": "blake3:7031514b03a13ba58764eb76fb90d3fdae8855818cf4d8cd20c0b3077f0ea380",
+    "cases": [
+      "silent",
+      "failed",
+      "spoof",
+      "fetch-grant",
+      "workspace-none",
+      "workspace-read-only",
+      "workspace-read-write",
+      "immutable-input",
+      "unapproved-input",
+      "unsupported-closure",
+      "cancel",
+      "deadline",
+      "aggregate-memory",
+      "revoked-tool",
+      "audit",
+      "authentication"
+    ],
+    "dirty": false,
+    "host": "Linux 7.1.12-200.fc44.x86_64 x86_64 GNU/Linux",
+    "revision": "c4a2c9670a088a00d7d7353dd0a669403fd26b29",
+    "status": "passed",
+    "suite": "dispatcher-real-kvm"
+  },
+  "sympozium": {
+    "suite": "sympozium-real-controller-celln-kvm",
+    "status": "passed",
+    "revision": "aabe054989aec9db5ae29b3b76da8bfbdc8a0509",
+    "dirty": false,
+    "controllerSha256": "bb4d81a6d73fa479da7abd76e34a5281f0cef7a8a811981606f13806ffe0f345",
+    "kind": "kind v0.33.0 go1.26.7 linux/amd64",
+    "cases": [
+      "silent",
+      "failed",
+      "spoof",
+      "inputs",
+      "workspace-none",
+      "workspace-read-only",
+      "workspace-read-write",
+      "unsupported",
+      "unapproved-input",
+      "timeout",
+      "delete-cancel"
+    ]
+  },
+  "preflight": {
+    "suite": "celln-kubernetes-conformance",
+    "status": "passed",
+    "revision": "c4a2c9670a088a00d7d7353dd0a669403fd26b29",
+    "dirty": false,
+    "provider": "podman",
+    "kind": "kind v0.33.0 go1.26.7 linux/amd64",
+    "runtime": "podman version 5.8.4",
+    "binarySha256": "56578bbdbb9b2986b8703da6b1839d764053276c7b53f2e768386c68f1c06529",
+    "cases": [
+      {
+        "name": "unsupported_hardware",
+        "status": "passed",
+        "evidence": {
+          "verdict": "refused",
+          "request_id": "celln-conformance-unsupported",
+          "node": {
+            "node_name": "celln-conformance-1182407-control-plane",
+            "kvm": false,
+            "cpu_virtualization": true,
+            "guest_kernel": false,
+            "mote_store": false,
+            "tool_store": false,
+            "live_cells": 0,
+            "max_cells": 1,
+            "memory_bytes": 268435456,
+            "egress_slots": 0
+          },
+          "reason": "unsupported"
+        }
+      }
+    ]
+  },
+  "finalNode": {
+    "availability_is_advisory": true,
+    "configured_egress_slots": 1,
+    "configured_memory_bytes": 268435456,
+    "node": {
+      "cpu_virtualization": true,
+      "egress_slots": 1,
+      "guest_kernel": true,
+      "kvm": true,
+      "live_cells": 0,
+      "max_cells": 2,
+      "memory_bytes": 268435456,
+      "mote_store": true,
+      "node_name": "conformance",
+      "tool_store": true
+    },
+    "preflight_only": true,
+    "warm": [
+      {
+        "guest_memory_bytes": 268435456,
+        "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+        "tools": [
+          "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+        ]
+      }
+    ]
+  },
+  "executions": [
+    {
+      "name": "proof-silent",
+      "uid": "ed0ed2ef-df08-4ce1-a0c4-224ac5600f82",
+      "controllerPhase": "Succeeded",
+      "request": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "id": "proof-silent-ed0ed2ef-df08-4ce1-a0c4-224ac5600f82",
+        "workload": {
+          "id": "reference",
+          "caller": "sympozium:celln-proof/proof-silent"
+        },
+        "mote": {
+          "hash": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9"
+        },
+        "tools": [
+          {
+            "alias": "/tools/program",
+            "hash": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          }
+        ],
+        "inputs": [
+          {
+            "name": "data",
+            "hash": "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface",
+            "mediaType": "text/plain",
+            "bytes": 11
+          }
+        ],
+        "invocation": {
+          "alias": "/tools/program",
+          "args": [
+            "silent"
+          ]
+        },
+        "capabilities": {
+          "workspace": "read-only",
+          "timeoutMs": 15000,
+          "memoryBytes": 268435456,
+          "outputBytes": 1024
+        },
+        "execution": {
+          "lane": "tool",
+          "requireHardwareIsolation": true
+        }
+      },
+      "persistedReceipt": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "requestId": "proof-silent-ed0ed2ef-df08-4ce1-a0c4-224ac5600f82",
+        "phase": "succeeded",
+        "node": "conformance",
+        "startedAt": "2026-09-06T13:59:09Z",
+        "completedAt": "2026-09-06T13:59:09Z",
+        "cellId": "b388288891d7",
+        "resolved": {
+          "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+          "tools": [
+            "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          ],
+          "inputs": [
+            "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+          ]
+        },
+        "output": null
+      },
+      "audit": {
+        "apiVersion": "celln.dev/audit-v1alpha1",
+        "requestId": "proof-silent-ed0ed2ef-df08-4ce1-a0c4-224ac5600f82",
+        "caller": "sympozium:celln-proof/proof-silent",
+        "workload": "reference",
+        "node": "conformance",
+        "events": [
+          {
+            "sequence": 0,
+            "at": "2026-09-06T13:59:09Z",
+            "phase": "Admitting"
+          },
+          {
+            "sequence": 1,
+            "at": "2026-09-06T13:59:09Z",
+            "phase": "Resolving"
+          },
+          {
+            "sequence": 2,
+            "at": "2026-09-06T13:59:09Z",
+            "phase": "CellRunning"
+          },
+          {
+            "sequence": 3,
+            "at": "2026-09-06T13:59:09Z",
+            "phase": "Dissolved"
+          },
+          {
+            "sequence": 4,
+            "at": "2026-09-06T13:59:09Z",
+            "phase": "Succeeded"
+          }
+        ],
+        "execution": {
+          "cellId": "b388288891d7",
+          "substrate": {
+            "kernel": "blake3:93f20d4f258dcf1a567faa54fa5b125a8b55433f5af381ee08530bdd50c78048",
+            "initrd": "blake3:8346e685bdd74cdcf71fbe3373b0537e80fb854724c52f1e1b1a0e055b7c0c05",
+            "toolfs": "blake3:ac65b00b8b472842ae6b03bf7008a84aad9b58c4882961a9752934bbd1a2737d",
+            "invocation": "blake3:563064b0bca893d49d382bbcd785025c3bf4a7d8b48570ea61bfb47ec4e1bf00"
+          },
+          "pilot": {
+            "tool": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776",
+            "lane": "tool",
+            "workspace": "read-only",
+            "fetch": false
+          },
+          "granted": {
+            "workspace": "read-only",
+            "egress": [],
+            "timeoutMs": 15000,
+            "memoryBytes": 268435456,
+            "outputBytes": 1024
+          },
+          "inputs": [
+            "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+          ],
+          "broker": {
+            "requests": 0,
+            "denied": 0,
+            "responseBytes": 0
+          },
+          "exitCode": 0,
+          "signal": null,
+          "watchdogStopped": false
+        },
+        "receipt": {
+          "apiVersion": "celln.dev/v1alpha1",
+          "requestId": "proof-silent-ed0ed2ef-df08-4ce1-a0c4-224ac5600f82",
+          "phase": "succeeded",
+          "node": "conformance",
+          "cellId": "b388288891d7",
+          "resolved": {
+            "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+            "tools": [
+              "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+            ],
+            "inputs": [
+              "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+            ]
+          },
+          "output": null,
+          "startedAt": "2026-09-06T13:59:09Z",
+          "completedAt": "2026-09-06T13:59:09Z"
+        }
+      }
+    },
+    {
+      "name": "proof-failed",
+      "uid": "55a0c669-5cbd-48dc-8319-c154df302659",
+      "controllerPhase": "Failed",
+      "request": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "id": "proof-failed-55a0c669-5cbd-48dc-8319-c154df302659",
+        "workload": {
+          "id": "reference",
+          "caller": "sympozium:celln-proof/proof-failed"
+        },
+        "mote": {
+          "hash": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9"
+        },
+        "tools": [
+          {
+            "alias": "/tools/program",
+            "hash": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          }
+        ],
+        "inputs": [
+          {
+            "name": "data",
+            "hash": "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface",
+            "mediaType": "text/plain",
+            "bytes": 11
+          }
+        ],
+        "invocation": {
+          "alias": "/tools/program",
+          "args": [
+            "failed"
+          ]
+        },
+        "capabilities": {
+          "workspace": "read-only",
+          "timeoutMs": 15000,
+          "memoryBytes": 268435456,
+          "outputBytes": 1024
+        },
+        "execution": {
+          "lane": "tool",
+          "requireHardwareIsolation": true
+        }
+      },
+      "persistedReceipt": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "requestId": "proof-failed-55a0c669-5cbd-48dc-8319-c154df302659",
+        "phase": "failed",
+        "node": "conformance",
+        "startedAt": "2026-09-06T13:59:15Z",
+        "completedAt": "2026-09-06T13:59:15Z",
+        "cellId": "01167ca8fc5c",
+        "resolved": {
+          "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+          "tools": [
+            "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          ],
+          "inputs": [
+            "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+          ]
+        },
+        "output": {
+          "hash": "blake3:afeba30c5f97f946a12a34b0c9f4dfdf824651acfb2ab870e498863c0bd22db1",
+          "mediaType": "application/octet-stream",
+          "bytes": 15
+        }
+      },
+      "audit": {
+        "apiVersion": "celln.dev/audit-v1alpha1",
+        "requestId": "proof-failed-55a0c669-5cbd-48dc-8319-c154df302659",
+        "caller": "sympozium:celln-proof/proof-failed",
+        "workload": "reference",
+        "node": "conformance",
+        "events": [
+          {
+            "sequence": 0,
+            "at": "2026-09-06T13:59:15Z",
+            "phase": "Admitting"
+          },
+          {
+            "sequence": 1,
+            "at": "2026-09-06T13:59:15Z",
+            "phase": "Resolving"
+          },
+          {
+            "sequence": 2,
+            "at": "2026-09-06T13:59:15Z",
+            "phase": "CellRunning"
+          },
+          {
+            "sequence": 3,
+            "at": "2026-09-06T13:59:15Z",
+            "phase": "Dissolved"
+          },
+          {
+            "sequence": 4,
+            "at": "2026-09-06T13:59:15Z",
+            "phase": "Failed"
+          }
+        ],
+        "execution": {
+          "cellId": "01167ca8fc5c",
+          "substrate": {
+            "kernel": "blake3:93f20d4f258dcf1a567faa54fa5b125a8b55433f5af381ee08530bdd50c78048",
+            "initrd": "blake3:8346e685bdd74cdcf71fbe3373b0537e80fb854724c52f1e1b1a0e055b7c0c05",
+            "toolfs": "blake3:ac65b00b8b472842ae6b03bf7008a84aad9b58c4882961a9752934bbd1a2737d",
+            "invocation": "blake3:d7dbc9a275305d8e322413602ab32b822857832cbaf26909988374bd550d427f"
+          },
+          "pilot": {
+            "tool": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776",
+            "lane": "tool",
+            "workspace": "read-only",
+            "fetch": false
+          },
+          "granted": {
+            "workspace": "read-only",
+            "egress": [],
+            "timeoutMs": 15000,
+            "memoryBytes": 268435456,
+            "outputBytes": 1024
+          },
+          "inputs": [
+            "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+          ],
+          "broker": {
+            "requests": 0,
+            "denied": 0,
+            "responseBytes": 0
+          },
+          "exitCode": 7,
+          "signal": null,
+          "watchdogStopped": false
+        },
+        "receipt": {
+          "apiVersion": "celln.dev/v1alpha1",
+          "requestId": "proof-failed-55a0c669-5cbd-48dc-8319-c154df302659",
+          "phase": "failed",
+          "node": "conformance",
+          "cellId": "01167ca8fc5c",
+          "resolved": {
+            "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+            "tools": [
+              "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+            ],
+            "inputs": [
+              "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+            ]
+          },
+          "output": {
+            "hash": "blake3:afeba30c5f97f946a12a34b0c9f4dfdf824651acfb2ab870e498863c0bd22db1",
+            "mediaType": "application/octet-stream",
+            "bytes": 15
+          },
+          "startedAt": "2026-09-06T13:59:15Z",
+          "completedAt": "2026-09-06T13:59:15Z"
+        }
+      }
+    },
+    {
+      "name": "proof-spoof",
+      "uid": "8d2965c6-6f74-4ddd-923b-bee99ab029b7",
+      "controllerPhase": "Failed",
+      "request": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "id": "proof-spoof-8d2965c6-6f74-4ddd-923b-bee99ab029b7",
+        "workload": {
+          "id": "reference",
+          "caller": "sympozium:celln-proof/proof-spoof"
+        },
+        "mote": {
+          "hash": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9"
+        },
+        "tools": [
+          {
+            "alias": "/tools/program",
+            "hash": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          }
+        ],
+        "inputs": [
+          {
+            "name": "data",
+            "hash": "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface",
+            "mediaType": "text/plain",
+            "bytes": 11
+          }
+        ],
+        "invocation": {
+          "alias": "/tools/program",
+          "args": [
+            "spoof"
+          ]
+        },
+        "capabilities": {
+          "workspace": "read-only",
+          "timeoutMs": 15000,
+          "memoryBytes": 268435456,
+          "outputBytes": 1024
+        },
+        "execution": {
+          "lane": "tool",
+          "requireHardwareIsolation": true
+        }
+      },
+      "persistedReceipt": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "requestId": "proof-spoof-8d2965c6-6f74-4ddd-923b-bee99ab029b7",
+        "phase": "failed",
+        "node": "conformance",
+        "startedAt": "2026-09-06T13:59:21Z",
+        "completedAt": "2026-09-06T13:59:21Z",
+        "cellId": "016cbf60d820",
+        "resolved": {
+          "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+          "tools": [
+            "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          ],
+          "inputs": [
+            "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+          ]
+        },
+        "output": {
+          "hash": "blake3:3c0dd8221eba0a0c0bd4f2418f5bc58291f8dfa3a521f4dade3fa2a9a3819610",
+          "mediaType": "application/octet-stream",
+          "bytes": 103
+        }
+      },
+      "audit": {
+        "apiVersion": "celln.dev/audit-v1alpha1",
+        "requestId": "proof-spoof-8d2965c6-6f74-4ddd-923b-bee99ab029b7",
+        "caller": "sympozium:celln-proof/proof-spoof",
+        "workload": "reference",
+        "node": "conformance",
+        "events": [
+          {
+            "sequence": 0,
+            "at": "2026-09-06T13:59:21Z",
+            "phase": "Admitting"
+          },
+          {
+            "sequence": 1,
+            "at": "2026-09-06T13:59:21Z",
+            "phase": "Resolving"
+          },
+          {
+            "sequence": 2,
+            "at": "2026-09-06T13:59:21Z",
+            "phase": "CellRunning"
+          },
+          {
+            "sequence": 3,
+            "at": "2026-09-06T13:59:21Z",
+            "phase": "Dissolved"
+          },
+          {
+            "sequence": 4,
+            "at": "2026-09-06T13:59:21Z",
+            "phase": "Failed"
+          }
+        ],
+        "execution": {
+          "cellId": "016cbf60d820",
+          "substrate": {
+            "kernel": "blake3:93f20d4f258dcf1a567faa54fa5b125a8b55433f5af381ee08530bdd50c78048",
+            "initrd": "blake3:8346e685bdd74cdcf71fbe3373b0537e80fb854724c52f1e1b1a0e055b7c0c05",
+            "toolfs": "blake3:ac65b00b8b472842ae6b03bf7008a84aad9b58c4882961a9752934bbd1a2737d",
+            "invocation": "blake3:11f62284752efc2d496a1f7a01247557329d138adf764bfcaca9262d1289c048"
+          },
+          "pilot": {
+            "tool": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776",
+            "lane": "tool",
+            "workspace": "read-only",
+            "fetch": false
+          },
+          "granted": {
+            "workspace": "read-only",
+            "egress": [],
+            "timeoutMs": 15000,
+            "memoryBytes": 268435456,
+            "outputBytes": 1024
+          },
+          "inputs": [
+            "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+          ],
+          "broker": {
+            "requests": 0,
+            "denied": 0,
+            "responseBytes": 0
+          },
+          "exitCode": 9,
+          "signal": null,
+          "watchdogStopped": false
+        },
+        "receipt": {
+          "apiVersion": "celln.dev/v1alpha1",
+          "requestId": "proof-spoof-8d2965c6-6f74-4ddd-923b-bee99ab029b7",
+          "phase": "failed",
+          "node": "conformance",
+          "cellId": "016cbf60d820",
+          "resolved": {
+            "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+            "tools": [
+              "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+            ],
+            "inputs": [
+              "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+            ]
+          },
+          "output": {
+            "hash": "blake3:3c0dd8221eba0a0c0bd4f2418f5bc58291f8dfa3a521f4dade3fa2a9a3819610",
+            "mediaType": "application/octet-stream",
+            "bytes": 103
+          },
+          "startedAt": "2026-09-06T13:59:21Z",
+          "completedAt": "2026-09-06T13:59:21Z"
+        }
+      }
+    },
+    {
+      "name": "proof-inputs",
+      "uid": "c8271612-fe34-460e-986c-2373cc221e8f",
+      "controllerPhase": "Succeeded",
+      "request": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "id": "proof-inputs-c8271612-fe34-460e-986c-2373cc221e8f",
+        "workload": {
+          "id": "reference",
+          "caller": "sympozium:celln-proof/proof-inputs"
+        },
+        "mote": {
+          "hash": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9"
+        },
+        "tools": [
+          {
+            "alias": "/tools/program",
+            "hash": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          }
+        ],
+        "inputs": [
+          {
+            "name": "data",
+            "hash": "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface",
+            "mediaType": "text/plain",
+            "bytes": 11
+          }
+        ],
+        "invocation": {
+          "alias": "/tools/program",
+          "args": [
+            "inputs",
+            "first-input"
+          ]
+        },
+        "capabilities": {
+          "workspace": "read-only",
+          "timeoutMs": 15000,
+          "memoryBytes": 268435456,
+          "outputBytes": 1024
+        },
+        "execution": {
+          "lane": "tool",
+          "requireHardwareIsolation": true
+        }
+      },
+      "persistedReceipt": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "requestId": "proof-inputs-c8271612-fe34-460e-986c-2373cc221e8f",
+        "phase": "succeeded",
+        "node": "conformance",
+        "startedAt": "2026-09-06T13:59:27Z",
+        "completedAt": "2026-09-06T13:59:27Z",
+        "cellId": "b9599c20cd73",
+        "resolved": {
+          "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+          "tools": [
+            "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          ],
+          "inputs": [
+            "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+          ]
+        },
+        "output": {
+          "hash": "blake3:949dcae29b56b368105b70d9bc09df74b9e070de7b1fa0a58fa8c03252cf05ca",
+          "mediaType": "application/octet-stream",
+          "bytes": 19
+        }
+      },
+      "audit": {
+        "apiVersion": "celln.dev/audit-v1alpha1",
+        "requestId": "proof-inputs-c8271612-fe34-460e-986c-2373cc221e8f",
+        "caller": "sympozium:celln-proof/proof-inputs",
+        "workload": "reference",
+        "node": "conformance",
+        "events": [
+          {
+            "sequence": 0,
+            "at": "2026-09-06T13:59:27Z",
+            "phase": "Admitting"
+          },
+          {
+            "sequence": 1,
+            "at": "2026-09-06T13:59:27Z",
+            "phase": "Resolving"
+          },
+          {
+            "sequence": 2,
+            "at": "2026-09-06T13:59:27Z",
+            "phase": "CellRunning"
+          },
+          {
+            "sequence": 3,
+            "at": "2026-09-06T13:59:27Z",
+            "phase": "Dissolved"
+          },
+          {
+            "sequence": 4,
+            "at": "2026-09-06T13:59:27Z",
+            "phase": "Succeeded"
+          }
+        ],
+        "execution": {
+          "cellId": "b9599c20cd73",
+          "substrate": {
+            "kernel": "blake3:93f20d4f258dcf1a567faa54fa5b125a8b55433f5af381ee08530bdd50c78048",
+            "initrd": "blake3:8346e685bdd74cdcf71fbe3373b0537e80fb854724c52f1e1b1a0e055b7c0c05",
+            "toolfs": "blake3:ac65b00b8b472842ae6b03bf7008a84aad9b58c4882961a9752934bbd1a2737d",
+            "invocation": "blake3:68de40b1a8bf2bc635d6c11aa8c39b230d0f71c952c01f24839da703b7d8cf9a"
+          },
+          "pilot": {
+            "tool": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776",
+            "lane": "tool",
+            "workspace": "read-only",
+            "fetch": false
+          },
+          "granted": {
+            "workspace": "read-only",
+            "egress": [],
+            "timeoutMs": 15000,
+            "memoryBytes": 268435456,
+            "outputBytes": 1024
+          },
+          "inputs": [
+            "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+          ],
+          "broker": {
+            "requests": 0,
+            "denied": 0,
+            "responseBytes": 0
+          },
+          "exitCode": 0,
+          "signal": null,
+          "watchdogStopped": false
+        },
+        "receipt": {
+          "apiVersion": "celln.dev/v1alpha1",
+          "requestId": "proof-inputs-c8271612-fe34-460e-986c-2373cc221e8f",
+          "phase": "succeeded",
+          "node": "conformance",
+          "cellId": "b9599c20cd73",
+          "resolved": {
+            "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+            "tools": [
+              "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+            ],
+            "inputs": [
+              "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+            ]
+          },
+          "output": {
+            "hash": "blake3:949dcae29b56b368105b70d9bc09df74b9e070de7b1fa0a58fa8c03252cf05ca",
+            "mediaType": "application/octet-stream",
+            "bytes": 19
+          },
+          "startedAt": "2026-09-06T13:59:27Z",
+          "completedAt": "2026-09-06T13:59:27Z"
+        }
+      }
+    },
+    {
+      "name": "proof-workspace-none",
+      "uid": "c9b70fc9-fca9-4822-8157-c6dc40bbecb5",
+      "controllerPhase": "Succeeded",
+      "request": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "id": "proof-workspace-none-c9b70fc9-fca9-4822-8157-c6dc40bbecb5",
+        "workload": {
+          "id": "reference",
+          "caller": "sympozium:celln-proof/proof-workspace-none"
+        },
+        "mote": {
+          "hash": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9"
+        },
+        "tools": [
+          {
+            "alias": "/tools/program",
+            "hash": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          }
+        ],
+        "invocation": {
+          "alias": "/tools/program",
+          "args": [
+            "workspace",
+            "none"
+          ]
+        },
+        "capabilities": {
+          "workspace": "none",
+          "timeoutMs": 15000,
+          "memoryBytes": 268435456,
+          "outputBytes": 1024
+        },
+        "execution": {
+          "lane": "tool",
+          "requireHardwareIsolation": true
+        }
+      },
+      "persistedReceipt": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "requestId": "proof-workspace-none-c9b70fc9-fca9-4822-8157-c6dc40bbecb5",
+        "phase": "succeeded",
+        "node": "conformance",
+        "startedAt": "2026-09-06T13:59:33Z",
+        "completedAt": "2026-09-06T13:59:33Z",
+        "cellId": "e2ed44f0dfbc",
+        "resolved": {
+          "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+          "tools": [
+            "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          ],
+          "inputs": []
+        },
+        "output": {
+          "hash": "blake3:27a4a2e4d0268d516800537be7c06106066ccfbec42e08a8a1faac15811e7226",
+          "mediaType": "application/octet-stream",
+          "bytes": 15
+        }
+      },
+      "audit": {
+        "apiVersion": "celln.dev/audit-v1alpha1",
+        "requestId": "proof-workspace-none-c9b70fc9-fca9-4822-8157-c6dc40bbecb5",
+        "caller": "sympozium:celln-proof/proof-workspace-none",
+        "workload": "reference",
+        "node": "conformance",
+        "events": [
+          {
+            "sequence": 0,
+            "at": "2026-09-06T13:59:33Z",
+            "phase": "Admitting"
+          },
+          {
+            "sequence": 1,
+            "at": "2026-09-06T13:59:33Z",
+            "phase": "Resolving"
+          },
+          {
+            "sequence": 2,
+            "at": "2026-09-06T13:59:33Z",
+            "phase": "CellRunning"
+          },
+          {
+            "sequence": 3,
+            "at": "2026-09-06T13:59:33Z",
+            "phase": "Dissolved"
+          },
+          {
+            "sequence": 4,
+            "at": "2026-09-06T13:59:33Z",
+            "phase": "Succeeded"
+          }
+        ],
+        "execution": {
+          "cellId": "e2ed44f0dfbc",
+          "substrate": {
+            "kernel": "blake3:93f20d4f258dcf1a567faa54fa5b125a8b55433f5af381ee08530bdd50c78048",
+            "initrd": "blake3:8346e685bdd74cdcf71fbe3373b0537e80fb854724c52f1e1b1a0e055b7c0c05",
+            "toolfs": "blake3:ac65b00b8b472842ae6b03bf7008a84aad9b58c4882961a9752934bbd1a2737d",
+            "invocation": "blake3:6e9598084a83defcdf53d1a691cb254c5796448129548d44402bc01746727b6f"
+          },
+          "pilot": {
+            "tool": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776",
+            "lane": "tool",
+            "workspace": "none",
+            "fetch": false
+          },
+          "granted": {
+            "workspace": "none",
+            "egress": [],
+            "timeoutMs": 15000,
+            "memoryBytes": 268435456,
+            "outputBytes": 1024
+          },
+          "inputs": [],
+          "broker": {
+            "requests": 0,
+            "denied": 0,
+            "responseBytes": 0
+          },
+          "exitCode": 0,
+          "signal": null,
+          "watchdogStopped": false
+        },
+        "receipt": {
+          "apiVersion": "celln.dev/v1alpha1",
+          "requestId": "proof-workspace-none-c9b70fc9-fca9-4822-8157-c6dc40bbecb5",
+          "phase": "succeeded",
+          "node": "conformance",
+          "cellId": "e2ed44f0dfbc",
+          "resolved": {
+            "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+            "tools": [
+              "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+            ],
+            "inputs": []
+          },
+          "output": {
+            "hash": "blake3:27a4a2e4d0268d516800537be7c06106066ccfbec42e08a8a1faac15811e7226",
+            "mediaType": "application/octet-stream",
+            "bytes": 15
+          },
+          "startedAt": "2026-09-06T13:59:33Z",
+          "completedAt": "2026-09-06T13:59:33Z"
+        }
+      }
+    },
+    {
+      "name": "proof-workspace-read-only",
+      "uid": "21e9945e-9258-4b12-bffd-88bbe200b500",
+      "controllerPhase": "Succeeded",
+      "request": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "id": "proof-workspace-read-only-21e9945e-9258-4b12-bffd-88bbe200b500",
+        "workload": {
+          "id": "reference",
+          "caller": "sympozium:celln-proof/proof-workspace-read-only"
+        },
+        "mote": {
+          "hash": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9"
+        },
+        "tools": [
+          {
+            "alias": "/tools/program",
+            "hash": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          }
+        ],
+        "invocation": {
+          "alias": "/tools/program",
+          "args": [
+            "workspace",
+            "read-only"
+          ]
+        },
+        "capabilities": {
+          "workspace": "read-only",
+          "timeoutMs": 15000,
+          "memoryBytes": 268435456,
+          "outputBytes": 1024
+        },
+        "execution": {
+          "lane": "tool",
+          "requireHardwareIsolation": true
+        }
+      },
+      "persistedReceipt": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "requestId": "proof-workspace-read-only-21e9945e-9258-4b12-bffd-88bbe200b500",
+        "phase": "succeeded",
+        "node": "conformance",
+        "startedAt": "2026-09-06T13:59:39Z",
+        "completedAt": "2026-09-06T13:59:39Z",
+        "cellId": "62b06babc70f",
+        "resolved": {
+          "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+          "tools": [
+            "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          ],
+          "inputs": []
+        },
+        "output": {
+          "hash": "blake3:a4e12d7e48e2d8b7c9c66c010be13caef7d72724a3b73adede06f3d59b72845d",
+          "mediaType": "application/octet-stream",
+          "bytes": 20
+        }
+      },
+      "audit": {
+        "apiVersion": "celln.dev/audit-v1alpha1",
+        "requestId": "proof-workspace-read-only-21e9945e-9258-4b12-bffd-88bbe200b500",
+        "caller": "sympozium:celln-proof/proof-workspace-read-only",
+        "workload": "reference",
+        "node": "conformance",
+        "events": [
+          {
+            "sequence": 0,
+            "at": "2026-09-06T13:59:39Z",
+            "phase": "Admitting"
+          },
+          {
+            "sequence": 1,
+            "at": "2026-09-06T13:59:39Z",
+            "phase": "Resolving"
+          },
+          {
+            "sequence": 2,
+            "at": "2026-09-06T13:59:39Z",
+            "phase": "CellRunning"
+          },
+          {
+            "sequence": 3,
+            "at": "2026-09-06T13:59:39Z",
+            "phase": "Dissolved"
+          },
+          {
+            "sequence": 4,
+            "at": "2026-09-06T13:59:39Z",
+            "phase": "Succeeded"
+          }
+        ],
+        "execution": {
+          "cellId": "62b06babc70f",
+          "substrate": {
+            "kernel": "blake3:93f20d4f258dcf1a567faa54fa5b125a8b55433f5af381ee08530bdd50c78048",
+            "initrd": "blake3:8346e685bdd74cdcf71fbe3373b0537e80fb854724c52f1e1b1a0e055b7c0c05",
+            "toolfs": "blake3:ac65b00b8b472842ae6b03bf7008a84aad9b58c4882961a9752934bbd1a2737d",
+            "invocation": "blake3:8502b494008c5cb2be51503232d0e3a110d9f8d845f3f41a975e2e60d4d4300b"
+          },
+          "pilot": {
+            "tool": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776",
+            "lane": "tool",
+            "workspace": "read-only",
+            "fetch": false
+          },
+          "granted": {
+            "workspace": "read-only",
+            "egress": [],
+            "timeoutMs": 15000,
+            "memoryBytes": 268435456,
+            "outputBytes": 1024
+          },
+          "inputs": [],
+          "broker": {
+            "requests": 0,
+            "denied": 0,
+            "responseBytes": 0
+          },
+          "exitCode": 0,
+          "signal": null,
+          "watchdogStopped": false
+        },
+        "receipt": {
+          "apiVersion": "celln.dev/v1alpha1",
+          "requestId": "proof-workspace-read-only-21e9945e-9258-4b12-bffd-88bbe200b500",
+          "phase": "succeeded",
+          "node": "conformance",
+          "cellId": "62b06babc70f",
+          "resolved": {
+            "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+            "tools": [
+              "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+            ],
+            "inputs": []
+          },
+          "output": {
+            "hash": "blake3:a4e12d7e48e2d8b7c9c66c010be13caef7d72724a3b73adede06f3d59b72845d",
+            "mediaType": "application/octet-stream",
+            "bytes": 20
+          },
+          "startedAt": "2026-09-06T13:59:39Z",
+          "completedAt": "2026-09-06T13:59:39Z"
+        }
+      }
+    },
+    {
+      "name": "proof-workspace-read-write",
+      "uid": "60dc04df-36d8-4bcf-b639-90782cc87da8",
+      "controllerPhase": "Succeeded",
+      "request": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "id": "proof-workspace-read-write-60dc04df-36d8-4bcf-b639-90782cc87da8",
+        "workload": {
+          "id": "reference",
+          "caller": "sympozium:celln-proof/proof-workspace-read-write"
+        },
+        "mote": {
+          "hash": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9"
+        },
+        "tools": [
+          {
+            "alias": "/tools/program",
+            "hash": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          }
+        ],
+        "invocation": {
+          "alias": "/tools/program",
+          "args": [
+            "workspace",
+            "read-write"
+          ]
+        },
+        "capabilities": {
+          "workspace": "read-write",
+          "timeoutMs": 15000,
+          "memoryBytes": 268435456,
+          "outputBytes": 1024
+        },
+        "execution": {
+          "lane": "tool",
+          "requireHardwareIsolation": true
+        }
+      },
+      "persistedReceipt": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "requestId": "proof-workspace-read-write-60dc04df-36d8-4bcf-b639-90782cc87da8",
+        "phase": "succeeded",
+        "node": "conformance",
+        "startedAt": "2026-09-06T13:59:45Z",
+        "completedAt": "2026-09-06T13:59:45Z",
+        "cellId": "23e6116d66e5",
+        "resolved": {
+          "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+          "tools": [
+            "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          ],
+          "inputs": []
+        },
+        "output": {
+          "hash": "blake3:c700b0228d9a1e447597b91c9aa1ea314daf2322e6e725f63d44202a9916428d",
+          "mediaType": "application/octet-stream",
+          "bytes": 21
+        }
+      },
+      "audit": {
+        "apiVersion": "celln.dev/audit-v1alpha1",
+        "requestId": "proof-workspace-read-write-60dc04df-36d8-4bcf-b639-90782cc87da8",
+        "caller": "sympozium:celln-proof/proof-workspace-read-write",
+        "workload": "reference",
+        "node": "conformance",
+        "events": [
+          {
+            "sequence": 0,
+            "at": "2026-09-06T13:59:45Z",
+            "phase": "Admitting"
+          },
+          {
+            "sequence": 1,
+            "at": "2026-09-06T13:59:45Z",
+            "phase": "Resolving"
+          },
+          {
+            "sequence": 2,
+            "at": "2026-09-06T13:59:45Z",
+            "phase": "CellRunning"
+          },
+          {
+            "sequence": 3,
+            "at": "2026-09-06T13:59:45Z",
+            "phase": "Dissolved"
+          },
+          {
+            "sequence": 4,
+            "at": "2026-09-06T13:59:45Z",
+            "phase": "Succeeded"
+          }
+        ],
+        "execution": {
+          "cellId": "23e6116d66e5",
+          "substrate": {
+            "kernel": "blake3:93f20d4f258dcf1a567faa54fa5b125a8b55433f5af381ee08530bdd50c78048",
+            "initrd": "blake3:8346e685bdd74cdcf71fbe3373b0537e80fb854724c52f1e1b1a0e055b7c0c05",
+            "toolfs": "blake3:ac65b00b8b472842ae6b03bf7008a84aad9b58c4882961a9752934bbd1a2737d",
+            "invocation": "blake3:03caf1d23b3d6b35920702c34a20a47079dae1e977d24c2913cf0eb70e75ddcf"
+          },
+          "pilot": {
+            "tool": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776",
+            "lane": "tool",
+            "workspace": "read-write",
+            "fetch": false
+          },
+          "granted": {
+            "workspace": "read-write",
+            "egress": [],
+            "timeoutMs": 15000,
+            "memoryBytes": 268435456,
+            "outputBytes": 1024
+          },
+          "inputs": [],
+          "broker": {
+            "requests": 0,
+            "denied": 0,
+            "responseBytes": 0
+          },
+          "exitCode": 0,
+          "signal": null,
+          "watchdogStopped": false
+        },
+        "receipt": {
+          "apiVersion": "celln.dev/v1alpha1",
+          "requestId": "proof-workspace-read-write-60dc04df-36d8-4bcf-b639-90782cc87da8",
+          "phase": "succeeded",
+          "node": "conformance",
+          "cellId": "23e6116d66e5",
+          "resolved": {
+            "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+            "tools": [
+              "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+            ],
+            "inputs": []
+          },
+          "output": {
+            "hash": "blake3:c700b0228d9a1e447597b91c9aa1ea314daf2322e6e725f63d44202a9916428d",
+            "mediaType": "application/octet-stream",
+            "bytes": 21
+          },
+          "startedAt": "2026-09-06T13:59:45Z",
+          "completedAt": "2026-09-06T13:59:45Z"
+        }
+      }
+    },
+    {
+      "name": "proof-timeout",
+      "uid": "0812eeef-125b-4187-98e9-906d60cba004",
+      "controllerPhase": "Failed",
+      "request": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "id": "proof-timeout-0812eeef-125b-4187-98e9-906d60cba004",
+        "workload": {
+          "id": "reference",
+          "caller": "sympozium:celln-proof/proof-timeout"
+        },
+        "mote": {
+          "hash": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9"
+        },
+        "tools": [
+          {
+            "alias": "/tools/program",
+            "hash": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          }
+        ],
+        "inputs": [
+          {
+            "name": "data",
+            "hash": "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface",
+            "mediaType": "text/plain",
+            "bytes": 11
+          }
+        ],
+        "invocation": {
+          "alias": "/tools/program",
+          "args": [
+            "timeout"
+          ]
+        },
+        "capabilities": {
+          "workspace": "read-only",
+          "timeoutMs": 1000,
+          "memoryBytes": 268435456,
+          "outputBytes": 1024
+        },
+        "execution": {
+          "lane": "tool",
+          "requireHardwareIsolation": true
+        }
+      },
+      "persistedReceipt": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "requestId": "proof-timeout-0812eeef-125b-4187-98e9-906d60cba004",
+        "phase": "failed",
+        "node": "conformance",
+        "startedAt": "2026-09-06T13:59:53Z",
+        "completedAt": "2026-09-06T13:59:54Z",
+        "cellId": "28fb3f73c9fa",
+        "resolved": {
+          "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+          "tools": [
+            "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          ],
+          "inputs": [
+            "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+          ]
+        },
+        "output": {
+          "hash": "blake3:2d0f1ad08e2bb949f2127055789f8c78c6256804b2c6c63b762e7c74d7ba258f",
+          "mediaType": "application/octet-stream",
+          "bytes": 15
+        }
+      },
+      "audit": {
+        "apiVersion": "celln.dev/audit-v1alpha1",
+        "requestId": "proof-timeout-0812eeef-125b-4187-98e9-906d60cba004",
+        "caller": "sympozium:celln-proof/proof-timeout",
+        "workload": "reference",
+        "node": "conformance",
+        "events": [
+          {
+            "sequence": 0,
+            "at": "2026-09-06T13:59:53Z",
+            "phase": "Admitting"
+          },
+          {
+            "sequence": 1,
+            "at": "2026-09-06T13:59:53Z",
+            "phase": "Resolving"
+          },
+          {
+            "sequence": 2,
+            "at": "2026-09-06T13:59:53Z",
+            "phase": "CellRunning"
+          },
+          {
+            "sequence": 3,
+            "at": "2026-09-06T13:59:54Z",
+            "phase": "Dissolved"
+          },
+          {
+            "sequence": 4,
+            "at": "2026-09-06T13:59:54Z",
+            "phase": "Failed"
+          }
+        ],
+        "execution": {
+          "cellId": "28fb3f73c9fa",
+          "substrate": {
+            "kernel": "blake3:93f20d4f258dcf1a567faa54fa5b125a8b55433f5af381ee08530bdd50c78048",
+            "initrd": "blake3:8346e685bdd74cdcf71fbe3373b0537e80fb854724c52f1e1b1a0e055b7c0c05",
+            "toolfs": "blake3:ac65b00b8b472842ae6b03bf7008a84aad9b58c4882961a9752934bbd1a2737d",
+            "invocation": "blake3:92fe300a35bab7467a90503b3e8d72c93e0ef4b89c38e932537310a127ec8793"
+          },
+          "pilot": {
+            "tool": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776",
+            "lane": "tool",
+            "workspace": "read-only",
+            "fetch": false
+          },
+          "granted": {
+            "workspace": "read-only",
+            "egress": [],
+            "timeoutMs": 1000,
+            "memoryBytes": 268435456,
+            "outputBytes": 1024
+          },
+          "inputs": [
+            "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+          ],
+          "broker": {
+            "requests": 0,
+            "denied": 0,
+            "responseBytes": 0
+          },
+          "exitCode": null,
+          "signal": null,
+          "watchdogStopped": true
+        },
+        "receipt": {
+          "apiVersion": "celln.dev/v1alpha1",
+          "requestId": "proof-timeout-0812eeef-125b-4187-98e9-906d60cba004",
+          "phase": "failed",
+          "node": "conformance",
+          "cellId": "28fb3f73c9fa",
+          "resolved": {
+            "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+            "tools": [
+              "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+            ],
+            "inputs": [
+              "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+            ]
+          },
+          "output": {
+            "hash": "blake3:2d0f1ad08e2bb949f2127055789f8c78c6256804b2c6c63b762e7c74d7ba258f",
+            "mediaType": "application/octet-stream",
+            "bytes": 15
+          },
+          "startedAt": "2026-09-06T13:59:53Z",
+          "completedAt": "2026-09-06T13:59:54Z"
+        }
+      }
+    },
+    {
+      "name": "proof-cancel",
+      "uid": "b66547e3-b84b-4211-9371-c1c358813002",
+      "controllerPhase": "Running",
+      "request": {
+        "apiVersion": "celln.dev/v1alpha1",
+        "id": "proof-cancel-b66547e3-b84b-4211-9371-c1c358813002",
+        "workload": {
+          "id": "reference",
+          "caller": "sympozium:celln-proof/proof-cancel"
+        },
+        "mote": {
+          "hash": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9"
+        },
+        "tools": [
+          {
+            "alias": "/tools/program",
+            "hash": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+          }
+        ],
+        "inputs": [
+          {
+            "name": "data",
+            "hash": "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface",
+            "mediaType": "text/plain",
+            "bytes": 11
+          }
+        ],
+        "invocation": {
+          "alias": "/tools/program",
+          "args": [
+            "timeout"
+          ]
+        },
+        "capabilities": {
+          "workspace": "read-only",
+          "timeoutMs": 30000,
+          "memoryBytes": 268435456,
+          "outputBytes": 1024
+        },
+        "execution": {
+          "lane": "tool",
+          "requireHardwareIsolation": true
+        }
+      },
+      "persistedReceipt": null,
+      "audit": {
+        "apiVersion": "celln.dev/audit-v1alpha1",
+        "requestId": "proof-cancel-b66547e3-b84b-4211-9371-c1c358813002",
+        "caller": "sympozium:celln-proof/proof-cancel",
+        "workload": "reference",
+        "node": "conformance",
+        "events": [
+          {
+            "sequence": 0,
+            "at": "2026-09-06T13:59:59Z",
+            "phase": "Admitting"
+          },
+          {
+            "sequence": 1,
+            "at": "2026-09-06T13:59:59Z",
+            "phase": "Resolving"
+          },
+          {
+            "sequence": 2,
+            "at": "2026-09-06T13:59:59Z",
+            "phase": "CellRunning"
+          },
+          {
+            "sequence": 3,
+            "at": "2026-09-06T14:00:01Z",
+            "phase": "Cancelling"
+          },
+          {
+            "sequence": 4,
+            "at": "2026-09-06T14:00:01Z",
+            "phase": "Dissolved"
+          },
+          {
+            "sequence": 5,
+            "at": "2026-09-06T14:00:01Z",
+            "phase": "Cancelled"
+          }
+        ],
+        "execution": {
+          "cellId": "b2e2713e2c59",
+          "substrate": {
+            "kernel": "blake3:93f20d4f258dcf1a567faa54fa5b125a8b55433f5af381ee08530bdd50c78048",
+            "initrd": "blake3:8346e685bdd74cdcf71fbe3373b0537e80fb854724c52f1e1b1a0e055b7c0c05",
+            "toolfs": "blake3:ac65b00b8b472842ae6b03bf7008a84aad9b58c4882961a9752934bbd1a2737d",
+            "invocation": "blake3:92fe300a35bab7467a90503b3e8d72c93e0ef4b89c38e932537310a127ec8793"
+          },
+          "pilot": {
+            "tool": "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776",
+            "lane": "tool",
+            "workspace": "read-only",
+            "fetch": false
+          },
+          "granted": {
+            "workspace": "read-only",
+            "egress": [],
+            "timeoutMs": 30000,
+            "memoryBytes": 268435456,
+            "outputBytes": 1024
+          },
+          "inputs": [
+            "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+          ],
+          "broker": {
+            "requests": 0,
+            "denied": 0,
+            "responseBytes": 0
+          },
+          "exitCode": null,
+          "signal": null,
+          "watchdogStopped": true
+        },
+        "receipt": {
+          "apiVersion": "celln.dev/v1alpha1",
+          "requestId": "proof-cancel-b66547e3-b84b-4211-9371-c1c358813002",
+          "phase": "cancelled",
+          "node": "conformance",
+          "cellId": "b2e2713e2c59",
+          "resolved": {
+            "mote": "blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9",
+            "tools": [
+              "blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776"
+            ],
+            "inputs": [
+              "blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface"
+            ]
+          },
+          "output": {
+            "hash": "blake3:2d0f1ad08e2bb949f2127055789f8c78c6256804b2c6c63b762e7c74d7ba258f",
+            "mediaType": "application/octet-stream",
+            "bytes": 15
+          },
+          "startedAt": "2026-09-06T13:59:59Z",
+          "completedAt": "2026-09-06T14:00:01Z"
+        }
+      }
+    }
+  ],
+  "refusals": [
+    {
+      "name": "proof-unsupported",
+      "status": {
+        "cellnActionId": "proof-unsupported-d0c7f1e2-cfd9-4775-879d-e42e79aaf22f",
+        "cellnRequest": "{\"apiVersion\":\"celln.dev/v1alpha1\",\"id\":\"proof-unsupported-d0c7f1e2-cfd9-4775-879d-e42e79aaf22f\",\"workload\":{\"id\":\"reference\",\"caller\":\"sympozium:celln-proof/proof-unsupported\"},\"mote\":{\"hash\":\"blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9\"},\"tools\":[{\"alias\":\"/tools/program\",\"hash\":\"blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776\",\"closure\":{\"hash\":\"blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9\"}}],\"inputs\":[{\"name\":\"data\",\"hash\":\"blake3:503c76239615797c7455e89aa647f3c3aac4dfe197eed6730b6210a6543aface\",\"mediaType\":\"text/plain\",\"bytes\":11}],\"invocation\":{\"alias\":\"/tools/program\",\"args\":[\"unsupported\"]},\"capabilities\":{\"workspace\":\"read-only\",\"timeoutMs\":15000,\"memoryBytes\":268435456,\"outputBytes\":1024},\"execution\":{\"lane\":\"tool\",\"requireHardwareIsolation\":true}}",
+        "completedAt": "2026-09-06T13:59:51Z",
+        "error": "Celln router refused dispatch (HTTP 422): {\"detail\":\"unsupported authority: tool closure delivery is not implemented\",\"error\":\"request refused\",\"reason\":\"unsupported\"}",
+        "phase": "Failed"
+      }
+    },
+    {
+      "name": "proof-unapproved-input",
+      "status": {
+        "cellnActionId": "proof-unapproved-input-295804cf-35b0-430e-875d-51145e3cab5f",
+        "cellnRequest": "{\"apiVersion\":\"celln.dev/v1alpha1\",\"id\":\"proof-unapproved-input-295804cf-35b0-430e-875d-51145e3cab5f\",\"workload\":{\"id\":\"reference\",\"caller\":\"sympozium:celln-proof/proof-unapproved-input\"},\"mote\":{\"hash\":\"blake3:fc1f3d137d900dcf331fe2909a77ed561f007a47c654f8029227bd43964d4fa9\"},\"tools\":[{\"alias\":\"/tools/program\",\"hash\":\"blake3:80927c3d9d664a9e8c854c03634bbaf7ef401680f1af6e73d4c37aae19a8f776\"}],\"inputs\":[{\"name\":\"data\",\"hash\":\"blake3:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"mediaType\":\"text/plain\",\"bytes\":11}],\"invocation\":{\"alias\":\"/tools/program\",\"args\":[\"unapproved-input\"]},\"capabilities\":{\"workspace\":\"read-only\",\"timeoutMs\":15000,\"memoryBytes\":268435456,\"outputBytes\":1024},\"execution\":{\"lane\":\"tool\",\"requireHardwareIsolation\":true}}",
+        "completedAt": "2026-09-06T13:59:51Z",
+        "error": "Celln execution Refused: input is not authorized by host policy",
+        "phase": "Failed",
+        "startedAt": "2026-09-06T13:59:51Z"
+      }
+    }
+  ],
+  "cleanup": {
+    "ownedClustersRemoved": true,
+    "originalKubernetesContext": "kubernetes-admin@kubernetes"
+  }
+}

--- a/integrations/kubernetes/README.md
+++ b/integrations/kubernetes/README.md
@@ -11,7 +11,8 @@ and process lifecycle; Celln must instead receive explicit content hashes and
 capabilities, then let `warden` make a sealed cell from a warm mote. The node agent
 is the narrow Kubernetes seam: it reports eligibility and admits or refuses a
 request. The Sympozium controller adapter must translate `AgentRun` policy
-into this request and persist the returned verdict in `AgentRun.status.conditions`.
+into this request. It freezes the request in `AgentRun.status.cellnRequest` and
+persists the validated terminal receipt in `AgentRun.status.cellnReceipt`.
 
 The included DaemonSet has only the privileged access required to inspect `/dev/kvm`
 and read the Celln mote/tool stores. It does not mount the container runtime socket,
@@ -36,7 +37,7 @@ selects Podman; see the [Kind rootless requirements](https://kind.sigs.k8s.io/do
 `CELLN_KIND_BIN` selects a project-local Kind executable. Missing tools/runtime
 fail explicitly; this proof never modifies host cgroup or kernel settings.
 
-The command emits JSON only. `verdict: accepted` means the node admitted the intent;
+The `celln node admit` command emits JSON only. `verdict: accepted` means the node admitted the intent;
 it does not claim the request's workload was run. An accepted node now also requires
 a readable loader-compatible guest kernel with matching modules. This remains
 preflight, not a proof that a particular guest boots. The versioned terminal result contract is
@@ -45,7 +46,7 @@ it binds a request, node, cell, resolved authority, and optional output to immut
 BLAKE3 references. `celln dispatcher` now executes requests and returns terminal
 results through its authenticated execution endpoints. Declared requests fork an
 operator-pinned warm mote; forge requests build their program before preparing and
-forking a mote. Fresh external Sympozium integration acceptance remains tracked in #2.
+forking a mote. External controller acceptance uses the separate full-path proof below.
 
 For live scheduling, use authenticated `GET /v1/node`, not a standalone node-probe
 process that cannot see the service's pre-cell reservations. The dispatcher now
@@ -82,6 +83,21 @@ operator state. Hardware prerequisites may skip; a skipped run is not evidence
 that isolation passed. The broader kernel sealing/hostile-guest proofs remain
 in `celln verify` and the warden suite.
 
+For the actual Sympozium controller → Kubernetes AgentRun → Celln execution path:
+
+```sh
+CELLN_KIND_BIN=/absolute/path/to/kind \
+CELLN_SYMPOZIUM_PROOF=/absolute/path/to/sympozium/test/integration/test-celln-real-controller.sh \
+make conformance-kvm
+```
+
+This opt-in starts a fresh Kind/Podman API server and the production Sympozium
+controller on the host, connected to the isolated host KVM dispatcher. It does
+not deploy to an existing cluster or claim nested KVM isolation inside Kind.
+Requests, status, receipts and audits are retained under the conformance run's
+`sympozium/` directory. See [conformance](../../docs/DISPATCH_CONFORMANCE.md)
+for prerequisites, permissions and evidence semantics.
+
 The companion benchmark harness exercises model-authored tasks: code is forged
 twice, sealed and run in a real cell; bounded web tasks use `/pilot-fetch`.
 
@@ -98,8 +114,6 @@ latter; it stores raw hardware measurements in `target/celln-bench/`.
 Open `docs/kubernetes.html` locally for the full-stack SVG and two animated
 walkthroughs, including the recorded 10- and 20-run measurements.
 
-Clean up with:
-
-```sh
-kubectl delete -f integrations/kubernetes/node-probe.yaml
-```
+Both proof scripts clean up their owned clusters automatically. If you separately
+deploy `node-probe.yaml`, remove it only from the explicitly selected test context;
+the proof scripts never require deleting resources from your current context.


### PR DESCRIPTION
## Summary

Record the completed one-node acceptance for epic #2, with portable revision/binary/request/receipt/audit evidence from actual merged heads:

- Celln `c4a2c9670a088a00d7d7353dd0a669403fd26b29`
- Sympozium `aabe054989aec9db5ae29b3b76da8bfbdc8a0509`

Both worktrees were clean. Both real-KVM suites and all 11 real-controller/Kubernetes cases passed; the separate no-KVM Job returned exit 5 with structured unsupported refusal. The exact live cell was cancelled on AgentRun deletion, nonempty output proved guest execution, all reservations returned, no fallback Jobs were created, and owned clusters were removed without changing the user's context.

Also passed `make ci`, `celln --json verify`, actual HTTPS `make fetch-proof`, and the deterministic-model-fixture public CLI acceptance. Sympozium PR checks passed vet/build/test/generated-code gates and local controller/API tests passed with the race detector.

Replace obsolete integration-gap/admission-only documentation with the current tested seam and explicit limits. Keep closures, secret/provider withdrawal, durable/OTel transport, distributed conformance, fleet revocation, persistence and broader benchmarks open. This record is not a claim of whole-agent/CRI parity or an existing-cluster deployment.

## Verification

- `git diff --check`
- JSON evidence parsed and checked for clean passed summaries, 9 correlated execution audits, 2 explicit refusals, and zero final live cells.
- Evidence contains synthetic request identities and artifact hashes, not credentials or user payloads.

Documentation/evidence only; no runtime code differs from the tested merged Celln revision. Epic closure follows this PR's merge and final issue audit.
