### PR TITLE
feat: trusted precomposed closure dispatch and regression proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +99,15 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -139,6 +154,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "toml",
+ "zeroize",
 ]
 
 [[package]]
@@ -164,6 +180,7 @@ name = "celln-manifest"
 version = "0.5.7"
 dependencies = [
  "blake3",
+ "ed25519-dalek",
  "serde",
  "serde_json",
  "thiserror",
@@ -270,10 +287,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "equivalent"
@@ -298,10 +411,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -406,6 +546,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +574,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +603,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -489,16 +663,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -597,6 +807,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +825,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "vmm-sys-util"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +839,12 @@ dependencies = [
  "bitflags 1.3.2",
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "windows-link"
@@ -714,6 +942,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zmij"

--- a/crates/celln-cli/Cargo.toml
+++ b/crates/celln-cli/Cargo.toml
@@ -28,6 +28,7 @@ serde_json.workspace = true
 is-terminal.workspace = true
 toml.workspace = true
 tempfile.workspace = true
+zeroize = "=1.8.1"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/celln-cli/src/closure_cli.rs
+++ b/crates/celln-cli/src/closure_cli.rs
@@ -1,0 +1,67 @@
+//! Offline publisher tooling. Private keys never enter a dispatcher request.
+use anyhow::{Context, Result};
+use celln_manifest::closure::{Closure, SignedClosure};
+use std::{collections::BTreeSet, io::Read, path::Path};
+
+pub fn sign(descriptor: &Path, key: &Path) -> Result<u8> {
+    let closure: Closure = serde_json::from_slice(&read(descriptor)?)?;
+    let mut seed = zeroize::Zeroizing::new([0u8; 32]);
+    let mut source = std::fs::File::open(key).context("opening private seed file")?;
+    source
+        .read_exact(&mut *seed)
+        .context("private seed must contain exactly 32 raw bytes")?;
+    let mut extra = [0];
+    anyhow::ensure!(
+        source.read(&mut extra)? == 0,
+        "private seed must contain exactly 32 raw bytes"
+    );
+    let signed = closure.sign(&seed).map_err(anyhow::Error::msg);
+    println!("{}", serde_json::to_string_pretty(&signed?)?);
+    Ok(0)
+}
+
+fn read(path: &Path) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)?
+        .take(262145)
+        .read_to_end(&mut bytes)?;
+    anyhow::ensure!(bytes.len() <= 262144, "closure descriptor too large");
+    Ok(bytes)
+}
+
+pub fn admit(descriptor: &Path, root: &Path) -> Result<u8> {
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    struct Policy {
+        api_version: String,
+        publishers: BTreeSet<String>,
+        revoked: BTreeSet<String>,
+    }
+    let bytes = read(descriptor)?;
+    let signed: SignedClosure = serde_json::from_slice(&bytes)?;
+    let policy: Policy = serde_json::from_slice(&read(&root.join("trusted-closures.json"))?)?;
+    anyhow::ensure!(
+        policy.api_version == "celln.dev/closure-policy-v1",
+        "unsupported closure policy"
+    );
+    signed
+        .verify(&policy.publishers)
+        .map_err(anyhow::Error::msg)?;
+    let identity = celln_manifest::Hash::of(&bytes);
+    anyhow::ensure!(
+        !policy.revoked.contains(&identity.0)
+            && !policy.revoked.contains(&signed.closure.toolfs)
+            && signed
+                .closure
+                .members
+                .values()
+                .all(|m| !policy.revoked.contains(&m.hash)),
+        "closure revoked"
+    );
+    let hash = celln_store::Store::open(root.join("closures"))?.put(&bytes)?;
+    println!(
+        "{}",
+        serde_json::json!({"closure": hash.0,"publisher": signed.publisher})
+    );
+    Ok(0)
+}

--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -10,6 +10,9 @@ use celln_store::Store;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+#[path = "dispatch_closure.rs"]
+pub(crate) mod closure;
+
 #[path = "dispatch_substrate.rs"]
 mod substrate;
 pub(crate) use substrate::launch_declared;
