### PR TITLE
fix(router): authenticate callers and forward cancellation (M0)

### DIFF
--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -818,7 +818,7 @@ fn reply(stream: &mut TcpStream, status: u16, body: &impl Serialize) -> Result<(
     Ok(())
 }
 
-fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+pub(crate) fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
     if left.len() != right.len() {
         return false;
     }

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -118,7 +118,12 @@ enum Cmd {
 
         /// File containing the bearer token forwarded to dispatcher backends.
         #[arg(long)]
-        token_file: Option<PathBuf>,
+        token_file: PathBuf,
+
+        /// Required inbound bearer credential, distinct from the backend token.
+        /// Both files are reread per request so rotation does not need a restart.
+        #[arg(long)]
+        client_token_file: PathBuf,
     },
 
     /// Work with cell specs.
@@ -407,12 +412,14 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             backends_srv,
             mode,
             token_file,
+            client_token_file,
         } => router::serve(
             listen,
             backends.to_vec(),
             backends_srv.as_deref(),
             *mode,
-            token_file.as_deref(),
+            token_file,
+            client_token_file,
         ),
         Cmd::Node(NodeCmd::Probe { probe }) => node::probe(probe, &root),
         Cmd::Node(NodeCmd::Admit { request, probe }) => node::admit_file(request, probe, &root),

--- a/crates/celln-cli/src/router.rs
+++ b/crates/celln-cli/src/router.rs
@@ -1,4 +1,4 @@
-//! Thin stateless router that distributes actions across Celln dispatcher
+//! Authenticated router that distributes actions across Celln dispatcher
 //! backends. Each backend is a Celln process with a `/v1/health` endpoint that
 //! reports KVM availability. The router picks a backend, checks its health,
 //! and forwards if healthy; otherwise it tries the next.
@@ -8,19 +8,45 @@
 //! One accepted request = one warden = one cell — no multiplexing.
 
 use crate::dispatch_http::{
-    read_bounded_line, MAX_HEADER_COUNT, MAX_HEADER_LINE, MAX_REQUEST_LINE,
+    constant_time_eq, read_bounded_line, MAX_HEADER_COUNT, MAX_HEADER_LINE, MAX_REQUEST_LINE,
 };
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream, ToSocketAddrs};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 const ROUTER_TOKEN_BYTES: usize = 24;
+
+// Credentials are bounded and never echoed in errors. Reload on each request
+// to support atomic file/Secret rotation; an unreadable file fails closed.
+fn read_token(path: &Path) -> Result<String> {
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)?
+        .take(4097)
+        .read_to_end(&mut bytes)?;
+    let token = std::str::from_utf8(&bytes)?.trim();
+    if bytes.len() > 4096
+        || token.len() < ROUTER_TOKEN_BYTES
+        || !token.bytes().all(|b| b.is_ascii_graphic())
+    {
+        bail!("invalid router credential");
+    }
+    Ok(token.to_owned())
+}
+
+fn credentials(state: &RouterState) -> Result<(String, String)> {
+    let client = read_token(&state.client_token_file)?;
+    let backend = read_token(&state.token_file)?;
+    if constant_time_eq(client.as_bytes(), backend.as_bytes()) {
+        bail!("client and dispatcher credentials must be distinct");
+    }
+    Ok((client, backend))
+}
 
 /// How the router selects a dispatcher backend for each action.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
