### PR TITLE
feat(harness): document requirements and prove in-cell model POST (prototype)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,8 @@ dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
 ]

--- a/crates/celln-pilot/src/fetch.rs
+++ b/crates/celln-pilot/src/fetch.rs
@@ -3,7 +3,7 @@
 //! It has no sockets and does no DNS. It sends an HTTPS URL over three private
 //! I/O ports; `warden` owns validation, DNS pinning, TLS and the request.
 
-use std::io::Write;
+use std::io::{Read, Write};
 use std::os::unix::process::ExitStatusExt;
 use std::process::Command;
 
@@ -93,8 +93,8 @@ fn prove_ioperm_scope() -> std::io::Result<()> {
 }
 
 fn main() {
-    let Some(url) = std::env::args().nth(1) else {
-        eprintln!("usage: pilot-fetch https://allowed.example/path");
+    let Some(mut url) = std::env::args().nth(1) else {
+        eprintln!("usage: pilot-fetch https://allowed.example/path | --json-stdin");
         std::process::exit(2);
     };
     if url == DENIAL_PROBE {
@@ -107,6 +107,18 @@ fn main() {
             std::process::exit(1);
         }
         return;
+    }
+    if url == "--json-stdin" {
+        url.clear();
+        if std::io::stdin()
+            .take(8193)
+            .read_to_string(&mut url)
+            .is_err()
+            || !url.starts_with('{')
+        {
+            eprintln!("pilot-fetch: invalid JSON request");
+            std::process::exit(2);
+        }
     }
     if url.len() > 8192 || url.contains('\0') {
         eprintln!("pilot-fetch: invalid URL request");

--- a/crates/celln-pilot/src/fetch_proof.rs
+++ b/crates/celln-pilot/src/fetch_proof.rs
@@ -12,7 +12,7 @@ use anyhow::{bail, Context, Result};
 use celln_manifest::{Author, Entry, Hash, Manifest, Tier};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use warden::egress::HttpPolicy;
+use warden::egress::{HttpPolicy, JsonPostGrant};
 use warden::vmm::boot::{BootConfig, LinuxCell};
 
 fn main() -> Result<()> {
@@ -20,6 +20,16 @@ fn main() -> Result<()> {
         .nth(1)
         .unwrap_or_else(|| "https://example.com/".into());
     let host = host_of(&url)?;
+    let model_token_file = std::env::var_os("CELLN_MODEL_TOKEN_FILE").map(PathBuf::from);
+    let request = if model_token_file.is_some() {
+        serde_json::json!({
+            "apiVersion":"celln.fetch/v1", "method":"POST", "url":url,
+            "body": {"model":"deepseek-chat", "max_tokens":64, "stream":false,
+                "messages":[{"role":"user","content":"Reply with exactly CELLN_MODEL_PROOF_OK and no other text."}]}
+        }).to_string()
+    } else {
+        url.clone()
+    };
     let root = repo_root()?;
     let work = std::env::temp_dir().join(format!("celln-fetch-proof-{}", std::process::id()));
     std::fs::create_dir_all(&work)?;
@@ -63,7 +73,7 @@ fn main() -> Result<()> {
     std::fs::write(
         &run_path,
         serde_json::to_vec(&serde_json::json!({
-            "path": "/tools/program", "alias": "/probe", "args": [url],
+            "path": "/tools/program", "alias": "/probe", "args": [request, if model_token_file.is_some() { "model" } else { "get" }],
             "agent_authored_input": true,
             "allow_fetch": true,
         }))?,
@@ -96,7 +106,16 @@ fn main() -> Result<()> {
             .with_pmem(payload.len())
             .with_initrd(initrd),
     )?;
-    cell.enable_http_fetch(HttpPolicy::new(vec![host]));
+    let mut policy = HttpPolicy::new(vec![host]);
+    if let Some(bearer_token_file) = model_token_file {
+        policy.json_posts.push(JsonPostGrant {
+            url,
+            bearer_token_file,
+        });
+        policy.timeout = std::time::Duration::from_secs(45);
+        cell.set_timeout(std::time::Duration::from_secs(90));
+    }
+    cell.enable_http_fetch(policy);
     cell.seal_tool(&Hash::of(&payload), &payload)?;
     let report = cell.run()?;
     if !report
@@ -124,6 +143,14 @@ fn main() -> Result<()> {
     println!(
         "PASS: a real cell used only broker ports 0x500-0x502 and fetched HTTPS through pilot"
     );
+    for line in report
+        .console
+        .lines()
+        .filter(|line| line.contains("CELLN_MODEL_RESPONSE"))
+    {
+        println!("{line}");
+    }
+    println!("host-observed fetch counters: {:?}", cell.fetch_activity());
     Ok(())
 }
 

--- a/crates/celln-pilot/tests/fixtures/fetch_probe.rs
+++ b/crates/celln-pilot/tests/fixtures/fetch_probe.rs
@@ -3,7 +3,8 @@
 //! It has no network code. Its only possible path to a response is invoking
 //! `/pilot-fetch`, which exercises the guest→warden broker ABI.
 
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::io::Write;
 
 unsafe extern "C" {
     fn syscall(number: isize, ...) -> isize;
@@ -70,15 +71,25 @@ fn main() {
     let url = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "https://example.com/".into());
-    let result = Command::new("/pilot-fetch")
-        .arg(url)
-        .output()
-        .expect("pilot-fetch must exist in the initramfs");
+    let result = if url.starts_with('{') {
+        let mut child = Command::new("/pilot-fetch").arg("--json-stdin")
+            .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped())
+            .spawn().expect("pilot-fetch must exist");
+        child.stdin.take().unwrap().write_all(url.as_bytes()).unwrap();
+        child.wait_with_output().unwrap()
+    } else {
+        Command::new("/pilot-fetch").arg(url).output().expect("pilot-fetch must exist in the initramfs")
+    };
     assert!(
         result.status.success(),
         "pilot-fetch failed: {}",
         String::from_utf8_lossy(&result.stderr)
     );
     assert!(!result.stdout.is_empty(), "broker returned an empty response");
+    if std::env::args().nth(2).as_deref() == Some("model") {
+        let response = String::from_utf8(result.stdout.clone()).unwrap();
+        assert!(response.contains("choices") && response.contains("CELLN_MODEL_PROOF_OK"), "model completion did not meet proof assertion");
+        println!("CELLN_MODEL_RESPONSE {}", response.trim());
+    }
     println!("CELLN_FETCH_OK bytes={}", result.stdout.len());
 }

--- a/crates/celln-warden/Cargo.toml
+++ b/crates/celln-warden/Cargo.toml
@@ -23,6 +23,8 @@ tempfile.workspace = true
 celln-control.workspace = true
 celln-manifest.workspace = true
 thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 kvm-ioctls = { workspace = true, optional = true }
 kvm-bindings = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }

--- a/crates/celln-warden/src/egress.rs
+++ b/crates/celln-warden/src/egress.rs
@@ -7,6 +7,10 @@ use std::net::{IpAddr, ToSocketAddrs};
 use std::process::Command;
 use std::time::Duration;
 
+#[path = "egress_post.rs"]
+mod post;
+pub use post::JsonPostGrant;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HttpPolicy {
     /// Exact DNS names this cell may contact. Empty means no egress.
@@ -14,6 +18,9 @@ pub struct HttpPolicy {
     pub max_requests: usize,
     pub max_response_bytes: usize,
     pub timeout: Duration,
+    /// Additional operator-owned authority. A GET host grant never implies
+    /// POST or access to provider credentials.
+    pub json_posts: Vec<JsonPostGrant>,
 }
 
 impl HttpPolicy {
@@ -23,6 +30,7 @@ impl HttpPolicy {
             max_requests: 32,
             max_response_bytes: 1 << 20,
             timeout: Duration::from_secs(10),
+            json_posts: Vec::new(),
         }
     }
 }
@@ -119,6 +127,14 @@ impl HttpBroker {
     /// followed one hop at a time so every destination is independently
     /// authorised; `curl --location` would bypass the allowlist on hop two.
     pub fn fetch(&mut self, raw: &str) -> Result<Vec<u8>, FetchDenied> {
+        if raw.len() > 8192 {
+            return Err(FetchDenied::Fetch(
+                "request exceeds broker wire budget".into(),
+            ));
+        }
+        if raw.starts_with('{') {
+            return self.post_json(raw);
+        }
         let mut url = raw.to_owned();
         for _ in 0..=5 {
             if self.used >= self.policy.max_requests {

--- a/crates/celln-warden/src/egress_post.rs
+++ b/crates/celln-warden/src/egress_post.rs
@@ -1,0 +1,223 @@
+//! Explicit, endpoint-scoped JSON POST authority for an in-cell model client.
+//! The wire contains no headers, credential reference, redirects or proxy
+//! options. Only the host chooses a credential and the permitted endpoint.
+
+use super::{response_status_and_location, FetchDenied, HttpBroker};
+use serde::Deserialize;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::process::Command;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct JsonPostGrant {
+    pub url: String,
+    /// Operator-controlled file, read per request. Never delivered to guest.
+    pub bearer_token_file: PathBuf,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Request {
+    api_version: String,
+    method: String,
+    url: String,
+    body: serde_json::Value,
+}
+
+fn refused(reason: &str) -> FetchDenied {
+    FetchDenied::Fetch(reason.into())
+}
+
+fn parse(raw: &str) -> Result<Request, FetchDenied> {
+    if raw.len() > 8192 {
+        return Err(refused("request exceeds broker wire budget"));
+    }
+    let request: Request =
+        serde_json::from_str(raw).map_err(|_| refused("invalid JSON request"))?;
+    if request.api_version != "celln.fetch/v1" || request.method != "POST" {
+        return Err(refused("unsupported broker request version or method"));
+    }
+    if !request.body.is_object() {
+        return Err(refused("POST body must be a JSON object"));
+    }
+    Ok(request)
+}
+
+fn credential_header(path: &std::path::Path) -> Result<tempfile::NamedTempFile, FetchDenied> {
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)
+        .and_then(|file| file.take(4097).read_to_end(&mut bytes))
+        .map_err(|_| refused("provider credential unavailable"))?;
+    let token = std::str::from_utf8(&bytes)
+        .map_err(|_| refused("invalid provider credential"))?
+        .trim();
+    if bytes.len() > 4096 || token.len() < 24 || !token.bytes().all(|b| b.is_ascii_graphic()) {
+        return Err(refused("invalid provider credential"));
+    }
+    // tempfile creates mode 0600. curl reads this file, never a token in argv.
+    let mut header =
+        tempfile::NamedTempFile::new().map_err(|_| refused("credential staging failed"))?;
+    writeln!(header, "Authorization: Bearer {token}")
+        .map_err(|_| refused("credential staging failed"))?;
+    Ok(header)
+}
+
+impl HttpBroker {
+    fn grant_for(&self, request: &Request) -> Result<&JsonPostGrant, FetchDenied> {
+        self.policy
+            .json_posts
+            .iter()
+            .find(|grant| grant.url == request.url)
+            .ok_or_else(|| refused("JSON POST endpoint not granted"))
+    }
+
+    pub(super) fn post_json(&mut self, raw: &str) -> Result<Vec<u8>, FetchDenied> {
+        let request = parse(raw)?;
+        let grant = self.grant_for(&request)?.clone();
+        if self.used >= self.policy.max_requests {
+            return Err(FetchDenied::Budget);
+        }
+        let (host, ip) = self.authorize(&request.url)?;
+        self.used += 1;
+        let credential = credential_header(&grant.bearer_token_file)?;
+        let mut body =
+            tempfile::NamedTempFile::new().map_err(|_| refused("request staging failed"))?;
+        serde_json::to_writer(&mut body, &request.body)
+            .map_err(|_| refused("request staging failed"))?;
+        let response_headers =
+            tempfile::NamedTempFile::new().map_err(|_| refused("response staging failed"))?;
+        let mut command = Command::new("curl");
+        command
+            .args([
+                "--disable",
+                "--silent",
+                "--show-error",
+                "--globoff",
+                "--noproxy",
+                "*",
+                "--proto",
+                "=https",
+                "--max-redirs",
+                "0",
+                "--request",
+                "POST",
+                "--header",
+                "Content-Type: application/json",
+            ])
+            .arg("--header")
+            .arg(format!("@{}", credential.path().display()))
+            .arg("--data-binary")
+            .arg(format!("@{}", body.path().display()))
+            .arg("--max-time")
+            .arg(self.policy.timeout.as_secs().max(1).to_string())
+            .arg("--max-filesize")
+            .arg(self.policy.max_response_bytes.to_string())
+            .arg("--resolve")
+            .arg(format!("{host}:443:{ip}"))
+            .arg("--dump-header")
+            .arg(response_headers.path())
+            .arg("--url")
+            .arg(&request.url);
+        let out =
+            celln_control::process::output_with_timeout(&mut command, Some(self.policy.timeout))
+                .map_err(|_| refused("HTTPS POST interrupted or unavailable"))?;
+        if !out.status.success() {
+            return Err(refused("HTTPS POST failed"));
+        }
+        if out.stdout.len() > self.policy.max_response_bytes {
+            return Err(refused("response exceeded byte budget"));
+        }
+        let headers = std::fs::read_to_string(response_headers.path())
+            .map_err(|_| refused("invalid response headers"))?;
+        let (status, _) = response_status_and_location(&headers)
+            .ok_or_else(|| refused("missing HTTP response headers"))?;
+        // No redirect/retry for credential-bearing, potentially billed requests.
+        if !(200..300).contains(&status) {
+            return Err(refused(&format!("HTTP {status}; POST not replayed")));
+        }
+        Ok(out.stdout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::egress::HttpPolicy;
+
+    fn wire() -> String {
+        serde_json::json!({"apiVersion":"celln.fetch/v1","method":"POST","url":"https://example.com/model","body":{"messages":[]}}).to_string()
+    }
+
+    #[test]
+    fn get_authority_does_not_imply_post_or_credentials() {
+        let mut broker = HttpBroker::new(HttpPolicy::new(vec!["example.com".into()]));
+        assert_eq!(
+            broker.fetch(&wire()).unwrap_err(),
+            refused("JSON POST endpoint not granted")
+        );
+        assert_eq!(broker.used(), 0);
+    }
+
+    #[test]
+    fn endpoints_are_exact_and_untrusted_headers_are_rejected() {
+        let mut policy = HttpPolicy::new(vec!["example.com".into()]);
+        policy.json_posts.push(JsonPostGrant {
+            url: "https://example.com/model".into(),
+            bearer_token_file: "/not-read".into(),
+        });
+        let broker = HttpBroker::new(policy);
+        assert!(broker.grant_for(&parse(&wire()).unwrap()).is_ok());
+        for url in [
+            "https://example.com/other",
+            "https://example.com/model?extra=1",
+            "https://evil.example/model",
+        ] {
+            let mut req = parse(&wire()).unwrap();
+            req.url = url.into();
+            assert!(broker.grant_for(&req).is_err());
+        }
+        for field in ["headers", "credential", "proxy"] {
+            let mut req: serde_json::Value = serde_json::from_str(&wire()).unwrap();
+            req[field] = "untrusted".into();
+            assert!(parse(&req.to_string()).is_err());
+        }
+    }
+
+    #[test]
+    fn protocol_is_versioned_bounded_and_object_only() {
+        for (field, value) in [
+            ("apiVersion", "other"),
+            ("method", "PUT"),
+            ("body", "not an object"),
+        ] {
+            let mut req: serde_json::Value = serde_json::from_str(&wire()).unwrap();
+            req[field] = value.into();
+            assert!(parse(&req.to_string()).is_err());
+        }
+        assert!(parse(&"x".repeat(8193)).is_err());
+    }
+
+    #[test]
+    fn credentials_reload_refuse_injection_and_never_appear_in_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("token");
+        for token in [
+            "first-test-token-at-least-24",
+            "rotated-test-token-at-least-24",
+        ] {
+            std::fs::write(&file, token).unwrap();
+            let header = credential_header(&file).unwrap();
+            assert_eq!(
+                std::fs::read_to_string(header.path()).unwrap(),
+                format!("Authorization: Bearer {token}\n")
+            );
+        }
+        for token in ["short", "secret-with-injected\r\nX-Header: bad"] {
+            std::fs::write(&file, token).unwrap();
+            assert_eq!(
+                credential_header(&file).unwrap_err(),
+                refused("invalid provider credential")
+            );
+        }
+    }
+}

--- a/crates/celln-warden/src/vmm/boot.rs
+++ b/crates/celln-warden/src/vmm/boot.rs
@@ -1489,9 +1489,12 @@ impl LinuxCell {
                             } else if port == PILOT_FETCH_TX {
                                 // Bounded before allocation: a malicious cell
                                 // cannot make the host buffer an unbounded URL.
-                                if self.fetch_request.len() < 8192 {
-                                    self.fetch_request.extend_from_slice(data);
-                                }
+                                // Retain one overflow byte so a truncated,
+                                // valid JSON prefix cannot execute as a request.
+                                let take = 8193usize
+                                    .saturating_sub(self.fetch_request.len())
+                                    .min(data.len());
+                                self.fetch_request.extend_from_slice(&data[..take]);
                             } else if port == PILOT_FETCH_CALL {
                                 self.dispatch_fetch();
                             } else if port == PCI_CONFIG_ADDR && data.len() == 4 {

--- a/docs/HARNESS_EXECUTION_REQUIREMENTS.md
+++ b/docs/HARNESS_EXECUTION_REQUIREMENTS.md
@@ -1,0 +1,190 @@
+# Agent Harness execution in Celln — requirements and proof contract
+
+Status: implementation requirements, not a declaration of delivered capability.
+Recorded 2026-09-07. Product tracking: [Sympozium epic #426](https://github.com/sympozium-ai/sympozium/issues/426).
+
+## User outcome
+
+A user chooses an approved Agent Harness, opts into Celln execution and lends
+an explicit set of approved tools, including tools they have brought for
+admission. The Harness runs a real model-driven agent loop, invokes those
+tools, and returns useful results with attributable execution evidence.
+
+The user must not need to understand mote packaging, PIO or the VMM to use the
+feature. Administrators must still be able to inspect what code and authority
+were admitted and revoke access. A **mote** is the substrate at rest; a **cell**
+is a live, sealed, tool-loaned mote. Every cell is a sealed mote.
+
+## Two distinct capabilities
+
+| Mode | Where the agent loop runs | What Celln isolates | Completion claim |
+|---|---|---|---|
+| Celln tool execution | Existing Job/HarnessSession adapter | Individual borrowed-tool invocations | Intermediate integration proof only |
+| Harness in Celln | Approved sealed runtime inside a cell | The Harness runtime and its explicitly lent execution authority | Required target experience |
+
+Do not describe a host-side model loop calling cells as an in-cell Harness.
+Do not relabel built-in functions compiled into a reference program as user-
+borrowed tools. Do not remove the current Harness/backend refusal until the
+requested runtime and authority are actually delivered.
+
+## Current baseline and gaps
+
+Baseline inspected: Celln `4b95a1c`, Sympozium `88a432c`, plus draft M0 router
+changes in [Celln #70](https://github.com/sympozium-ai/celln/pull/70) and ingress
+policy in [Sympozium #427](https://github.com/sympozium-ai/sympozium/pull/427).
+
+- Direct typed AgentRun execution and a signed dynamic closure have committed
+  hardware evidence: [trusted closure acceptance](TRUSTED_CLOSURES_ACCEPTANCE.md).
+- The real DeepSeek acceptance run exercised native forge/build/execute, not a
+  Harness agent loop or a Sympozium model-routed run.
+- The existing guest HTTPS broker accepts GET URLs only. Model completion APIs
+  require a bounded request body and POST. A host allowlist alone must not
+  implicitly grant POST or provider credential use.
+- The dispatcher delivers one invoked tool / one signed precomposed closure.
+  Multiple requested tools refuse. Closure requests with forge, immutable
+  inputs or egress also refuse. These guards need delivery proofs before removal.
+- AgentRuntime is presently an approved OCI primary-container profile;
+  HarnessSession uses a Deployment/Service. Neither is a sealed Celln runtime
+  contract. An OCI digest is not automatically a trusted closure or proof that
+  its runtime can function without ordinary networking/filesystem authority.
+- The local Pi adapter at version 0.84.4 explicitly disables tools and does not
+  implement MCP. Selecting it does not establish borrowed-tool support.
+- A three-node Kind cluster with two workers has demonstrated cross-worker
+  enforcement of the chart ingress policy and KVM VM creation from privileged
+  pods. This is environment qualification, not guest execution, independent
+  physical-host failure tolerance or the deployed Harness proof.
+
+## Required execution contracts
+
+### R1 — Runtime identity and placement
+
+Runtime identity, execution placement and tool selection must be separate
+concepts in the API and UX. Bind an administrator-approved, immutable runtime
+artifact to a versioned adapter contract. Resolve and freeze identities before
+dispatch; a runtime change must not silently change a retry.
+
+For full Celln mode, package all executable dependencies and necessary runtime
+data into an authenticated closure. Define how task/persona/configuration and
+results cross the boundary. Do not assume the container adapter's writable
+HOME, PVC, loopback MCP server, sockets or environment exist in the guest.
+
+Persistent conversation support needs an explicit design: state outside
+disposable cells, or a bounded persistent execution model. Define reconnect,
+turn cancellation, resume and teardown. An indefinitely extended one-shot run
+is not a persistence implementation. Coordinate with [Celln #9](https://github.com/sympozium-ai/celln/issues/9).
+
+### R2 — Model and remote-service mediation
+
+- The in-cell Harness must request model work through a bounded, host-enforced
+  broker. It must not receive an ordinary network stack or unrestricted socket
+  authority merely to make an SDK work.
+- Preserve the existing GET ABI. Version extensions explicitly; reject unknown
+  methods, fields and versions. Keep request/response bytes, call count, model
+  output, execution time and cancellation bounded.
+- A POST grant must identify an exact allowed endpoint separately from a GET
+  host grant. The host selects a credential bound to that endpoint. The guest
+  cannot supply arbitrary headers, credential files, proxy configuration or
+  alternate destinations that broaden authority.
+- Provider, model and permitted model parameters must reflect the selected
+  Sympozium configuration. Endpoint restriction alone does not enforce model
+  choice or token/cost budget: validate those independently before product use.
+- DNS pinning, public-address/SSRF checks and TLS verification remain mandatory.
+  Do not expose private-cluster MCP by weakening the public HTTPS checks;
+  platform services need a separately defined authenticated mediation path.
+- No implicit redirect or retry for credential-bearing POSTs. Define ambiguous
+  response handling so a transport error cannot cause duplicated side effects
+  or unbounded billing.
+- Provider keys stay outside the guest, invocation, immutable artifact, argv,
+  logs and evidence. Rotation must be defined, failures must refuse, and
+  revocation semantics must distinguish future calls from already in-flight
+  work. Local file reload is not fleet-wide live withdrawal.
+
+Related: [secret providers #7](https://github.com/sympozium-ai/celln/issues/7),
+[fleet revocation #8](https://github.com/sympozium-ai/celln/issues/8).
+
+### R3 — Borrowed tools
+
+Each tool binding requires an immutable artifact/closure identity, publisher,
+entry point, argument/result schema, supported lane and bounded resources,
+inputs, workspace and egress. Keep packaging, publisher approval, admission,
+distribution, prewarming and lending distinct lifecycle steps.
+
+Users may submit a tool for approval; they may not self-approve its publisher
+or elevate its authority. Effective authority is the intersection of operator
+policy, approved runtime/tool capability, Agent grants and per-run selections.
+Tool discovery and invocation must both enforce that intersection; an invented
+tool name or model-supplied capability claim must refuse.
+
+Lending is not installation into a writable guest filesystem. Code remains
+sealed; executable authority is content-hash based. Interpreters and agent-
+authored code must preserve lane classification. A signature authenticates an
+artifact's origin; it does not make arbitrary behavior safe.
+
+Distinguish executable tools, remote MCP services and privileged SkillPacks.
+Do not move Kubernetes service-account credentials or the entire sidecar/IPC
+surface into a cell as a compatibility shortcut.
+
+### R4 — Lifecycle, provenance and operations
+
+Correlate AgentRun/HarnessSession, model turn, tool call, resolved runtime and
+tool identities, policy decision, node, Celln execution and terminal receipt.
+Closure publisher/member provenance currently belongs to the correlated audit,
+not receipt v1alpha1; do not claim otherwise.
+
+Cancellation must reach the owning execution and wait for teardown. Submission
+retries, router restarts/replicas and node loss need stable ownership and
+explicit ambiguous-outcome handling. Health-based redistribution is not safe
+retry semantics. Bound registry retention without losing live ownership.
+
+Integrate applicable lifecycle gates, metering, events, memory and delegation
+through mediated control-plane services; explicitly reject unsupported options
+rather than ignoring them. Reuse common completion accounting where possible.
+
+Capability reporting must distinguish reachability, authentication, runtime
+compatibility, hardware eligibility, admitted artifacts and current capacity.
+A TCP connection or `/dev/kvm` file alone is not execution readiness.
+
+### R5 — UX
+
+Expose approved Harness selection, placement and a reviewable borrowed-tool
+list. Show effective permissions and unsupported combinations before launch;
+show resolved runtime/tool identities, refusals, results and receipts afterward.
+Use the two distinct mode labels above. Keep full Celln opt-in unavailable for
+an adapter until it passes its supported-contract conformance gate.
+
+## Acceptance evidence — no substitutes
+
+1. **Model-in-cell proof:** guest code actually initiates a bounded request via
+   the broker, receives a real model response and uses it. Observe host-side
+   request counters and guest execution evidence. A canned response or a model
+   called only by the host does not pass. This alone is not a borrowed-tool proof.
+2. **Tool-lending proof:** one real model task uses at least two independently
+   identified, selected tools, including an admitted user-supplied artifact.
+   Record model tool-call IDs, executed arguments, receipts and results used in
+   the next model turn. Verify an unselected tool is rejected.
+3. **Full placement proof:** the supported Harness agent loop itself executes
+   inside a cell with the approved runtime identity. Observe actual guest
+   attempts at forbidden code mutation/network/authority expansion; host-side
+   assertions alone do not prove the boundary.
+4. **Product proof:** submit through Sympozium using the supported API and
+   deployed controller/router/dispatcher path; show results, receipts, model
+   routing and failure/refusal reasons. Direct-launch probes supplement, not
+   replace, this evidence. Include the chosen conversational lifecycle.
+5. **Failure proof:** cancellation, deadlines, malformed/flooded output,
+   missing credentials, tampered closures, revoked tools, exhausted budgets,
+   replica restarts and node loss. No retry may silently duplicate tool work.
+6. **Regression/measurement:** retain existing GET/PIO, hardware sealing,
+   closure, Job and HarnessSession suites; publish cold/warm latency, concurrent
+   memory and cleanup with exact revisions and topology. Two Kind workers on
+   one host are not independent physical failure domains. A skipped hardware
+   test is not a pass.
+
+## Delivery sequence
+
+Finish M0's authenticated deployed path and ownership semantics. In parallel,
+develop the versioned model broker needed for in-cell inference, then approved
+runtime delivery and tool lending. An intermediate external Harness calling
+Celln tools may validate the UX and tool-call contract, but must remain labelled
+as such. Full opt-in and epic completion require the full-placement and product
+proofs above. Record each increment's actual evidence and remaining limits in
+the epic rather than promoting a prerequisite test into an end-to-end claim.

--- a/docs/HARNESS_MODEL_PROOF.md
+++ b/docs/HARNESS_MODEL_PROOF.md
@@ -1,0 +1,81 @@
+# In-cell model broker — first prerequisite proof
+
+2026-09-07: a static guest probe running in the agent lane in a real KVM cell
+initiated an authenticated DeepSeek JSON POST through `pilot-fetch` and warden.
+It received the model response and checked the completion inside the guest.
+The API credential was read from an operator-owned host file, not delivered to
+the guest or placed in curl arguments.
+
+This is **not** the completed Agent Harness + borrowed-tools proof. It is gate
+1's minimal model-call prerequisite in [the requirements](HARNESS_EXECUTION_REQUIREMENTS.md).
+It uses the direct hardware proof launcher, not Sympozium, the Kind router path
+or a production Harness adapter. It does not demonstrate an agent tool loop,
+multiple lent tools, warm production dispatch, conversational persistence,
+runtime admission or tenant budget enforcement.
+
+## Observed result
+
+- Guest completed the existing agent-lane checks: raw I/O devices inaccessible,
+  io_uring and x32 socket bypasses denied, permitted broker ports accessible,
+  widening I/O permissions denied, and adjacent port access caused SIGSEGV.
+- Host broker counters: 2 requests, 1 rejection (the intentional malformed
+  permission probe), 475 successful response bytes.
+- Requested endpoint: `https://api.deepseek.com/chat/completions`.
+- Requested model alias: `deepseek-chat`; provider reported `deepseek-v4-flash`.
+  These identities are recorded separately, not treated as exact model pinning.
+- Completion ID: `d9930ced-7749-40ce-8108-6da73cc59286`.
+- Guest-checked completion: `CELLN_MODEL_PROOF_OK`.
+- Provider-reported usage: 19 prompt tokens + 7 completion tokens = 26 tokens.
+
+No credential or private publisher key is part of this record.
+
+## Broker contract in this increment
+
+Existing GET URL requests keep their wire format. A new optional JSON request
+uses `apiVersion: celln.fetch/v1`, `method: POST`, `url` and an object `body`.
+Unknown fields, methods and versions refuse. `pilot-fetch --json-stdin` accepts
+bounded request data without putting the body in its arguments. The existing
+PIO ports and 8192-byte request / 1 MiB client response limits are unchanged.
+
+Host policy must explicitly lend a `JsonPostGrant` for the exact endpoint,
+including its host-owned bearer credential file. GET host allowlists do not
+imply this grant. The regular dispatcher does not yet accept or provision
+model grants: only the explicitly configured hardware proof enables one.
+
+The host checks its host allowlist/public destination and pins DNS, disables
+curl configuration/proxies, verifies TLS, bounds calls/body/time, and never
+follows redirects or automatically retries a POST. Credential files reload on
+each call; malformed/missing values refuse. No guest headers, file references
+or proxy options are accepted. Credential staging uses a temporary mode-0600
+host file, removed when the request completes.
+
+An exact endpoint grant is **not** a model/token/cost policy. Product integration
+must validate selected model and permitted request parameters, add per-run
+budget/usage accounting, address credential lifecycle/withdrawal and durable
+audit, and define ambiguous POST failures. This increment remains experimental.
+
+## Reproduce
+
+Requires real KVM, a readable kernel, the static guest toolchain and a separately
+provisioned mode-0600 file containing the authorized provider key. Do not put the
+key in a command line. The following makes one billed request:
+
+```sh
+CELLN_MODEL_TOKEN_FILE=/operator/provisioned/deepseek-token \
+  cargo run -p celln-pilot --features kvm --bin celln-fetch-proof -- \
+  https://api.deepseek.com/chat/completions
+```
+
+The smoke's model is currently fixed to `deepseek-chat`, its completion budget
+to 64 tokens, and its prompt to the proof marker. This is deliberate fixture
+scope, not a configurable Harness API. Without `CELLN_MODEL_TOKEN_FILE`, the
+same launcher exercises the original GET path:
+
+```sh
+cargo run -p celln-pilot --features kvm --bin celln-fetch-proof -- https://example.com/
+```
+
+For a checkout using an external Cargo target directory, build the musl guest
+binaries first and set `CELLN_PILOT_DIR` to that target's
+`x86_64-unknown-linux-musl/release` directory. Neither the existing GET command
+nor normal host grants opt into provider credentials implicitly.


### PR DESCRIPTION
## Purpose

Prerequisite for https://github.com/sympozium-ai/sympozium/issues/426, not epic completion.

- Check in durable Harness-in-Celln requirements and six explicit acceptance gates.
- Prototype versioned, exact-endpoint JSON POST grants separate from GET host authority.
- Keep provider credentials on the host; reload a bounded credential file and use a private temporary header file rather than argv or guest state.
- Preserve GET/PIO compatibility, reject unknown wire fields/methods, refuse overflowing requests instead of accepting a truncated prefix, pin DNS and verify TLS; no POST redirects or automatic retries.
- Add pilot-fetch JSON stdin mode and an explicitly opt-in real-model hardware probe.

## Evidence

Actual KVM guest code in the agent lane initiated a DeepSeek request and checked its response. Completion `d9930ced-7749-40ce-8108-6da73cc59286`: `CELLN_MODEL_PROOF_OK`; provider reported 19 prompt + 7 completion tokens. Requested alias `deepseek-chat`, reported model `deepseek-v4-flash`. Host-observed counters: 2 requests, 1 deliberately malformed permission-probe rejection, 475 response bytes. Credential never entered the guest/argv/evidence; the temporary operator credential file was removed after the test.

Original real-KVM GET proof also passed: 2 requests, 1 deliberate rejection, 559 response bytes. Final `make ci` passed. An earlier full run hit the previously observed unchanged pilot executable-FD test `Text file busy` failure; full rerun passed. New host policy/protocol/credential unit tests pass.

## Why draft

This is a **model-call prerequisite**, not a working Harness + borrowed-tools product. There is no full agent tool loop, multiple lent-tool dispatch, real adapter closure, conversational lifecycle or deployed Sympozium path in this proof. It uses the direct hardware launcher, not warm production dispatch. No regular dispatcher request can implicitly acquire these grants.

Remaining review/implementation includes exact selected-model/request-parameter validation, tenant token/cost budgets, stronger negative transport tests, credential withdrawal, durable correlated audit, runtime/tool admission and the full product gate. Endpoint authorization alone is not model-policy enforcement. M0 ownership/TLS/deployment work is not bypassed or declared complete.