@@ -69,8 +72,12 @@ pub struct ResolvedBundle {
 pub(crate) fn check_supported_authority(request: &ExecutionRequest) -> Result<(), String> {
     celln_control::check().map_err(|e| e.to_string())?;
     inputs::validate(request)?;
-    if request.tools.iter().any(|tool| tool.closure.is_some()) {
-        return Err("unsupported authority: tool closure delivery is not implemented".into());
+    if request.tools.iter().any(|tool| tool.closure.is_some())
+        && (request.forge.is_some()
+            || !request.inputs.is_empty()
+            || !request.capabilities.egress.is_empty())
+    {
+        return Err("unsupported authority: closure delivery with forge, inputs or egress".into());
     }
     if request.tools.len() > 1 {
         return Err("unsupported authority: only the invoked tool can be delivered".into());
@@ -181,6 +188,8 @@ pub struct LaunchOutcome {
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubstrateIdentity {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub closure: Option<closure::Provenance>,
     pub kernel: String,
     /// Exact loaded initrd including the fixed warm-dispatch marker.
     pub initrd: String,
@@ -464,6 +473,7 @@ fn run_prepared(
         cfg.mem_size
     );
     let identity = SubstrateIdentity {
+        closure: None,
         kernel: kernel_hash.0,
         initrd: initrd_hash.0,
         toolfs: Hash::of(&payload).0,
@@ -692,6 +702,7 @@ mod tests {
         closure.tools[0].closure = Some(celln_spec::ImmutableRef {
             hash: Hash::of(b"closure").0,
         });
+        closure.capabilities.egress = vec!["https://example.com".into()];
         cases.push((closure, "closure delivery"));
         let mut extra = base.clone();
         extra.tools.push(celln_spec::ToolRef {
@@ -996,8 +1007,8 @@ mod tests {
     /// Full forge-from-task pipeline, on real hardware: a real,
     /// already-authenticated backend writes a program from a task string,
     /// `forge` builds/admits it, and `launch` seals and runs the exact bytes
-    /// that came back — no pre-declared mote or tool at all. Pinned to
-    /// `anthropic` for a repeatable choice of backend; this makes a real,
+    /// that came back — no pre-declared mote or tool at all. Defaults to
+    /// `anthropic`; CELLN_TEST_FORGE_BACKEND explicitly selects another backend. This makes a real,
     /// possibly billed, call. Not run by default — needs /dev/kvm, the
     /// guest pilot binaries, and `claude` authenticated on this host. Run
     /// explicitly with:
@@ -1010,10 +1021,12 @@ mod tests {
             eprintln!("skipping: no /dev/kvm on this runner");
             return;
         }
-        if !crate::agent::Backend::Anthropic.available() {
-            eprintln!(
-                "skipping: `claude` not available/authenticated on this host — see `celln providers`"
-            );
+        let backend =
+            std::env::var("CELLN_TEST_FORGE_BACKEND").unwrap_or_else(|_| "anthropic".into());
+        let provider =
+            crate::agent::Backend::from_saved_name(&backend).expect("known explicit test backend");
+        if !provider.available() {
+            eprintln!("skipping: selected backend is unavailable — see `celln providers`");
             return;
         }
 
@@ -1026,7 +1039,7 @@ mod tests {
             "apiVersion": "celln.dev/v1alpha1",
             "id": "forge-smoke-test",
             "workload": { "id": "smoke-test", "caller": "test:forge" },
-            "forge": { "task": "print exactly the line: hello from a forged execution request", "backend": "anthropic" },
+            "forge": { "task": "print exactly the line: hello from a forged execution request", "backend": backend },
             "capabilities": { "workspace": "none", "timeoutMs": 90000, "memoryBytes": 268435456, "outputBytes": 65536 },
             "execution": { "lane": "agent", "requireHardwareIsolation": true }
         }))
@@ -1057,6 +1070,15 @@ mod tests {
             &state_root,
         )
         .expect("cell launches and runs");
+
+        assert!(outcome.succeeded(), "{outcome:?}");
+        assert_eq!(outcome.execution.as_ref().unwrap().lane, "agent");
+        assert_eq!(outcome.execution.as_ref().unwrap().tool, forged.hash);
+        assert_eq!(crate::cells::live_count(&state_root), 0);
+        eprintln!(
+            "PASS: real {backend} model → reproduced program {} → sealed KVM execution → dissolved",
+            forged.hash
+        );
 
         assert!(
             outcome.denial.is_none(),

--- a/crates/celln-cli/src/dispatch_closure.rs
+++ b/crates/celln-cli/src/dispatch_closure.rs
@@ -1,0 +1,93 @@
+//! Resolve authenticated, precomposed closures without consulting host runtimes.
+use celln_manifest::{closure::SignedClosure, Hash};
+use celln_spec::ExecutionRequest;
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeSet, path::Path};
+
+#[cfg(all(test, target_os = "linux"))]
+#[path = "dispatch_closure_tests.rs"]
+mod tests;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Policy {
+    api_version: String,
+    publishers: BTreeSet<String>,
+    revoked: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Provenance {
+    pub hash: String,
+    pub publisher: String,
+    pub toolfs: String,
+    pub members: std::collections::BTreeMap<String, celln_manifest::closure::Member>,
+}
+
+pub struct Admitted {
+    pub signed: SignedClosure,
+    pub provenance: Provenance,
+}
+
+pub fn resolve(
+    request: &ExecutionRequest,
+    bundle: &super::ResolvedBundle,
+    root: &Path,
+) -> Result<Option<Admitted>, String> {
+    let Some(reference) = request.tools.first().and_then(|t| t.closure.as_ref()) else {
+        if bundle.format.as_deref() == Some("celln.warm-closure-v1") {
+            return Err("closure substrate requires explicit closure identity".into());
+        }
+        return Ok(None);
+    };
+    if bundle.format.as_deref() != Some("celln.warm-closure-v1") {
+        return Err(
+            "unsupported authority: closure requires celln.warm-closure-v1 substrate".into(),
+        );
+    }
+    let policy: Policy = serde_json::from_slice(
+        &std::fs::read(root.join("trusted-closures.json"))
+            .map_err(|_| "closure trust policy unavailable")?,
+    )
+    .map_err(|_| "invalid closure trust policy")?;
+    if policy.api_version != "celln.dev/closure-policy-v1"
+        || policy.revoked.contains(&reference.hash)
+    {
+        return Err("closure policy version unsupported or closure revoked".into());
+    }
+    let store = celln_store::Store::open(root.join("closures")).map_err(|e| e.to_string())?;
+    let bytes = store
+        .get_bounded(&Hash(reference.hash.clone()), 262144)
+        .map_err(|e| e.to_string())?;
+    if bytes.len() > 262144 {
+        return Err("closure descriptor exceeds limit".into());
+    }
+    let signed: SignedClosure =
+        serde_json::from_slice(&bytes).map_err(|_| "invalid signed closure")?;
+    signed.verify(&policy.publishers)?;
+    let closure = &signed.closure;
+    if bundle.toolfs_bytes.len() as u64 > crate::image::MAX_IMAGE_BYTES {
+        return Err("unsupported closure filesystem exceeds 512 MiB".into());
+    }
+    if closure.toolfs != bundle.toolfs_hash
+        || closure.members[&closure.entrypoint].hash != bundle.program_hash
+    {
+        return Err("closure does not bind selected filesystem and executable".into());
+    }
+    if closure
+        .members
+        .values()
+        .any(|m| policy.revoked.contains(&m.hash))
+        || policy.revoked.contains(&closure.toolfs)
+    {
+        return Err("closure dependency revoked".into());
+    }
+    let provenance = Provenance {
+        hash: reference.hash.clone(),
+        publisher: signed.publisher.clone(),
+        toolfs: closure.toolfs.clone(),
+        members: closure.members.clone(),
+    };
+    Ok(Some(Admitted { signed, provenance }))
+}

--- a/crates/celln-cli/src/dispatch_closure_tests.rs
+++ b/crates/celln-cli/src/dispatch_closure_tests.rs
@@ -33,6 +33,16 @@ fn signed_closure_on_real_kvm() {
         eprintln!("SKIP: no kernel");
         return;
     };
+    for tool in ["rustc", "ldd", "gcc", "cpio", "mke2fs", "debugfs"] {
+        if Command::new("sh")
+            .args(["-c", "command -v \"$1\"", "check", tool])
+            .output()
+            .map_or(true, |out| !out.status.success())
+        {
+            eprintln!("SKIP: missing {tool}");
+            return;
+        }
+    }
     let work = tempfile::tempdir().unwrap();
     let Some(runtime) = super::super::tests::test_runtime_root(work.path()) else {
         return;

--- a/crates/celln-cli/src/dispatch_closure_tests.rs
+++ b/crates/celln-cli/src/dispatch_closure_tests.rs
@@ -1,0 +1,349 @@
+use super::*;
+use celln_manifest::{
+    closure::{Closure, Member},
+    Hash,
+};
+use celln_store::Store;
+use serde_json::json;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+    process::Command,
+};
+
+fn command(cmd: &mut Command) -> Vec<u8> {
+    let out = cmd.output().unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out.stdout
+}
+
+#[test]
+#[ignore = "requires real KVM, native Rust linker, static pilot and initramfs tools"]
+fn signed_closure_on_real_kvm() {
+    let _proof = super::super::warm::PROOF_LOCK.lock().unwrap();
+    if !Path::new("/dev/kvm").exists() {
+        eprintln!("SKIP: no KVM");
+        return;
+    }
+    let Some(kernel) = warden::vmm::boot::BootConfig::host_kernel() else {
+        eprintln!("SKIP: no kernel");
+        return;
+    };
+    let work = tempfile::tempdir().unwrap();
+    let Some(runtime) = super::super::tests::test_runtime_root(work.path()) else {
+        return;
+    };
+    let started = std::time::Instant::now();
+    let rootfs = work.path().join("rootfs");
+    for dir in ["bin", "lib64", "tmp", "etc"] {
+        std::fs::create_dir_all(rootfs.join(dir)).unwrap();
+    }
+    let program = rootfs.join("bin/program");
+    command(
+        Command::new("rustc")
+            .args(["--edition=2021", "-O"])
+            .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/closure_probe.rs"))
+            .arg("-o")
+            .arg(&program),
+    );
+    // Packaging-only inspection of our freshly compiled fixture. Dispatch
+    // never runs ldd or opens host libraries; it consumes signed sealed bytes.
+    let linked = command(Command::new("ldd").arg(&program));
+    let mut members = BTreeMap::new();
+    for word in String::from_utf8(linked)
+        .unwrap()
+        .split_whitespace()
+        .filter(|s| s.starts_with('/'))
+    {
+        let path = Path::new(word);
+        let bytes = std::fs::read(path).unwrap();
+        let target = rootfs.join(word.trim_start_matches('/'));
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::copy(path, target).unwrap();
+        members.insert(
+            word.to_owned(),
+            Member {
+                hash: Hash::of(&bytes).0,
+                dependencies: BTreeSet::new(),
+            },
+        );
+    }
+    assert!(
+        members.len() >= 2,
+        "fixture must use an actual dynamic loader and libraries"
+    );
+    let library = members
+        .keys()
+        .find(|p| p.contains("libc.so"))
+        .unwrap()
+        .clone();
+    let dependencies = members.keys().cloned().collect();
+    let program_bytes = std::fs::read(&program).unwrap();
+    let program_hash = Hash::of(&program_bytes);
+    members.insert(
+        "/bin/program".into(),
+        Member {
+            hash: program_hash.0.clone(),
+            dependencies,
+        },
+    );
+    std::fs::write(rootfs.join("etc/closure-unlisted"), b"not lent").unwrap();
+    std::os::unix::fs::symlink("/bin/program", rootfs.join("bin/program-link")).unwrap();
+    let image = work.path().join("closure.ext2");
+    command(
+        Command::new("mke2fs")
+            .args(["-q", "-t", "ext2", "-b", "4096", "-F", "-d"])
+            .arg(&rootfs)
+            .arg(&image)
+            .arg("8192"),
+    );
+    let image_bytes = std::fs::read(&image).unwrap();
+    let image_hash = Hash::of(&image_bytes);
+    let signed = Closure {
+        api_version: "celln.dev/closure-v1".into(),
+        toolfs: image_hash.0.clone(),
+        entrypoint: "/bin/program".into(),
+        interpreter: false,
+        members,
+    }
+    .sign(&[17; 32])
+    .unwrap();
+    let state = work.path().join("state");
+    let closure_store = Store::open(state.join("closures")).unwrap();
+    let closure_hash = closure_store
+        .put(&serde_json::to_vec(&signed).unwrap())
+        .unwrap();
+    let policy = json!({"apiVersion":"celln.dev/closure-policy-v1", "publishers":[signed.publisher], "revoked":[]});
+    std::fs::write(
+        state.join("trusted-closures.json"),
+        serde_json::to_vec(&policy).unwrap(),
+    )
+    .unwrap();
+    let assay_root = state.join("assay");
+    let mut assayer = assay::Assayer::open(&assay_root).unwrap();
+    assayer
+        .admit_verified_authored(
+            "/closure/program",
+            &program_bytes,
+            false,
+            celln_manifest::Author::Host,
+        )
+        .unwrap();
+    let initrd = work.path().join("initrd");
+    crate::agent::sh_env(
+        &runtime,
+        "scripts/mkinitramfs.sh",
+        &[initrd.display().to_string()],
+        &[
+            (
+                "CELLN_MANIFEST",
+                assay_root.join("manifest.json").display().to_string(),
+            ),
+            (
+                "CELLN_PILOT_DIR",
+                runtime.join("pilot").display().to_string(),
+            ),
+        ],
+    )
+    .unwrap();
+    let motes = state.join("motes");
+    let tools = state.join("tools");
+    let store = Store::open(&motes).unwrap();
+    Store::open(&tools).unwrap().put(&program_bytes).unwrap();
+    let kernel_hash = store.put(&std::fs::read(kernel).unwrap()).unwrap();
+    let initrd_hash = store.put(&std::fs::read(&initrd).unwrap()).unwrap();
+    store.put(&image_bytes).unwrap();
+    let bundle = store.put(&serde_json::to_vec(&json!({"apiVersion":"celln.dev/v1alpha1", "format":"celln.warm-closure-v1", "kernel":kernel_hash.0,"initrd":initrd_hash.0,"toolfs":image_hash.0,"invocation":{"alias":"/closure/program","toolHash":program_hash.0}})).unwrap()).unwrap();
+    std::fs::write(
+        state.join("trusted-motes.json"),
+        serde_json::to_vec(&json!({"apiVersion":"celln.dev/v1alpha1","bundles":[bundle.0]}))
+            .unwrap(),
+    )
+    .unwrap();
+    let materialisation = started.elapsed();
+    let mut request: ExecutionRequest = serde_json::from_value(json!({
+        "apiVersion":"celln.dev/v1alpha1","id":"closure-proof","workload":{"id":"closure-proof","caller":"test:closure"},
+        "mote":{"hash":bundle.0},"tools":[{"alias":"/closure/program","hash":program_hash.0,"closure":{"hash":closure_hash.0}}],
+        "invocation":{"alias":"/closure/program","args":["none",library]},
+        "capabilities":{"workspace":"none","timeoutMs":15000,"memoryBytes":268435456,"outputBytes":4096},
+        "execution":{"lane":"tool","requireHardwareIsolation":true}
+    })).unwrap();
+    let preparations = super::super::warm::PREPARATIONS.load(std::sync::atomic::Ordering::SeqCst);
+    let mut measurements = Vec::new();
+    for mode in ["none", "read-only", "read-write"] {
+        request.capabilities.workspace = serde_json::from_value(json!(mode)).unwrap();
+        request.invocation.as_mut().unwrap().args[0] = mode.into();
+        let start = std::time::Instant::now();
+        let (out, _) = super::super::launch_declared(&request, &motes, &tools, &state).unwrap();
+        assert!(out.succeeded(), "{out:?}");
+        assert_eq!(
+            out.output.as_deref(),
+            Some(format!("closure:{mode}:dynamic-loader:replacement-denied\n").as_bytes())
+        );
+        assert_eq!(out.substrate.unwrap().closure.unwrap().hash, closure_hash.0);
+        measurements.push(json!({"workspace":mode,"elapsedMicros":start.elapsed().as_micros()}));
+    }
+    assert_eq!(
+        super::super::warm::PREPARATIONS.load(std::sync::atomic::Ordering::SeqCst),
+        preparations + 1
+    );
+    assert_eq!(crate::cells::live_count(&state), 0);
+    let mut revoked_cell = super::super::warm::fork(
+        format!("{}:268435456", bundle.0),
+        vec![program_hash.0.clone()],
+        || panic!("warm only"),
+    )
+    .unwrap();
+    revoked_cell
+        .set_invocation(
+            &serde_json::to_vec(&json!({
+                "path":"/bin/program","alias":"/closure/program","root":"/tools",
+                "expected_hash":program_hash.0,"closure_members":signed.closure.members,
+                "workspace_access":"none","report_output_limit":4096,"args":["revoke",library]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    revoked_cell.set_timeout(std::time::Duration::from_secs(5));
+    revoked_cell.revoke_when_guest_prints(&image_hash, "\"kind\":\"output\"");
+    let revoked_report = revoked_cell.run().unwrap();
+    assert!(revoked_report.revoked_live);
+    assert!(
+        revoked_report.console.contains("\"kind\":\"signal\""),
+        "closure must die on memslot withdrawal, not execute a page-cache copy: {}",
+        revoked_report.console
+    );
+    drop(revoked_cell);
+    // A valid publisher cannot substitute the declared library with different
+    // bytes inside the sealed image. Pilot checks the actual dependency too.
+    let mut bad_member = signed.closure.clone();
+    bad_member.members.get_mut(&library).unwrap().hash = Hash::of(b"substituted library").0;
+    let bad_member = bad_member.sign(&[17; 32]).unwrap();
+    let mut denied = request.clone();
+    denied.tools[0].closure.as_mut().unwrap().hash = closure_store
+        .put(&serde_json::to_vec(&bad_member).unwrap())
+        .unwrap()
+        .0;
+    let (out, _) = super::super::launch_declared(&denied, &motes, &tools, &state).unwrap();
+    assert_eq!(
+        out.denial.as_deref(),
+        Some("sealed closure member mismatch")
+    );
+    assert!(out.execution.is_none());
+    let mut symlink = signed.closure.clone();
+    let member = symlink.members.remove("/bin/program").unwrap();
+    symlink.entrypoint = "/bin/program-link".into();
+    symlink.members.insert(symlink.entrypoint.clone(), member);
+    denied.tools[0].closure.as_mut().unwrap().hash = closure_store
+        .put(&serde_json::to_vec(&symlink.sign(&[17; 32]).unwrap()).unwrap())
+        .unwrap()
+        .0;
+    let (out, _) = super::super::launch_declared(&denied, &motes, &tools, &state).unwrap();
+    assert_eq!(
+        out.denial.as_deref(),
+        Some("sealed closure member mismatch")
+    );
+    assert!(out.execution.is_none());
+    let mut forged_signature = signed.clone();
+    forged_signature.signature = celln_manifest::closure::hex(&[0; 64]);
+    denied.tools[0].closure.as_mut().unwrap().hash = closure_store
+        .put(&serde_json::to_vec(&forged_signature).unwrap())
+        .unwrap()
+        .0;
+    assert!(
+        super::super::launch_declared(&denied, &motes, &tools, &state)
+            .unwrap_err()
+            .contains("signature")
+    );
+    let mut withdrawn = policy.clone();
+    withdrawn["publishers"] = json!([]);
+    std::fs::write(
+        state.join("trusted-closures.json"),
+        serde_json::to_vec(&withdrawn).unwrap(),
+    )
+    .unwrap();
+    assert!(
+        super::super::launch_declared(&request, &motes, &tools, &state)
+            .unwrap_err()
+            .contains("publisher")
+    );
+    std::fs::write(
+        state.join("trusted-closures.json"),
+        serde_json::to_vec(&policy).unwrap(),
+    )
+    .unwrap();
+    let shared = warden::vmm::kvm::shared_tool_map_existing(&image_hash).unwrap();
+    let before_maps = warden::vmm::kvm::shared_tool_count();
+    let mut forks = Vec::new();
+    for _ in 0..8 {
+        forks.push(
+            super::super::warm::fork(
+                format!("{}:268435456", bundle.0),
+                vec![program_hash.0.clone()],
+                || panic!("warm only"),
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            warden::vmm::kvm::shared_tool_map_existing(&image_hash)
+                .unwrap()
+                .addr(),
+            shared.addr()
+        );
+    }
+    assert_eq!(warden::vmm::kvm::shared_tool_count(), before_maps);
+    drop(forks);
+    warden::vmm::kvm::collect_unused_tools();
+    assert!(
+        warden::vmm::kvm::shared_tool_map_existing(&image_hash).is_some(),
+        "parked mote must retain its closure"
+    );
+    let evidence_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(format!("../../target/closure-proof/{}", std::process::id()));
+    std::fs::create_dir_all(&evidence_dir).unwrap();
+    crate::dispatch_conformance::prove_closure(&request, &motes, &tools, &state, &evidence_dir);
+    let mut revoked = policy.clone();
+    revoked["revoked"] = json!([signed.closure.members[&library].hash]);
+    std::fs::write(
+        state.join("trusted-closures.json"),
+        serde_json::to_vec(&revoked).unwrap(),
+    )
+    .unwrap();
+    assert!(
+        super::super::launch_declared(&request, &motes, &tools, &state)
+            .unwrap_err()
+            .contains("revoked")
+    );
+    let shared_bytes = shared.len();
+    let retained = super::super::warm::fork(
+        format!("{}:268435456", bundle.0),
+        vec![program_hash.0.clone()],
+        || panic!("warm only"),
+    )
+    .unwrap();
+    drop(shared);
+    super::super::warm::evict();
+    assert!(
+        warden::vmm::kvm::shared_tool_map_existing(&image_hash).is_some(),
+        "live fork must survive cache eviction"
+    );
+    drop(retained);
+    warden::vmm::kvm::collect_unused_tools();
+    assert!(
+        warden::vmm::kvm::shared_tool_map_existing(&image_hash).is_none(),
+        "unused closure backing must be collected after eviction"
+    );
+    let evidence = json!({"status":"passed","closure":closure_hash.0,"publisher":signed.publisher,"members":signed.closure.members,"toolfsBytes":image_bytes.len(),"materialisationMicros":materialisation.as_micros(),"runs":measurements,"warmPreparations":1,"replacementDenied":true,"dependencyRevocationDenied":true,"signatureForgeryDenied":true,"publisherWithdrawalDenied":true,"memberMismatchDenied":true,"symlinkMemberDenied":true,"daxRevocationKilledGuest":true,"executableScratchMappingDenied":true,"liveForkSurvivedEviction":true,"unusedPagesCollected":true,"simultaneousForks":8,"additionalToolAllocations":0,"sharedToolBytes":shared_bytes});
+    let evidence_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/closure-proof");
+    std::fs::create_dir_all(&evidence_dir).unwrap();
+    std::fs::write(
+        evidence_dir.join(format!("{}.json", std::process::id())),
+        serde_json::to_vec_pretty(&evidence).unwrap(),
+    )
+    .unwrap();
+    eprintln!("PASS: signed dynamic closure, guest replacement attacks, DAX revocation, warm reuse, dependency revocation and GC; {evidence}");
+}

--- a/crates/celln-cli/src/dispatch_conformance.rs
+++ b/crates/celln-cli/src/dispatch_conformance.rs
@@ -11,6 +11,94 @@ use std::time::{Duration, Instant};
 
 const TOKEN: &str = "isolated-conformance-token-not-a-real-secret";
 
+pub(crate) fn prove_closure(
+    request: &ExecutionRequest,
+    motes: &Path,
+    tools: &Path,
+    root: &Path,
+    evidence: &Path,
+) {
+    let binary = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/celln");
+    let address = TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap();
+    let token = root.join("closure-test-token");
+    std::fs::write(&token, TOKEN).unwrap();
+    let log = std::fs::File::create(evidence.join("dispatcher.log")).unwrap();
+    let child = Command::new(binary)
+        .arg("--root")
+        .arg(root)
+        .arg("dispatcher")
+        .arg("--listen")
+        .arg(address.to_string())
+        .arg("--token-file")
+        .arg(&token)
+        .arg("--mote-store")
+        .arg(motes)
+        .arg("--tool-store")
+        .arg(tools)
+        .args(["--memory-bytes", "268435456", "--egress-slots", "1"])
+        .stdout(Stdio::from(log.try_clone().unwrap()))
+        .stderr(Stdio::from(log))
+        .spawn()
+        .unwrap();
+    let mut server = Server {
+        child,
+        address,
+        evidence: evidence.to_owned(),
+    };
+    let start = Instant::now();
+    while TcpStream::connect(address).is_err() {
+        assert!(
+            server.child.try_wait().unwrap().is_none(),
+            "dispatcher exited"
+        );
+        assert!(start.elapsed() < Duration::from_secs(10));
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    server.submit(request);
+    let audit = server.terminal(request, "Succeeded");
+    assert_eq!(
+        audit["execution"]["substrate"]["closure"]["hash"],
+        request.tools[0].closure.as_ref().unwrap().hash
+    );
+    let mut refused = request.clone();
+    refused.id = "unknown-closure".into();
+    refused.tools[0].closure.as_mut().unwrap().hash =
+        celln_manifest::Hash::of(b"unknown closure").0;
+    server.submit(&refused);
+    assert!(server.terminal(&refused, "Failed")["execution"].is_null());
+    if let Some(script) = std::env::var_os("CELLN_SYMPOZIUM_PROOF") {
+        let external = evidence.join("sympozium");
+        std::fs::create_dir_all(&external).unwrap();
+        let reference = evidence.join(format!("{}-request.json", request.id));
+        let log = std::fs::File::create(external.join("proof.log")).unwrap();
+        let status = Command::new("timeout")
+            .args(["--signal=TERM", "--kill-after=10s", "600s"])
+            .arg(script)
+            .env("CELLN_ROUTER_URL", format!("http://{address}"))
+            .env("CELLN_TOKEN_FILE", &token)
+            .env("CELLN_PROOF_REQUEST", reference)
+            .env("CELLN_PROOF_EVIDENCE", &external)
+            .env("CELLN_PROOF_ROOT", root)
+            .env(
+                "CELLN_PROOF_BINARY",
+                Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/celln"),
+            )
+            .env("CELLN_PROOF_MODE", "closure")
+            .stdout(Stdio::from(log.try_clone().unwrap()))
+            .stderr(Stdio::from(log))
+            .status()
+            .unwrap();
+        assert!(
+            status.success(),
+            "external closure proof failed; inspect {}",
+            external.display()
+        );
+    }
+}
+
 struct Server {
     child: Child,
     address: SocketAddr,
@@ -271,6 +359,7 @@ pub(crate) fn prove(base: ExecutionRequest, motes: &Path, tools: &Path, root: &P
     assert!(audit["receipt"].is_null());
     let mut unsupported = request.clone();
     unsupported.id = "http-unsupported-closure".into();
+    unsupported.capabilities.egress = vec!["https://example.com".into()];
     unsupported.tools[0].closure = Some(celln_spec::ImmutableRef {
         hash: celln_manifest::Hash::of(b"closure").0,
     });

--- a/crates/celln-cli/src/dispatch_substrate.rs
+++ b/crates/celln-cli/src/dispatch_substrate.rs
@@ -26,7 +26,7 @@ fn authorize(request: &ExecutionRequest, state_root: &Path) -> Result<(), String
 }
 
 /// A pinned bundle cannot undo authority already narrowed on this node.
-fn local_agent_constraint(hash: &str, state_root: &Path) -> Result<bool, String> {
+pub(super) fn local_agent_constraint(hash: &str, state_root: &Path) -> Result<bool, String> {
     let path = state_root.join("assay/manifest.json");
     let bytes = match std::fs::read(path) {
         Ok(bytes) => bytes,
@@ -96,8 +96,12 @@ pub(crate) fn launch_declared(
     let inputs = super::inputs::resolve(request, state_root)?;
     let resolved = super::resolve_bundle(request, mote_root, tool_root)?;
     let local_agent = local_agent_constraint(&resolved.program_hash, state_root)?;
-    if resolved.format.as_deref() != Some("celln.warm-static-v1") {
-        return Err("unsupported declared mote format; expected celln.warm-static-v1".into());
+    let closure = super::closure::resolve(request, &resolved, state_root)?;
+    if !matches!(
+        resolved.format.as_deref(),
+        Some("celln.warm-static-v1" | "celln.warm-closure-v1")
+    ) {
+        return Err("unsupported declared mote format".into());
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -114,11 +118,22 @@ pub(crate) fn launch_declared(
         if !resolved.initrd_bytes.starts_with(b"070701") {
             return Err("unsupported initrd: warm static format requires uncompressed newc".into());
         }
+        let mut force_agent =
+            local_agent || request.execution.lane == celln_spec::RequestedLane::Agent;
+        if let Some(c) = &closure {
+            force_agent |= c.signed.closure.interpreter;
+            for m in c.signed.closure.members.values() {
+                force_agent |= local_agent_constraint(&m.hash, state_root)?;
+            }
+        }
         let run = serde_json::to_vec(&serde_json::json!({
-            "path": "/tools/program", "alias": invocation.alias,
+            "path": closure.as_ref().map_or("/tools/program", |c| c.signed.closure.entrypoint.as_str()),
+            "root": closure.as_ref().map(|_| "/tools"),
+            "closure_members": closure.as_ref().map(|c| &c.signed.closure.members),
+            "alias": invocation.alias,
             "args": invocation.args, "expected_hash": resolved.program_hash,
             "agent_authored_input": request.execution.lane == celln_spec::RequestedLane::Agent,
-            "force_agent_lane": local_agent || request.execution.lane == celln_spec::RequestedLane::Agent,
+            "force_agent_lane": force_agent,
             "allow_fetch": !request.capabilities.egress.is_empty(),
             "report_output_limit": request.capabilities.output_bytes,
             "workspace_access": request.capabilities.workspace,
@@ -138,6 +153,7 @@ pub(crate) fn launch_declared(
         }
         initrd_bytes.extend(file_archive("celln/dispatch-warm", b"pio-v1\n"));
         let identity = super::SubstrateIdentity {
+            closure: closure.as_ref().map(|c| c.provenance.clone()),
             kernel: resolved.kernel_hash.clone(),
             initrd: celln_manifest::Hash::of(&initrd_bytes).0,
             toolfs: resolved.toolfs_hash.clone(),
@@ -320,6 +336,7 @@ mod tests {
         let Some(runtime) = super::super::tests::test_runtime_root(work.path()) else {
             return;
         };
+        let material_started = std::time::Instant::now();
         let program = work.path().join("program");
         let source =
             Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/dispatch_outcome_probe.rs");
@@ -394,6 +411,7 @@ mod tests {
         let bundle_hash = store.put(&serde_json::to_vec(&bundle).unwrap()).unwrap();
         let state = work.path().join("state");
         pin(&state, &bundle_hash);
+        let material_elapsed = material_started.elapsed();
         let preparations =
             super::super::warm::PREPARATIONS.load(std::sync::atomic::Ordering::SeqCst);
         let cold_started = std::time::Instant::now();
@@ -429,6 +447,7 @@ mod tests {
         assert_eq!(hints[0].tools, vec![program_hash.0.clone()]);
         assert_eq!(hints[0].guest_memory_bytes, 268435456);
         let cold_elapsed = cold_started.elapsed();
+        let mut warm_micros = Vec::new();
         for arg in ["first", "second"] {
             let mut req = request(&bundle_hash, &program_hash);
             req.capabilities.workspace = celln_spec::WorkspaceAccess::ReadWrite;
@@ -445,7 +464,34 @@ mod tests {
                 preparations + 1
             );
             eprintln!("PASS: warm {arg}, private scratch, distinct args; cold={cold_elapsed:?}, warm={:?}", started.elapsed());
+            warm_micros.push(started.elapsed().as_micros());
         }
+        let shared = warden::vmm::kvm::shared_tool_map_existing(&toolfs_hash).unwrap();
+        let maps = warden::vmm::kvm::shared_tool_count();
+        let forks: Vec<_> = (0..8)
+            .map(|_| {
+                super::super::warm::fork(
+                    format!("{}:268435456", bundle_hash.0),
+                    vec![program_hash.0.clone()],
+                    || panic!("warm only"),
+                )
+                .unwrap()
+            })
+            .collect();
+        assert_eq!(warden::vmm::kvm::shared_tool_count(), maps);
+        assert_eq!(
+            warden::vmm::kvm::shared_tool_map_existing(&toolfs_hash)
+                .unwrap()
+                .addr(),
+            shared.addr()
+        );
+        drop(forks);
+        let evidence_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/closure-proof");
+        std::fs::create_dir_all(&evidence_dir).unwrap();
+        std::fs::write(evidence_dir.join(format!("static-{}.json", std::process::id())), serde_json::to_vec_pretty(&json!({
+            "materialisationMicros":material_elapsed.as_micros(), "coldExecutionMicros":cold_elapsed.as_micros(), "warmExecutionMicros":warm_micros,
+            "simultaneousForks":8,"additionalToolAllocations":0,"sharedToolBytes":shared.len(), "programBytes":program_bytes.len()
+        })).unwrap()).unwrap();
 
         for (access, name) in [
             (celln_spec::WorkspaceAccess::None, "none"),

--- a/crates/celln-cli/src/dispatch_warm.rs
+++ b/crates/celln-cli/src/dispatch_warm.rs
@@ -24,6 +24,11 @@ pub(crate) fn availability() -> Option<Vec<Availability>> {
 }
 static CACHE: OnceLock<Mutex<Cached>> = OnceLock::new();
 #[cfg(test)]
+pub(super) fn evict() {
+    *CACHE.get_or_init(|| Mutex::new(None)).lock().unwrap() = None;
+    warden::vmm::kvm::collect_unused_tools();
+}
+#[cfg(test)]
 pub(super) static PREPARATIONS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 #[cfg(test)]
@@ -77,6 +82,7 @@ pub(super) fn fork(
             // Drop the only shared writable RAM mapping before publishing.
             drop(template);
             *cache = Some((key, Arc::clone(&mote), hint));
+            warden::vmm::kvm::collect_unused_tools();
             mote
         }
     };

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -2,6 +2,7 @@
 
 mod agent;
 mod cells;
+mod closure_cli;
 mod config;
 mod dispatch;
 #[cfg(all(test, target_os = "linux"))]
@@ -61,6 +62,9 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
+    /// Authenticate and admit precomposed dependency closures.
+    #[command(subcommand)]
+    Closure(ClosureCmd),
     /// Report what this machine can run.
     Doctor,
 
@@ -313,6 +317,19 @@ enum NodeCmd {
     },
 }
 
+#[derive(Subcommand)]
+enum ClosureCmd {
+    /// Offline signing; write the signed descriptor to stdout (never the key).
+    Sign {
+        descriptor: PathBuf,
+        /// Exactly 32 raw private seed bytes; keep this file offline.
+        #[arg(long)]
+        key_file: PathBuf,
+    },
+    /// Verify against host policy and store a signed descriptor by content hash.
+    Admit { descriptor: PathBuf },
+}
+
 #[derive(clap::Args, Clone)]
 struct NodeProbeArgs {
     #[arg(long, env = "CELLN_NODE_NAME", default_value = "local")]
@@ -364,6 +381,11 @@ fn resolve_root(explicit: &Option<PathBuf>) -> PathBuf {
 fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
     let root = resolve_root(&cli.root);
     match &cli.cmd {
+        Cmd::Closure(ClosureCmd::Sign {
+            descriptor,
+            key_file,
+        }) => closure_cli::sign(descriptor, key_file),
+        Cmd::Closure(ClosureCmd::Admit { descriptor }) => closure_cli::admit(descriptor, &root),
         Cmd::Doctor => Ok(doctor(o)),
         Cmd::Dispatcher {
             listen,

--- a/crates/celln-cli/tests/deepseek_adapter.rs
+++ b/crates/celln-cli/tests/deepseek_adapter.rs
@@ -1,0 +1,46 @@
+#[test]
+#[cfg(unix)]
+fn deepseek_credential_is_stdin_not_argv_and_prompt_stays_data() {
+    use std::os::unix::fs::PermissionsExt;
+    let work = tempfile::tempdir().unwrap();
+    let curl = work.path().join("curl");
+    std::fs::write(&curl, r#"#!/usr/bin/env bash
+set -euo pipefail
+[[ -z "${DEEPSEEK_API_KEY:-}" ]]
+[[ "$*" != *synthetic-private-key* ]]
+IFS= read -r header
+[[ "$header" == 'Authorization: Bearer synthetic-private-key' ]]
+while (($#)); do
+  if [[ "$1" == -d ]]; then
+    jq -e '.model == "deepseek-chat" and .messages[0].content == "quotes: \" ; $(touch forbidden)\nnext line"' <<<"$2" >/dev/null
+    break
+  fi
+  shift
+done
+printf '%s\n' '{"choices":[{"message":{"content":"SAFE"}}]}' '200'
+"#).unwrap();
+    std::fs::set_permissions(&curl, std::fs::Permissions::from_mode(0o700)).unwrap();
+    let shim = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/deepseek-api");
+    let out = std::process::Command::new("bash")
+        .arg(shim)
+        .arg("quotes: \" ; $(touch forbidden)\nnext line")
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                work.path().display(),
+                std::env::var("PATH").unwrap()
+            ),
+        )
+        .env("DEEPSEEK_API_KEY", "synthetic-private-key")
+        .current_dir(work.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(out.stdout, b"SAFE\n");
+    assert!(!work.path().join("forbidden").exists());
+}

--- a/crates/celln-cli/tests/fixtures/closure_probe.rs
+++ b/crates/celln-cli/tests/fixtures/closure_probe.rs
@@ -1,0 +1,38 @@
+use std::{fs, io::Write, process::Command};
+use std::os::fd::AsRawFd;
+extern "C" {
+    fn mmap(addr: *mut std::ffi::c_void, len: usize, prot: i32, flags: i32, fd: i32, offset: i64) -> *mut std::ffi::c_void;
+}
+
+fn main() {
+    let mode = std::env::args().nth(1).unwrap_or_else(|| "none".into());
+    let library = std::env::args().nth(2).expect("library path");
+    if mode == "revoke" {
+        println!("closure-revoke-ready");
+        loop { std::thread::sleep(std::time::Duration::from_millis(1)); }
+    }
+    let before = fs::read(&library).expect("admitted library readable");
+    assert!(fs::OpenOptions::new().write(true).open(&library).is_err());
+    assert!(fs::remove_file(&library).is_err());
+    assert!(fs::rename(&library, "/tmp/stolen.so").is_err());
+    assert!(fs::read("/etc/closure-unlisted").is_err());
+    assert!(fs::read("/celln/manifest.json").is_err());
+    if mode == "read-write" {
+        let mut scratch = fs::File::create("/tmp/data").unwrap();
+        scratch.write_all(b"private scratch").unwrap();
+        fs::copy("/bin/program", "/tmp/copied").unwrap();
+        assert!(Command::new("/tmp/copied").status().is_err());
+        assert!(fs::rename("/tmp/copied", &library).is_err());
+        assert!(fs::hard_link(&library, "/tmp/library.so").is_err());
+        fs::copy(&library, "/tmp/library.so").unwrap();
+        let copied = fs::File::open("/tmp/library.so").unwrap();
+        // Landlock EXECUTE alone does not cover dlopen/mmap(PROT_EXEC).
+        // The host-selected noexec scratch mount must stop that alternate path.
+        let mapping = unsafe { mmap(std::ptr::null_mut(), 4096, 1 | 4, 2, copied.as_raw_fd(), 0) };
+        assert_eq!(mapping as isize, -1, "mutable library executable mapping permitted");
+    } else {
+        assert!(fs::write("/tmp/data", b"denied").is_err());
+    }
+    assert_eq!(before, fs::read(&library).unwrap());
+    println!("closure:{mode}:dynamic-loader:replacement-denied");
+}

--- a/crates/celln-manifest/Cargo.toml
+++ b/crates/celln-manifest/Cargo.toml
@@ -15,3 +15,4 @@ blake3.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+ed25519-dalek = "=2.1.1"

--- a/crates/celln-manifest/src/closure.rs
+++ b/crates/celln-manifest/src/closure.rs
@@ -1,0 +1,227 @@
+//! Publisher-authenticated, precomposed dependency closures. This is separate
+//! from the legacy manifest checksum: possession of bytes is not admission.
+use crate::Hash;
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+const DOMAIN: &[u8] = b"celln.dev/closure-v1\0";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Closure {
+    pub api_version: String,
+    /// Hash of the entire immutable ext2 filesystem, including loader paths.
+    pub toolfs: String,
+    pub entrypoint: String,
+    pub interpreter: bool,
+    /// Every admitted code file, keyed by canonical absolute path. Dependencies
+    /// name other members; composition never consults a host library directory.
+    pub members: BTreeMap<String, Member>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Member {
+    pub hash: String,
+    pub dependencies: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SignedClosure {
+    pub closure: Closure,
+    /// Lowercase hex Ed25519 public key, matched against separate host policy.
+    pub publisher: String,
+    pub signature: String,
+}
+
+fn hash(value: &str) -> bool {
+    value.strip_prefix("blake3:").is_some_and(|s| {
+        s.len() == 64
+            && s.bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    })
+}
+
+pub fn canonical_path(path: &str) -> bool {
+    path.starts_with('/')
+        && path.len() <= 1024
+        && path[1..].split('/').all(|p| {
+            !p.is_empty()
+                && p != "."
+                && p != ".."
+                && p.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b"-_.+".contains(&b))
+        })
+}
+
+pub fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn decode<const N: usize>(value: &str) -> Result<[u8; N], String> {
+    if value.len() != N * 2
+        || !value
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    {
+        return Err("invalid closure key/signature encoding".into());
+    }
+    let mut bytes = [0; N];
+    for (i, byte) in bytes.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&value[i * 2..i * 2 + 2], 16).map_err(|_| "invalid hex")?;
+    }
+    Ok(bytes)
+}
+
+impl Closure {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.api_version != "celln.dev/closure-v1"
+            || !hash(&self.toolfs)
+            || self.members.is_empty()
+            || self.members.len() > 256
+            || !self.members.contains_key(&self.entrypoint)
+        {
+            return Err("invalid closure identity, version, or entrypoint".into());
+        }
+        for (path, member) in &self.members {
+            if !canonical_path(path)
+                || !hash(&member.hash)
+                || member
+                    .dependencies
+                    .iter()
+                    .any(|p| !self.members.contains_key(p))
+            {
+                return Err("invalid closure member or unresolved dependency".into());
+            }
+        }
+        // Cycles are legal (real shared libraries can depend on one another),
+        // unreachable extras are not: they must not accidentally gain authority.
+        let mut seen = BTreeSet::new();
+        let mut pending = vec![self.entrypoint.as_str()];
+        while let Some(path) = pending.pop() {
+            if seen.insert(path) {
+                pending.extend(self.members[path].dependencies.iter().map(String::as_str));
+            }
+        }
+        if seen.len() != self.members.len() {
+            return Err("closure contains unreachable code members".into());
+        }
+        Ok(())
+    }
+
+    fn message(&self) -> Result<Vec<u8>, String> {
+        self.validate()?;
+        let mut message = DOMAIN.to_vec();
+        message.extend(serde_json::to_vec(self).map_err(|e| e.to_string())?);
+        Ok(message)
+    }
+
+    /// Offline publisher operation. Dispatch never needs this private key.
+    pub fn sign(self, seed: &[u8; 32]) -> Result<SignedClosure, String> {
+        let key = SigningKey::from_bytes(seed);
+        let signature = hex(&key.sign(&self.message()?).to_bytes());
+        Ok(SignedClosure {
+            closure: self,
+            publisher: hex(&key.verifying_key().to_bytes()),
+            signature,
+        })
+    }
+}
+
+impl SignedClosure {
+    pub fn verify(&self, publishers: &BTreeSet<String>) -> Result<(), String> {
+        if !publishers.contains(&self.publisher) {
+            return Err("closure publisher is not authorized".into());
+        }
+        let key = VerifyingKey::from_bytes(&decode(&self.publisher)?)
+            .map_err(|_| "invalid closure publisher key")?;
+        key.verify_strict(
+            &self.closure.message()?,
+            &Signature::from_bytes(&decode(&self.signature)?),
+        )
+        .map_err(|_| "closure signature verification failed".into())
+    }
+
+    pub fn identity(&self) -> Result<Hash, String> {
+        Ok(Hash::of(
+            &serde_json::to_vec(self).map_err(|e| e.to_string())?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn fixture() -> Closure {
+        Closure {
+            api_version: "celln.dev/closure-v1".into(),
+            toolfs: Hash::of(b"filesystem").0,
+            entrypoint: "/bin/program".into(),
+            interpreter: false,
+            members: BTreeMap::from([
+                (
+                    "/bin/program".into(),
+                    Member {
+                        hash: Hash::of(b"program").0,
+                        dependencies: BTreeSet::from(["/lib/loader.so".into()]),
+                    },
+                ),
+                (
+                    "/lib/loader.so".into(),
+                    Member {
+                        hash: Hash::of(b"loader").0,
+                        dependencies: BTreeSet::new(),
+                    },
+                ),
+            ]),
+        }
+    }
+    #[test]
+    fn authenticates_publisher_and_every_authority_field() {
+        let signed = fixture().sign(&[42; 32]).unwrap();
+        let policy = BTreeSet::from([signed.publisher.clone()]);
+        assert!(signed.verify(&policy).is_ok());
+        assert!(signed.verify(&BTreeSet::new()).is_err());
+        let mut mutations = Vec::new();
+        let mut c = signed.clone();
+        c.closure.toolfs = Hash::of(b"replacement").0;
+        mutations.push(c);
+        let mut c = signed.clone();
+        c.closure.interpreter = true;
+        mutations.push(c);
+        let mut c = signed.clone();
+        c.closure.members.get_mut("/lib/loader.so").unwrap().hash = Hash::of(b"evil").0;
+        mutations.push(c);
+        let mut c = signed.clone();
+        c.signature = hex(&[0; 64]);
+        mutations.push(c);
+        for mutation in mutations {
+            assert!(mutation.verify(&policy).is_err());
+        }
+    }
+    #[test]
+    fn graph_and_paths_fail_closed() {
+        for path in [
+            "relative",
+            "/../bin",
+            "/bin//program",
+            "/bin/./program",
+            "/bin/a\ncommand",
+            "/",
+        ] {
+            assert!(!canonical_path(path));
+        }
+        let mut c = fixture();
+        c.members.remove("/lib/loader.so");
+        assert!(c.validate().is_err());
+        let mut c = fixture();
+        c.members
+            .get_mut("/bin/program")
+            .unwrap()
+            .dependencies
+            .clear();
+        assert!(c.validate().is_err());
+    }
+}

--- a/crates/celln-manifest/src/lib.rs
+++ b/crates/celln-manifest/src/lib.rs
@@ -373,3 +373,4 @@ mod tests {
         assert!(!m.verify_standin());
     }
 }
+pub mod closure;

--- a/crates/celln-pilot/src/guest.rs
+++ b/crates/celln-pilot/src/guest.rs
@@ -149,6 +149,7 @@ fn enter_agent_lane(
     allow_fetch: bool,
     access: Option<WorkspaceAccess>,
     has_inputs: bool,
+    closure_members: Option<&BTreeMap<String, celln_manifest::closure::Member>>,
 ) -> io::Result<()> {
     if allow_fetch {
         // CAP_SYS_RAWIO also authorises legacy device-node interfaces that
@@ -228,10 +229,20 @@ fn enter_agent_lane(
         if let Some(access) = access {
             // Child-process libraries open /dev/null for unused standard
             // streams. This exact sink/source grants no console or host data.
-            add(
-                "/dev/null",
-                LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_WRITE_FILE,
-            )?;
+            if closure_members.is_none() {
+                add(
+                    "/dev/null",
+                    LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_WRITE_FILE,
+                )?;
+            }
+            if let Some(members) = closure_members {
+                for path in members.keys() {
+                    add(
+                        path,
+                        LANDLOCK_ACCESS_FS_EXECUTE | LANDLOCK_ACCESS_FS_READ_FILE,
+                    )?;
+                }
+            }
             if allow_fetch {
                 add(
                     "/pilot-fetch",
@@ -579,6 +590,8 @@ struct InputData {
 
 #[derive(Deserialize)]
 struct RunRequest {
+    #[serde(default)]
+    closure_members: Option<BTreeMap<String, celln_manifest::closure::Member>>,
     /// Where the bytes live in the cell — normally on the sealed DAX mount.
     ///
     /// When `root` is set this is relative to *that* root, not to pilot's own
@@ -626,6 +639,8 @@ struct RunRequest {
 #[derive(Deserialize)]
 struct RunFile {
     #[serde(default)]
+    closure_members: Option<BTreeMap<String, celln_manifest::closure::Member>>,
+    #[serde(default)]
     runs: Vec<RunRequest>,
     #[serde(default)]
     root: Option<String>,
@@ -668,6 +683,7 @@ impl RunFile {
         }
         match (self.path, self.alias) {
             (Some(path), Some(alias)) => vec![RunRequest {
+                closure_members: self.closure_members,
                 path,
                 alias,
                 args: self.args,
@@ -693,7 +709,7 @@ impl RunFile {
 /// scratch. This gives each cell its own private tmpfs at a path the image
 /// already provides, so the read-only image stays shareable across every cell
 /// while the writes stay per-cell.
-fn mount_scratch(root: &str) -> io::Result<()> {
+fn mount_scratch(root: &str, strict: bool) -> io::Result<()> {
     let target = CString::new(format!("{root}/tmp"))
         .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
     let fstype = CString::new("tmpfs").expect("constant");
@@ -703,7 +719,11 @@ fn mount_scratch(root: &str) -> io::Result<()> {
             source.as_ptr(),
             target.as_ptr(),
             fstype.as_ptr(),
-            0,
+            if strict {
+                libc::MS_NOEXEC | libc::MS_NODEV | libc::MS_NOSUID
+            } else {
+                0
+            },
             std::ptr::null(),
         ) != 0
         {
@@ -721,6 +741,28 @@ fn open_and_hash(path: &str) -> io::Result<(File, Hash)> {
     let mut bytes = Vec::new();
     file.read_to_end(&mut bytes)?;
     Ok((file, Hash::of(&bytes)))
+}
+
+fn sealed_member_path(path: &str) -> bool {
+    if !celln_manifest::closure::canonical_path(path) {
+        return false;
+    }
+    let mut full = std::path::PathBuf::from("/tools");
+    let mut parts = path[1..].split('/').peekable();
+    while let Some(part) = parts.next() {
+        full.push(part);
+        let Ok(metadata) = std::fs::symlink_metadata(&full) else {
+            return false;
+        };
+        if parts.peek().is_some() {
+            if !metadata.is_dir() {
+                return false;
+            }
+        } else if !metadata.is_file() || metadata.len() > 512 * 1024 * 1024 {
+            return false;
+        }
+    }
+    true
 }
 
 fn child_error(error_fd: i32, error: io::Error) -> ! {
@@ -848,6 +890,7 @@ fn exec_open_file(
                 req.allow_fetch,
                 req.workspace_access,
                 !req.inputs.is_empty(),
+                req.closure_members.as_ref(),
             ) {
                 child_error(error_pipe[1], error);
             }
@@ -1073,11 +1116,17 @@ fn run_requested(manifest: &Manifest) {
     for req in invocations {
         if let Some(root) = req.root.clone() {
             if !mounted.contains(&root) {
-                match mount_scratch(&root) {
+                match mount_scratch(&root, req.workspace_access.is_some()) {
                     Ok(()) => report("pilot_scratch", "tmpfs"),
                     Err(e) => {
                         report("pilot_scratch", "failed");
                         eprintln!("pilot: tmpfs on {root}/tmp: {e}");
+                        if req.workspace_access.is_some() {
+                            emit(Frame::Failed {
+                                reason: "private closure workspace unavailable".into(),
+                            });
+                            continue;
+                        }
                     }
                 }
                 mounted.push(root);
@@ -1194,6 +1243,26 @@ fn run_one(manifest: &Manifest, req: &RunRequest) {
         Some(root) => format!("{root}{}", req.path),
         None => req.path.clone(),
     };
+    if let Some(members) = &req.closure_members {
+        // Verify each actual sealed member, not a host assertion about what
+        // the filesystem ought to contain. The mount is hardware read-only,
+        // so these paths cannot change between hashing and dynamic loading.
+        if req.root.as_deref() != Some("/tools")
+            || members.is_empty()
+            || members.len() > 256
+            || !members.contains_key(&req.path)
+            || members.iter().any(|(path, member)| {
+                !sealed_member_path(path)
+                    || open_and_hash(&format!("/tools{path}"))
+                        .map_or(true, |(_, h)| h.0 != member.hash)
+            })
+        {
+            emit(Frame::Failed {
+                reason: "sealed closure member mismatch".into(),
+            });
+            return;
+        }
+    }
     let Ok((executable, hash)) = open_and_hash(&host_view) else {
         report(&format!("pilot_run_{}", req.alias), "absent");
         if req.report_output_limit.is_some() {
@@ -1343,6 +1412,7 @@ mod tests {
         );
 
         let request = RunRequest {
+            closure_members: None,
             path: path.to_string_lossy().into_owned(),
             alias: "verified-fd".into(),
             args: Vec::new(),

--- a/crates/celln-warden/src/vmm/boot.rs
+++ b/crates/celln-warden/src/vmm/boot.rs
@@ -772,6 +772,7 @@ pub struct ForkTiming {
 }
 
 pub struct Mote {
+    tool_maps: Vec<super::kvm::SharedTool>,
     ram: Arc<OwnedFd>,
     ram_size: usize,
     /// Width of the tool-window hole, so a fork rebuilds the same RAM split.
@@ -857,6 +858,7 @@ pub struct LinuxCell {
     /// The CPUID the vCPU was configured with; travels with a snapshot.
     cpuid: kvm_bindings::CpuId,
     tools: HashMap<Hash, (u32, u64, usize)>, // slot, gpa, len
+    tool_maps: Vec<super::kvm::SharedTool>,
     next_slot: u32,
     next_tool_gpa: u64,
     cfg: BootConfig,
@@ -988,6 +990,7 @@ impl LinuxCell {
             stop_on_signal: false,
             cpuid,
             tools: HashMap::new(),
+            tool_maps: Vec::new(),
             next_slot: FIRST_TOOL_SLOT,
             next_tool_gpa: TOOL_WINDOW_GPA,
             cfg,
@@ -1019,6 +1022,7 @@ impl LinuxCell {
         unsafe { self.vm.set_user_memory_region(region) }
             .map_err(|e| kvm_err("set_user_memory_region(tool)", e))?;
         self.tools.insert(hash.clone(), (self.next_slot, gpa, len));
+        self.tool_maps.push(map);
         self.next_slot += 1;
         // Advance by the aligned extent, not the raw length, so the Nth
         // sealed image lands exactly on the Nth declared namespace base.
@@ -1204,6 +1208,7 @@ impl LinuxCell {
                 .map(|(h, (_, gpa, len))| (h.clone(), *gpa, *len))
                 .collect(),
             cfg: self.cfg.clone(),
+            tool_maps: self.tool_maps.clone(),
         })
     }
 
@@ -1351,6 +1356,7 @@ impl LinuxCell {
                 stop_on_signal: false,
                 cpuid: mote.cpuid.clone(),
                 tools,
+                tool_maps: mote.tool_maps.clone(),
                 next_slot,
                 next_tool_gpa: TOOL_WINDOW_GPA,
                 cfg: mote.cfg.clone(),

--- a/crates/celln-warden/src/vmm/kvm.rs
+++ b/crates/celln-warden/src/vmm/kvm.rs
@@ -146,6 +146,17 @@ pub fn shared_tool_count() -> usize {
     tool_registry().lock().map(|r| r.len()).unwrap_or(0)
 }
 
+/// Release cache-only page sets. Active VMMs and parked motes own strong
+/// handles, so neither execution nor a future fork can lose its backing memory.
+pub fn collect_unused_tools() -> usize {
+    let Ok(mut registry) = tool_registry().lock() else {
+        return 0;
+    };
+    let before = registry.len();
+    registry.retain(|_, map| Arc::strong_count(map) > 1);
+    before - registry.len()
+}
+
 /// The shared page-set for `hash`, creating it from `bytes` if this is the
 /// first cell to loan it. Other backends (e.g. [`super::boot::LinuxCell`]) go
 /// through here so every cell in the process maps one physical copy.
@@ -176,6 +187,7 @@ pub fn shared_tool_bytes(hash: &Hash, off: usize, len: usize) -> Option<Vec<u8>>
 
 /// A handle to one shared tool page-set: a host mapping every cell that loans
 /// this hash points at.
+#[derive(Clone)]
 pub struct SharedTool(Arc<HostMap>);
 
 impl SharedTool {

--- a/docs/TRUSTED_CLOSURES.md
+++ b/docs/TRUSTED_CLOSURES.md
@@ -1,0 +1,136 @@
+# Trusted precomposed closures
+
+Issue #6 adds `celln.warm-closure-v1` alongside the unchanged
+`celln.warm-static-v1` bundle format. A closure is an immutable ext2 image plus
+an Ed25519-signed inventory/dependency graph. It is not an ambient host library
+search path, an OCI tag, or a replacement for the operator's mote trust policy.
+
+## Admission and composition
+
+The publisher builds a self-contained filesystem offline, including the ELF
+loader at its required absolute path and a real `/tmp` directory. Every runtime
+file that the workload needs to read must be a member. Paths are canonical
+absolute names; member paths and their parent components must not be symlinks.
+This prevents pre-chroot verification and post-chroot loading resolving an
+absolute symlink against different roots. Package real files at loader paths.
+Dependencies refer to member paths, all are resolved, and every member must be
+reachable from the entrypoint. Cycles are permitted. Limit: 256 members and a
+256 KiB signed descriptor; the serialized invocation must additionally fit the
+existing bounded PIO delivery channel.
+
+Unsigned descriptor shape (replace the illustrative hashes):
+
+```json
+{
+  "apiVersion": "celln.dev/closure-v1",
+  "toolfs": "blake3:<64 lowercase hex digits>",
+  "entrypoint": "/bin/program",
+  "interpreter": false,
+  "members": {
+    "/bin/program": {
+      "hash": "blake3:<program hash>",
+      "dependencies": ["/lib64/ld-linux-x86-64.so.2", "/lib64/libc.so.6"]
+    },
+    "/lib64/ld-linux-x86-64.so.2": {"hash": "blake3:<loader hash>", "dependencies": []},
+    "/lib64/libc.so.6": {"hash": "blake3:<libc hash>", "dependencies": []}
+  }
+}
+```
+
+Sign offline using a private, random 32-byte Ed25519 seed:
+
+```sh
+celln closure sign closure.json --key-file publisher.seed > signed-closure.json
+celln --root /var/lib/celln closure admit signed-closure.json
+```
+
+Do not reuse the deterministic test keys. Signing emits only the descriptor,
+public key and signature. The dispatcher never receives the private seed.
+Signatures cover a domain-separated, deterministic serialization of every
+descriptor field; strict Ed25519 verification rejects invalid/weak signatures.
+Implementation: [ed25519-dalek 2.1.1](https://docs.rs/crate/ed25519-dalek/2.1.1).
+
+The operator separately installs `trusted-closures.json` under the state root:
+
+```json
+{
+  "apiVersion": "celln.dev/closure-policy-v1",
+  "publishers": ["<64 lowercase hex public-key digits>"],
+  "revoked": []
+}
+```
+
+`closure admit` verifies that policy and stores the exact descriptor bytes in
+`<root>/closures`. Its returned BLAKE3 hash becomes `tools[0].closure.hash`.
+It does not install a trust root or claim the filesystem is already available.
+The normal content stores must contain the program and bundle artifacts. Pin
+the bundle in `trusted-motes.json` as before, changing only its `format` to
+`celln.warm-closure-v1`; its toolfs and program hashes must match the signed
+closure. The pinned initrd must contain the current pilot and an entry for the
+program in its manifest. The guest manifest's legacy checksum is **not** the
+publisher signature: publisher authentication happens on the host before fork.
+
+Every launch rechecks publisher policy, descriptor integrity, signature,
+filesystem identity, entrypoint identity and dependency revocation, including
+warm-cache hits. A publisher can be withdrawn by removing its key. `revoked`
+accepts closure-descriptor, filesystem or member hashes. Local manifest
+revocation also wins. A locally agent-authored/interpreter dependency narrows
+the whole invocation to the agent lane; a publisher-marked interpreter is always
+narrowed. Policy changes govern new launches, not live fleet withdrawal (#8).
+
+## What the cell receives
+
+Preparation seals the exact composed filesystem and parks the mote. Every
+execution forks that mote, including the first. Request arguments and the
+authenticated member inventory arrive only after the fork. Pilot re-hashes
+every actual member before executing the entrypoint by its verified descriptor.
+The child's root is the single sealed filesystem. Landlock grants read/execute
+only for the enumerated files; no root-wide read/execute grant is added.
+
+Strict closure scratch is private tmpfs with `noexec,nodev,nosuid`, including
+when workspace access is `none` or `read-only`. This matters because Landlock's
+EXECUTE restriction alone does not stop `mmap(PROT_EXEC)` of a copied library.
+Workspace access remains independently enforced by Landlock. Mount failure
+refuses execution. Guest socket creation and capabilities remain restricted.
+
+This version supports one precomposed closure for one invoked tool. Closure
+requests with forge, inputs or egress refuse explicitly. Arbitrary distribution
+images are not automatically admitted or granted root-wide access. Layer-level
+deduplication, registry/cosign identity discovery, and automatic dependency
+discovery are not claimed. Offline packaging may use OCI; dispatch never needs
+a container runtime or a host library directory.
+
+## Provenance, retention and collection
+
+The execution audit's `execution.substrate.closure` records descriptor hash,
+authenticated publisher, sealed filesystem hash, and member graph next to the
+actual pilot verdict and receipt. The immutable `celln.dev/v1alpha1` receipt
+schema is unchanged; its mote/tool hashes and cell ID correlate with that audit.
+Neither the receipt nor the legacy guest manifest is advertised as a signed
+publisher attestation. Preserve the audit when exporting execution evidence.
+
+Live cells and parked motes hold strong handles to their shared sealed pages.
+Warm-cache replacement collects page sets with no remaining live/template
+owner; an active fork cannot lose its backing memory. Cold store objects are
+retained, not automatically deleted. Offline disk collection must stop dispatch,
+retain the operator-pinned bundles and their kernel/initrd/toolfs/program
+objects, admitted descriptors plus audit-retained identities, and only remove
+unreachable objects. Do not infer deletability from a publisher withdrawal:
+historical audit retention may still need the bytes. There is intentionally no
+online disk sweep racing active resolution.
+
+## Proofs
+
+`make conformance-kvm` includes a native dynamically linked Rust workload, its
+loader/libc/libgcc closure, every workspace mode, guest code/library replacement
+and executable-mapping attempts, member mismatch, invalid signature, publisher
+withdrawal, dependency revocation, HTTP receipt/audit correlation, warm reuse,
+shared allocation measurements for eight simultaneous forks, and collection
+after eviction. It also reruns the existing static dispatcher suite.
+
+Set `CELLN_SYMPOZIUM_PROOF` to the counterpart real-controller script to test
+both static and signed-closure AgentRuns through isolated Kind, the production
+controller, HTTP dispatch and real host KVM. No user Kubernetes context is used.
+Measurements under `target/closure-proof` compare cold packaging/preparation,
+warm execution, and shared sealed allocation sizes. These are reference-fixture
+measurements, not a claim of whole-process RSS or general workload latency.

--- a/scripts/deepseek-api
+++ b/scripts/deepseek-api
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Never trace credentials, including when invoked with bash -x.
+set +x
 
 MODEL="deepseek-chat"
 PROMPT=""
@@ -21,22 +23,13 @@ if [[ -z "$PROMPT" ]]; then
   exit 1
 fi
 
-ESCAPED=$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$PROMPT")
+PAYLOAD=$(jq -nc --arg model "$MODEL" --arg prompt "$PROMPT" \
+  '{model:$model,messages:[{role:"user",content:$prompt}],stream:false,temperature:0.7,max_tokens:4096}')
 
-PAYLOAD=$(cat <<EOF
-{
-  "model": "$MODEL",
-  "messages": [{"role": "user", "content": $ESCAPED}],
-  "stream": false,
-  "temperature": 0.7,
-  "max_tokens": 4096
-}
-EOF
-)
-
-RESPONSE=$(curl -s -w '\n%{http_code}' https://api.deepseek.com/v1/chat/completions \
+RESPONSE=$(printf 'Authorization: Bearer %s\n' "$DEEPSEEK_API_KEY" | \
+  env -u DEEPSEEK_API_KEY curl -sS -w '\n%{http_code}' https://api.deepseek.com/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer ${DEEPSEEK_API_KEY}" \
+  -H @- \
   -d "$PAYLOAD" \
   --connect-timeout 10 \
   --max-time 120)
@@ -45,13 +38,8 @@ HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | sed '$d')
 
 if [[ "$HTTP_CODE" != "200" ]]; then
-  echo "deepseek API returned HTTP $HTTP_CODE: $BODY" >&2
+  echo "deepseek API returned HTTP $HTTP_CODE" >&2
   exit 1
 fi
 
-python3 -c "
-import json, sys
-data = json.loads(sys.stdin.read())
-content = data['choices'][0]['message']['content']
-sys.stdout.write(content)
-" <<< "$BODY"
+jq -er '.choices[0].message.content | select(type == "string" and length > 0)' <<< "$BODY"


### PR DESCRIPTION
Implements the remaining #6 milestone: strict Ed25519 publisher authentication and explicit host policy; fully bound sealed filesystem/member graph; warm-fork dispatch; exact guest member verification and scoped library access; noexec private scratch (including mmap attack proof); signature, symlink, replacement and dependency-revocation refusals; execution-audit provenance; safe shared-page cache collection and comparative static/closure measurements. Adds offline closure sign/admit commands. The receipt ABI remains unchanged. Explicitly refuses closure combinations with inputs/egress/forge and does not claim automatic OCI signature discovery or online disk GC.

Verification: make ci; real KVM static and closure HTTP suites; actual Sympozium controller with isolated Kind for static and closure AgentRuns; no-KVM Kubernetes refusal; celln verify; HTTPS fetch proof; setup-agent-ps acceptance; real authorized DeepSeek forge/reproduce/seal/execute test. DeepSeek adapter now uses jq and stdin credentials, with a regression test. Counterpart harness: sympozium-ai/sympozium#425.

Refs #6. Portable clean-revision acceptance evidence will be committed after the final merged-stack run.