@@ -56,7 +82,8 @@ pub fn serve(
     backends: Vec<String>,
     backends_srv: Option<&str>,
     mode: RoutingMode,
-    token_file: Option<&Path>,
+    token_file: &Path,
+    client_token_file: &Path,
 ) -> Result<u8> {
     let mut urls: Vec<String> = backends
         .into_iter()
@@ -87,29 +114,19 @@ pub fn serve(
     if urls.is_empty() {
         bail!("at least one dispatcher backend URL is required (--backends or --backends-srv)");
     }
-    let token = match token_file {
-        Some(path) => {
-            let t = std::fs::read_to_string(path)
-                .with_context(|| format!("reading router token {}", path.display()))?
-                .trim()
-                .to_owned();
-            if t.len() < ROUTER_TOKEN_BYTES {
-                bail!(
-                    "router token must contain at least {ROUTER_TOKEN_BYTES} non-whitespace bytes"
-                );
-            }
-            Some(t)
-        }
-        None => None,
-    };
-    let listener = TcpListener::bind(listen).with_context(|| format!("binding router {listen}"))?;
+    for url in &urls {
+        backend_to_addr(url)?;
+    }
     let state = Arc::new(RouterState {
         backends: urls.clone(),
         mode,
         cursor: AtomicUsize::new(0),
         executions: Mutex::new(HashMap::new()),
-        token,
+        token_file: token_file.to_owned(),
+        client_token_file: client_token_file.to_owned(),
     });
+    credentials(&state).context("router credentials are missing, invalid or not distinct")?;
+    let listener = TcpListener::bind(listen).with_context(|| format!("binding router {listen}"))?;
     eprintln!(
         "celln route listening on {listen} ({} backends, {mode:?})",
         urls.len()
@@ -137,10 +154,13 @@ struct RouterState {
     /// Which backend owns each in-flight `/v1/executions` id, so a later
     /// GET can find it.
     executions: Mutex<HashMap<String, String>>,
-    token: Option<String>,
+    token_file: PathBuf,
+    client_token_file: PathBuf,
 }
 
 fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
+    stream.set_read_timeout(Some(Duration::from_secs(10)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(10)))?;
     let mut reader = BufReader::new(stream.try_clone()?);
     let request_line = read_bounded_line(&mut reader, MAX_REQUEST_LINE)?;
     let Some((method, raw_path)) = request_line.trim_end().split_once(' ') else {
@@ -158,9 +178,14 @@ fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
     let method = method.to_owned();
 
     let mut length = 0usize;
+    let mut seen_length = false;
+    let mut authorization = None;
     let mut header_count = 0usize;
     loop {
         let header = read_bounded_line(&mut reader, MAX_HEADER_LINE)?;
+        if header.is_empty() {
+            bail!("unexpected EOF in headers");
+        }
         let header = header.trim_end();
         if header.is_empty() {
             break;
@@ -169,11 +194,70 @@ fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
         if header_count > MAX_HEADER_COUNT {
             bail!("too many headers (max {MAX_HEADER_COUNT})");
         }
-        if let Some(value) = header.strip_prefix("Content-Length: ") {
-            length = value.parse().context("invalid Content-Length")?;
+        let Some((name, value)) = header.split_once(':') else {
+            return reply(
+                &mut stream,
+                400,
+                &serde_json::json!({"error":"invalid header"}),
+            );
+        };
+        if name.eq_ignore_ascii_case("authorization") {
+            if authorization.is_some() {
+                return reply(
+                    &mut stream,
+                    400,
+                    &serde_json::json!({"error":"duplicate authorization"}),
+                );
+            }
+            authorization = Some(value.trim().to_owned());
+        } else if name.eq_ignore_ascii_case("content-length") {
+            if seen_length || !value.trim().bytes().all(|b| b.is_ascii_digit()) {
+                return reply(
+                    &mut stream,
+                    400,
+                    &serde_json::json!({"error":"invalid content length"}),
+                );
+            }
+            seen_length = true;
+            let Ok(parsed) = value.trim().parse() else {
+                return reply(
+                    &mut stream,
+                    400,
+                    &serde_json::json!({"error":"invalid content length"}),
+                );
+            };
+            length = parsed;
+        } else if name.eq_ignore_ascii_case("transfer-encoding") {
+            return reply(
+                &mut stream,
+                400,
+                &serde_json::json!({"error":"transfer encoding unsupported"}),
+            );
         }
     }
 
+    let Ok((client_token, backend_token)) = credentials(state) else {
+        return reply(
+            &mut stream,
+            503,
+            &serde_json::json!({"error":"router credentials unavailable"}),
+        );
+    };
+    let authorized = authorization
+        .as_deref()
+        .and_then(|value| {
+            let (scheme, token) = value.split_once(' ')?;
+            scheme.eq_ignore_ascii_case("bearer").then_some(token)
+        })
+        .is_some_and(|token| constant_time_eq(token.as_bytes(), client_token.as_bytes()));
+    if !authorized {
+        return reply(
+            &mut stream,
+            401,
+            &serde_json::json!({"error":"unauthorized"}),
+        );
+    }
+    let backend_token = Some(backend_token);
     match (method.as_str(), path.as_str()) {
         ("POST", "/v1/executions") => forward_submission(
             state,
@@ -182,14 +266,21 @@ fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
             length,
             "/v1/executions",
             &state.executions,
+            &backend_token,
         )?,
-        ("GET", path) if path.starts_with("/v1/executions/") => forward_poll(
-            state,
-            &mut stream,
-            path,
-            &state.executions,
-            "unknown execution",
-        )?,
+        ("POST", path) if execution_path_id(path, true).is_some() => {
+            if length != 0 {
+                return reply(
+                    &mut stream,
+                    400,
+                    &serde_json::json!({"error":"cancel body must be empty"}),
+                );
+            }
+            forward_existing(state, &mut stream, "POST", path, true, &backend_token)?;
+        }
+        ("GET", path) if execution_path_id(path, false).is_some() => {
+            forward_existing(state, &mut stream, "GET", path, false, &backend_token)?
+        }
         _ => {
             reply(&mut stream, 404, &serde_json::json!({"error":"not found"}))?;
         }
@@ -208,6 +299,7 @@ fn forward_submission(
     length: usize,
     endpoint: &str,
     tracker: &Mutex<HashMap<String, String>>,
+    token: &Option<String>,
 ) -> Result<()> {
     if length == 0 || length > 64 * 1024 {
         return reply(
@@ -219,10 +311,19 @@ fn forward_submission(
     let mut body = vec![0; length];
     reader.read_exact(&mut body)?;
 
-    let id = extract_id(&body)?;
+    let id = match extract_id(&body) {
+        Ok(id) if valid_path_id(&id) => id,
+        _ => {
+            return reply(
+                stream,
+                400,
+                &serde_json::json!({"error":"id must be a nonempty ASCII alphanumeric, dash, underscore or dot path component"}),
+            )
+        }
+    };
 
-    let backend = pick_backend(state, &id)?;
-    let resp = forward_post(&backend, endpoint, &body, &state.token)?;
+    let backend = pick_backend(state, &id, token)?;
+    let resp = forward_post(&backend, endpoint, &body, token)?;
     let status = parse_status(&resp);
 
     if status == 202 || status == 200 {
@@ -237,32 +338,58 @@ fn forward_submission(
 
 /// `GET <endpoint>/:id`: forward to whichever backend `forward_submission`
 /// recorded as owning that id.
-fn forward_poll(
+fn forward_existing(
     state: &RouterState,
     stream: &mut TcpStream,
+    method: &str,
     path: &str,
-    tracker: &Mutex<HashMap<String, String>>,
-    not_found_message: &str,
+    cancel: bool,
+    token: &Option<String>,
 ) -> Result<()> {
-    let backend = tracker
+    let id = execution_path_id(path, cancel).context("invalid execution path")?;
+    let backend = state
+        .executions
         .lock()
         .expect("router tracking map not poisoned")
-        .get(path.rsplit('/').next().unwrap_or_default())
+        .get(id)
         .cloned();
     match backend {
         Some(backend_url) => {
-            let resp = forward_get(&backend_url, path, &state.token)?;
+            let resp = if method == "POST" {
+                forward_post(&backend_url, path, &[], token)?
+            } else {
+                forward_get(&backend_url, path, token)?
+            };
             raw_reply(stream, &resp)
         }
         None => reply(
             stream,
             404,
-            &serde_json::json!({"error": not_found_message}),
+            &serde_json::json!({"error": "unknown execution"}),
         ),
     }
 }
 
-fn pick_backend(state: &RouterState, action_id: &str) -> Result<String> {
+fn execution_path_id(path: &str, cancel: bool) -> Option<&str> {
+    let suffix = path.strip_prefix("/v1/executions/")?;
+    let id = if cancel {
+        suffix.strip_suffix("/cancel")?
+    } else {
+        suffix.strip_suffix("/audit").unwrap_or(suffix)
+    };
+    valid_path_id(id).then_some(id)
+}
+
+fn valid_path_id(id: &str) -> bool {
+    !id.is_empty()
+        && id != "."
+        && id != ".."
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"-_.".contains(&b))
+}
+
+fn pick_backend(state: &RouterState, action_id: &str, token: &Option<String>) -> Result<String> {
     let n = state.backends.len();
     let start = match state.mode {
         RoutingMode::RoundRobin => (fnv1a(action_id.as_bytes()) as usize) % n,
@@ -279,7 +406,7 @@ fn pick_backend(state: &RouterState, action_id: &str) -> Result<String> {
 
     for offset in 0..n {
         let backend = &state.backends[(start + offset) % n];
-        if is_healthy(backend, &state.token)? {
+        if is_healthy(backend, token)? {
             return Ok(backend.clone());
         }
     }
@@ -337,9 +464,17 @@ fn forward_post(backend: &str, path: &str, body: &[u8], token: &Option<String>) 
 }
 
 fn backend_to_addr(backend: &str) -> Result<String> {
+    // This transport is raw TCP, not TLS. Never silently send a credential in
+    // plaintext when the operator supplied an HTTPS URL.
     let host = backend
-        .trim_start_matches("http://")
-        .trim_start_matches("https://");
+        .strip_prefix("http://")
+        .context("router backend requires http://; native TLS is unsupported")?;
+    if host.is_empty()
+        || host.contains(['/', '@', '?', '#'])
+        || host.chars().any(char::is_whitespace)
+    {
+        bail!("invalid router backend authority");
+    }
     let addr = if host.contains(':') {
         host.to_string()
     } else {
@@ -364,30 +499,15 @@ fn connect(addr: &str) -> Result<TcpStream> {
 }
 
 fn read_response(stream: &mut TcpStream) -> Result<String> {
-    let mut reader = BufReader::new(stream);
-    let mut response = String::new();
-
-    // Status line.
-    let mut line = String::new();
-    reader.read_line(&mut line)?;
-    response.push_str(&line);
-
-    // Headers.
-    loop {
-        let mut header = String::new();
-        reader.read_line(&mut header)?;
-        response.push_str(&header);
-        if header == "\r\n" || header == "\n" {
-            break;
-        }
+    // Dispatchers close each response. Bound the entire wire message, including
+    // headers; a truncated header must not cause an infinite EOF loop.
+    const MAX_RESPONSE: u64 = 16 * 1024 * 1024;
+    let mut bytes = Vec::new();
+    stream.take(MAX_RESPONSE + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_RESPONSE || !bytes.windows(4).any(|w| w == b"\r\n\r\n") {
+        bail!("invalid or oversized dispatcher response");
     }
-
-    // Body: read until connection closes.
-    let mut body = Vec::new();
-    reader.read_to_end(&mut body)?;
-    response.push_str(&String::from_utf8_lossy(&body));
-
-    Ok(response)
+    String::from_utf8(bytes).context("dispatcher response is not UTF-8")
 }
 
 fn parse_status(response: &str) -> u16 {
@@ -485,6 +605,283 @@ mod tests {
     #[test]
     fn backend_to_addr_defaults_to_port_80_without_an_explicit_port() {
         assert_eq!(backend_to_addr("http://node1").unwrap(), "node1:80");
-        assert_eq!(backend_to_addr("https://node1:9000").unwrap(), "node1:9000");
+        assert_eq!(backend_to_addr("http://node1:9000").unwrap(), "node1:9000");
+        assert!(backend_to_addr("https://node1:9000").is_err());
+        assert!(backend_to_addr("http://user:password@node1").is_err());
+    }
+
+    const CLIENT_TOKEN: &str = "client-test-credential-at-least-24";
+    const BACKEND_TOKEN: &str = "backend-test-credential-at-least-24";
+
+    fn state(dir: &Path) -> RouterState {
+        let client_token_file = dir.join("client");
+        let token_file = dir.join("backend");
+        std::fs::write(&client_token_file, CLIENT_TOKEN).unwrap();
+        std::fs::write(&token_file, BACKEND_TOKEN).unwrap();
+        RouterState {
+            backends: vec![],
+            mode: RoutingMode::RoundRobin,
+            cursor: AtomicUsize::new(0),
+            executions: Mutex::new(HashMap::new()),
+            token_file,
+            client_token_file,
+        }
+    }
+
+    // Actual TCP request parsing/forwarding; backend is a protocol fixture,
+    // deliberately not a KVM/isolation proof.
+    fn request(state: &RouterState, method: &str, path: &str, headers: &str, body: &str) -> String {
+        std::thread::scope(|scope| {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+            client
+                .set_read_timeout(Some(Duration::from_secs(3)))
+                .unwrap();
+            let server = scope.spawn(move || handle(listener.accept().unwrap().0, state));
+            write!(client, "{method} {path} HTTP/1.1\r\n{headers}\r\n{body}").unwrap();
+            let mut response = String::new();
+            if let Err(error) = client.read_to_string(&mut response) {
+                // Early refusal may close with unread request bytes. Linux
+                // then resets the connection after delivering the response.
+                assert_eq!(error.kind(), std::io::ErrorKind::ConnectionReset);
+                assert!(!response.is_empty());
+            }
+            server.join().unwrap().unwrap();
+            response
+        })
+    }
+
+    #[test]
+    fn inbound_auth_is_required_on_submission_poll_audit_and_cancel() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state(dir.path());
+        // Empty backend list would panic on submission if authorization were
+        // bypassed. No backend can be contacted by these requests.
+        for (method, path) in [
+            ("POST", "/v1/executions"),
+            ("GET", "/v1/executions/x"),
+            ("GET", "/v1/executions/x/audit"),
+            ("POST", "/v1/executions/x/cancel"),
+        ] {
+            for header in [
+                String::new(),
+                "Authorization: Bearer wrong\r\n".into(),
+                format!("Authorization: Bearer {BACKEND_TOKEN}\r\n"),
+            ] {
+                assert_eq!(
+                    parse_status(&request(&state, method, path, &header, "")),
+                    401
+                );
+            }
+        }
+        let header = format!("authorization: bEaReR {CLIENT_TOKEN}\r\n");
+        assert_eq!(
+            parse_status(&request(&state, "GET", "/v1/executions/x", &header, "")),
+            404
+        );
+    }
+
+    #[test]
+    fn credential_rotation_and_bad_files_fail_closed_without_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state(dir.path());
+        let old = format!("Authorization: Bearer {CLIENT_TOKEN}\r\n");
+        let new_token = "rotated-client-credential-at-least-24";
+        std::fs::write(&state.client_token_file, new_token).unwrap();
+        assert_eq!(
+            parse_status(&request(&state, "GET", "/v1/executions/x", &old, "")),
+            401
+        );
+        let new = format!("Authorization: Bearer {new_token}\r\n");
+        assert_eq!(
+            parse_status(&request(&state, "GET", "/v1/executions/x", &new, "")),
+            404
+        );
+        for invalid in [
+            "short",
+            "credential contains whitespace and is long",
+            BACKEND_TOKEN,
+        ] {
+            std::fs::write(&state.client_token_file, invalid).unwrap();
+            assert_eq!(
+                parse_status(&request(&state, "GET", "/v1/executions/x", &new, "")),
+                503
+            );
+        }
+        std::fs::remove_file(&state.client_token_file).unwrap();
+        assert!(credentials(&state).is_err());
+        assert_eq!(
+            parse_status(&request(&state, "GET", "/v1/executions/x", &old, "")),
+            503
+        );
+    }
+
+    #[test]
+    fn ambiguous_headers_and_cancel_bodies_are_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state(dir.path());
+        let auth = format!("Authorization: Bearer {CLIENT_TOKEN}\r\n");
+        for extra in [
+            auth.clone(),
+            "Content-Length: 0\r\ncontent-length: 0\r\n".into(),
+            "Transfer-Encoding: chunked\r\n".into(),
+            "Content-Length: -1\r\n".into(),
+        ] {
+            assert_eq!(
+                parse_status(&request(
+                    &state,
+                    "POST",
+                    "/v1/executions/x/cancel",
+                    &(auth.clone() + &extra),
+                    ""
+                )),
+                400
+            );
+        }
+        assert_eq!(
+            parse_status(&request(
+                &state,
+                "POST",
+                "/v1/executions/x/cancel",
+                &(auth + "Content-Length: 1\r\n"),
+                "x"
+            )),
+            400
+        );
+    }
+
+    #[test]
+    fn unaddressable_ids_refuse_before_submission() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state(dir.path());
+        for id in ["", ".", "..", "a/b", "a?b", "a b", "a%2fb"] {
+            let body = serde_json::json!({"id":id}).to_string();
+            let headers = format!(
+                "Authorization: Bearer {CLIENT_TOKEN}\r\nContent-Length: {}\r\n",
+                body.len()
+            );
+            assert_eq!(
+                parse_status(&request(&state, "POST", "/v1/executions", &headers, &body)),
+                400
+            );
+        }
+    }
+
+    #[test]
+    fn submission_poll_audit_and_cancel_use_only_rotatable_backend_credential() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = state(dir.path());
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        state
+            .backends
+            .push(format!("http://{}", listener.local_addr().unwrap()));
+        let server = std::thread::spawn(move || {
+            for (method, path, status, payload, token) in [
+                (
+                    "GET",
+                    "/v1/health",
+                    200,
+                    r#"{"ok":true,"kvm":true}"#,
+                    BACKEND_TOKEN,
+                ),
+                (
+                    "POST",
+                    "/v1/executions",
+                    202,
+                    r#"{"requestId":"x","phase":"Running"}"#,
+                    BACKEND_TOKEN,
+                ),
+                (
+                    "GET",
+                    "/v1/executions/x",
+                    200,
+                    r#"{"requestId":"x","phase":"Running"}"#,
+                    BACKEND_TOKEN,
+                ),
+                (
+                    "GET",
+                    "/v1/executions/x/audit",
+                    200,
+                    r#"{"requestId":"x"}"#,
+                    BACKEND_TOKEN,
+                ),
+                (
+                    "POST",
+                    "/v1/executions/x/cancel",
+                    202,
+                    r#"{"requestId":"x","phase":"Cancelling"}"#,
+                    "rotated-backend-credential-at-least-24",
+                ),
+                (
+                    "POST",
+                    "/v1/executions/x/cancel",
+                    200,
+                    r#"{"requestId":"x","phase":"Cancelled"}"#,
+                    "rotated-backend-credential-at-least-24",
+                ),
+            ] {
+                let (mut stream, _) = listener.accept().unwrap();
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(3)))
+                    .unwrap();
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                assert_eq!(
+                    read_bounded_line(&mut reader, MAX_REQUEST_LINE).unwrap(),
+                    format!("{method} {path} HTTP/1.1\r\n")
+                );
+                let mut headers = String::new();
+                let mut length = 0;
+                loop {
+                    let header = read_bounded_line(&mut reader, MAX_HEADER_LINE).unwrap();
+                    if header == "\r\n" {
+                        break;
+                    }
+                    if let Some(value) = header.strip_prefix("Content-Length: ") {
+                        length = value.trim().parse().unwrap();
+                    }
+                    headers.push_str(&header);
+                }
+                assert!(headers.contains(&format!("Authorization: Bearer {token}\r\n")));
+                assert!(!headers.contains(CLIENT_TOKEN));
+                let mut body = vec![0; length];
+                reader.read_exact(&mut body).unwrap();
+                if path.ends_with("/cancel") {
+                    assert!(body.is_empty());
+                }
+                write!(stream, "HTTP/1.1 {status} OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}", payload.len()).unwrap();
+            }
+        });
+        let auth = format!("Authorization: Bearer {CLIENT_TOKEN}\r\n");
+        let body = r#"{"id":"x"}"#;
+        assert_eq!(
+            parse_status(&request(
+                &state,
+                "POST",
+                "/v1/executions",
+                &format!("{auth}Content-Length: {}\r\n", body.len()),
+                body
+            )),
+            202
+        );
+        for path in ["/v1/executions/x", "/v1/executions/x/audit"] {
+            assert_eq!(parse_status(&request(&state, "GET", path, &auth, "")), 200);
+        }
+        std::fs::write(&state.token_file, "rotated-backend-credential-at-least-24").unwrap();
+        for (status, phase) in [(202, "Cancelling"), (200, "Cancelled")] {
+            let response = request(&state, "POST", "/v1/executions/x/cancel", &auth, "");
+            assert_eq!(parse_status(&response), status);
+            assert!(response.contains(phase));
+        }
+        assert_eq!(
+            parse_status(&request(
+                &state,
+                "POST",
+                "/v1/executions/absent/cancel",
+                &auth,
+                ""
+            )),
+            404
+        );
+        server.join().unwrap();
     }
 }

--- a/docs/ROUTER_SECURITY.md
+++ b/docs/ROUTER_SECURITY.md
@@ -1,0 +1,63 @@
+# Router boundary — M0 first increment
+
+The router now requires two distinct credentials:
+
+```sh
+celln route --listen 127.0.0.1:8788 \
+  --backends http://127.0.0.1:8787 \
+  --token-file /etc/celln/dispatcher-token/token \
+  --client-token-file /etc/celln/router-client-token/token
+```
+
+`--client-token-file` authenticates callers, including polling, audit and
+cancellation. `--token-file` is used only for router-to-dispatcher requests.
+The controller must hold the client credential, not the dispatcher credential.
+Neither is a model provider credential. Provision them through the operator's
+secret manager: each must contain 24 or more printable non-whitespace ASCII
+bytes, with at most 4096 file bytes. A trailing newline is allowed. Restrict file
+access to the service identity; never put secrets in argv, task text or logs.
+
+Both files are reread per request. Rotate through atomic file replacement (or
+a projected Secret directory, not a Kubernetes `subPath` mount). New requests
+use the new values; already authorized in-flight requests may finish. An invalid,
+missing or equal pair refuses startup or returns 503 after rotation. Old client
+tokens return 401. Dispatcher credential rotation must also be coordinated with
+the dispatcher, which currently loads its credential at startup.
+
+This is an intentional fail-closed CLI compatibility change. Old commands with
+only `--token-file` must be updated before rollout. Do not install this binary
+under an old chart and expect the existing router command to start. Pin and
+coordinate a tested binary/chart release; never disable authentication as an
+upgrade workaround.
+
+There is no native TLS on either router hop. Keep raw listeners/backends on
+trusted local links and expose remote access only through authenticated,
+TLS-terminating infrastructure. HTTPS backend URLs now refuse instead of
+silently sending bearer credentials over raw TCP. Cross-node encrypted backend
+transport remains M0 work; an HTTP node URL is not encryption.
+
+Authenticated `POST /v1/executions/:id/cancel` now forwards an empty body to the
+tracked dispatcher. Its status and record are returned unchanged: 202 is only
+acknowledgement, not teardown. The router also forwards the correlated audit
+endpoint using the execution ID rather than looking up the literal `audit`.
+Router execution IDs must be nonempty ASCII alphanumeric/dash/underscore/dot
+path components, excluding `.` and `..`; unaddressable IDs refuse before
+submission. This includes the UID-derived IDs emitted by Sympozium.
+
+## Proof and remaining limitations
+
+`cargo test -p celln-cli router::tests` exercises the real TCP parser and
+forwarder with a protocol fixture: missing/wrong/backend credentials at every
+execution endpoint, case-insensitive header names, duplicate/framing rejection,
+client and backend rotation, admission, polling, audit, cancellation and terminal
+status preservation. These are not KVM or production deployment tests.
+
+This increment does **not** solve in-memory ownership loss across router
+replicas/restarts, unhealthy-backend retry duplication, unbounded execution
+tracking, dispatcher registry loss, TLS deployment, or authenticated capability
+reporting. Do not treat it as multi-node readiness or M0 completion. The next
+ownership design must handle ambiguous submission without rerunning side effects;
+simply hashing against a changing healthy-node list is insufficient.
+
+Tracked by [Sympozium M0](https://github.com/sympozium-ai/sympozium/issues/426)
+and [the router boundary issue](https://github.com/sympozium-ai/sympozium/issues/331).


### PR DESCRIPTION
## M0 first increment

Part of https://github.com/sympozium-ai/sympozium/issues/426 and https://github.com/sympozium-ai/sympozium/issues/331. Does not close either issue.

- Require distinct inbound `--client-token-file` and outbound `--token-file`; reload both per request and fail closed on missing/invalid/equal credentials.
- Authenticate submission, poll, audit and cancellation before backend access; handle case-insensitive headers and reject ambiguous framing.
- Forward cancellation using the execution owner and preserve 202 versus terminal status; fix audit lookup by execution ID.
- Refuse HTTPS backend URLs rather than silently sending credentials over raw TCP; bound responses and avoid the truncated-header EOF loop.
- Document rotation, intentional CLI compatibility change and remaining ownership/deployment limitations.

## Validation

- 12 router tests pass, including real TCP parsing/forwarding against a protocol fixture. This is not a hardware isolation proof.
- `make ci` passed in the initial run. A repeat encountered `ExecutableFileBusy` / `Text file busy` in the unchanged `celln-pilot` executable-FD test; immediate targeted rerun passed. Final full rerun is recorded in a follow-up comment.

## Rollout / remaining M0

This PR is draft pending coordinated chart/credential/version/TLS rollout. The old chart command lacks the now-required client credential flag; do not independently replace its host binary. No migration to unauthenticated operation is provided.

In-memory execution ownership, replica/restart recovery, retry duplication, bounded registry retention, authenticated capability reporting and the deployed two-node proof remain open M0 work. There is no new fleet-readiness claim and no production cluster was modified.
