### PR TITLE
feat(harness): prove warm-forked in-cell model loop with lent tools

### DIFF
--- a/crates/celln-pilot/Cargo.toml
+++ b/crates/celln-pilot/Cargo.toml
@@ -43,6 +43,15 @@ name = "celln-fetch-proof"
 path = "src/fetch_proof.rs"
 required-features = ["kvm"]
 
+[[bin]]
+name = "celln-harness-reference"
+path = "src/harness_reference.rs"
+
+[[bin]]
+name = "celln-harness-proof"
+path = "src/harness_proof.rs"
+required-features = ["kvm"]
+
 [lib]
 name = "pilot"
 path = "src/lib.rs"

--- a/crates/celln-pilot/src/harness_proof.rs
+++ b/crates/celln-pilot/src/harness_proof.rs
@@ -1,0 +1,210 @@
+//! Opt-in real-model, warm-fork reference Harness proof. Not a dispatcher adapter.
+use anyhow::{ensure, Context, Result};
+use celln_manifest::{
+    closure::{Closure, Member},
+    Author, Entry, Hash, Manifest, Tier,
+};
+use serde_json::{json, Value};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    io::Read,
+    path::PathBuf,
+    process::Command,
+    time::Duration,
+};
+use warden::{
+    egress::{HttpPolicy, JsonPostGrant},
+    vmm::boot::{BootConfig, BootEnd, LinuxCell},
+};
+
+fn main() -> Result<()> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let binaries = PathBuf::from(
+        std::env::var_os("CELLN_PILOT_DIR")
+            .context("set CELLN_PILOT_DIR to static guest binaries")?,
+    );
+    let token = PathBuf::from(
+        std::env::var_os("CELLN_MODEL_TOKEN_FILE")
+            .context("set CELLN_MODEL_TOKEN_FILE to a private host credential file")?,
+    );
+    let work = std::env::temp_dir().join(format!("celln-harness-proof-{}", std::process::id()));
+    std::fs::create_dir(&work)?;
+    std::fs::copy(
+        binaries.join("celln-harness-reference"),
+        work.join("harness"),
+    )?;
+    std::fs::copy(binaries.join("pilot-fetch"), work.join("pilot-fetch"))?;
+    for name in ["add", "multiply"] {
+        let mut build = Command::new("rustc");
+        build.args([
+            "--edition",
+            "2021",
+            "-O",
+            "--target",
+            "x86_64-unknown-linux-musl",
+        ]);
+        if name == "add" {
+            build.args(["--cfg", "add_tool"]);
+        }
+        ensure!(
+            build
+                .arg(root.join("crates/celln-pilot/tests/fixtures/arithmetic_tool.rs"))
+                .arg("-o")
+                .arg(work.join(name))
+                .status()?
+                .success(),
+            "tool compile failed"
+        );
+    }
+    std::fs::copy(work.join("add"), work.join("unselected"))?;
+    let mut mk = Command::new(root.join("scripts/mktoolfs.sh"));
+    mk.arg(work.join("toolfs.img")).arg("32");
+    for name in ["harness", "pilot-fetch", "add", "multiply", "unselected"] {
+        mk.arg(work.join(name));
+    }
+    ensure!(mk.status()?.success(), "toolfs build failed");
+    let payload = std::fs::read(work.join("toolfs.img"))?;
+    let mut members = BTreeMap::new();
+    for name in ["harness", "pilot-fetch", "add", "multiply"] {
+        members.insert(
+            format!("/{name}"),
+            Member {
+                hash: Hash::of(&std::fs::read(work.join(name))?).0,
+                dependencies: BTreeSet::new(),
+            },
+        );
+    }
+    members.get_mut("/harness").unwrap().dependencies = ["/pilot-fetch", "/add", "/multiply"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+    let mut seed = [0; 32];
+    std::fs::File::open("/dev/urandom")?.read_exact(&mut seed)?;
+    let signed = Closure {
+        api_version: "celln.dev/closure-v1".into(),
+        toolfs: Hash::of(&payload).0,
+        entrypoint: "/harness".into(),
+        interpreter: false,
+        members: members.clone(),
+    }
+    .sign(&seed)
+    .map_err(anyhow::Error::msg)?;
+    signed
+        .verify(&BTreeSet::from([signed.publisher.clone()]))
+        .map_err(anyhow::Error::msg)?;
+    std::fs::write(
+        work.join("signed-closure.json"),
+        serde_json::to_vec_pretty(&signed)?,
+    )?;
+    let mut manifest = Manifest::new();
+    manifest.admit(Entry {
+        alias: "/harness".into(),
+        hash: Hash(members["/harness"].hash.clone()),
+        tier: Tier::Verified,
+        interpreter: false,
+        author: Author::Host,
+        recipe: None,
+    });
+    manifest.sign_standin();
+    std::fs::write(work.join("manifest.json"), serde_json::to_vec(&manifest)?)?;
+    ensure!(
+        Command::new(root.join("scripts/mkinitramfs.sh"))
+            .current_dir(&root)
+            .arg(work.join("initramfs.cpio"))
+            .env("CELLN_MANIFEST", work.join("manifest.json"))
+            .env("CELLN_WARM_DISPATCH", "1")
+            .env_remove("CELLN_RUN_JSON")
+            .status()?
+            .success(),
+        "initrd build failed"
+    );
+    let kernel = BootConfig::host_kernel().context("no host kernel")?;
+    let mut template = LinuxCell::boot(
+        BootConfig::new(kernel)
+            .with_pmem(payload.len())
+            .with_initrd(work.join("initramfs.cpio")),
+    )?;
+    template.seal_tool(&Hash::of(&payload), &payload)?;
+    template.stop_when_guest_prints("CELLN:mote=parked");
+    ensure!(
+        matches!(template.run()?.end, BootEnd::Parked),
+        "template did not park"
+    );
+    let mote = template.park()?;
+    let mut cell = LinuxCell::fork_from(&mote)?;
+    cell.set_timeout(Duration::from_secs(180));
+    let url = "https://api.deepseek.com/chat/completions";
+    let mut policy = HttpPolicy::new(vec!["api.deepseek.com".into()]);
+    policy.timeout = Duration::from_secs(45);
+    policy.max_requests = 6;
+    policy.json_posts.push(JsonPostGrant {
+        url: url.into(),
+        bearer_token_file: token,
+    });
+    cell.enable_http_fetch(policy);
+    let config = json!({"task":"Use add with args [\"37\",\"5\"], then use multiply with the returned result and \"2\". Wait for each tool result. Finally reply with exactly the final integer, no explanation.", "url":url,"model":"deepseek-chat","tools":[
+        {"name":"add","path":"/add","hash":members["/add"].hash,"description":"Add two integer strings; returns their sum."},
+        {"name":"multiply","path":"/multiply","hash":members["/multiply"].hash,"description":"Multiply two integer strings; returns their product."}
+    ]});
+    cell.set_invocation(&serde_json::to_vec(&json!({"path":"/harness","alias":"/harness","root":"/tools","args":[config.to_string()],"force_agent_lane":true,"agent_authored_input":true,"allow_fetch":true,"expected_hash":members["/harness"].hash,"workspace_access":"none","closure_members":members}))?)?;
+    let report = cell.run()?;
+    std::fs::write(work.join("console.log"), &report.console)?;
+    let events: Vec<Value> = report
+        .console
+        .lines()
+        .filter_map(|line| line.strip_prefix("CELLN_HARNESS_EVENT "))
+        .map(serde_json::from_str)
+        .collect::<std::result::Result<_, _>>()?;
+    std::fs::write(
+        work.join("events.json"),
+        serde_json::to_vec_pretty(&events)?,
+    )?;
+    ensure!(
+        matches!(report.end, BootEnd::Shutdown),
+        "cell did not shut down; evidence {}",
+        work.display()
+    );
+    ensure!(
+        report
+            .console
+            .contains("CELLN:pilot_run_/harness=permitted:agent"),
+        "not agent lane"
+    );
+    ensure!(
+        events.iter().any(|e| e["type"] == "negative-checks"
+            && e["unselected"] == "EACCES"
+            && e["toolWrites"] == "denied"),
+        "negative probes failed; {}",
+        work.display()
+    );
+    let calls: Vec<_> = events.iter().filter(|e| e["type"] == "tool").collect();
+    ensure!(
+        calls.len() == 2
+            && calls[0]["name"] == "add"
+            && calls[0]["args"] == json!(["37", "5"])
+            && calls[0]["result"] == "42\n"
+            && calls[1]["name"] == "multiply"
+            && calls[1]["args"] == json!(["42", "2"])
+            && calls[1]["result"] == "84\n",
+        "incorrect tool sequence; {}",
+        work.display()
+    );
+    ensure!(
+        calls[0]["hash"] == members["/add"].hash && calls[1]["hash"] == members["/multiply"].hash,
+        "tool identities differ"
+    );
+    ensure!(
+        events.iter().filter(|e| e["type"] == "model").count() >= 3
+            && events.iter().any(|e| e["type"] == "completed"
+                && e["answer"].as_str().is_some_and(|s| s.trim() == "84")),
+        "model did not consume results; {}",
+        work.display()
+    );
+    let evidence = json!({"scope":"direct-KVM reference Harness; not Sympozium dispatcher or Pi/Hermes","spawn":"warm mote CoW fork","publisher":signed.publisher,"toolfs":signed.closure.toolfs,"members":members,"fetchActivity":cell.fetch_activity(),"events":events});
+    std::fs::write(
+        work.join("evidence.json"),
+        serde_json::to_vec_pretty(&evidence)?,
+    )?;
+    println!("PASS: in-cell model loop used two lent tools, consumed results, answered 84; unselected exec denied. Evidence: {}",work.display());
+    Ok(())
+}

--- a/crates/celln-pilot/src/harness_reference.rs
+++ b/crates/celln-pilot/src/harness_reference.rs
@@ -1,0 +1,201 @@
+//! Experimental in-cell reference loop, not a Pi/Hermes compatibility claim.
+use anyhow::{bail, ensure, Context, Result};
+use celln_manifest::Hash;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::collections::BTreeSet;
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Tool {
+    name: String,
+    path: String,
+    hash: String,
+    description: String,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Config {
+    task: String,
+    url: String,
+    model: String,
+    tools: Vec<Tool>,
+}
+
+fn bounded_child(path: &str, args: &[String], input: Option<&[u8]>) -> Result<Vec<u8>> {
+    let mut command = Command::new(path);
+    command
+        .args(args)
+        .env_clear()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    // Avoid opening /dev/null inside the sealed root, where it is not lent.
+    command.stdin(if input.is_some() {
+        Stdio::piped()
+    } else {
+        Stdio::inherit()
+    });
+    let mut child = command.spawn().context("starting lent executable")?;
+    let result = (|| -> Result<Vec<u8>> {
+        if let Some(input) = input {
+            child.stdin.take().context("stdin")?.write_all(input)?;
+        }
+        let mut output = Vec::new();
+        child
+            .stdout
+            .take()
+            .context("stdout")?
+            .take(1_048_577)
+            .read_to_end(&mut output)?;
+        ensure!(output.len() <= 1_048_576, "child output exceeded limit");
+        ensure!(child.wait()?.success(), "lent executable failed");
+        Ok(output)
+    })();
+    if result.is_err() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    result
+}
+
+fn run() -> Result<()> {
+    let config: Config =
+        serde_json::from_str(&std::env::args().nth(1).context("missing host config")?)?;
+    ensure!(
+        config.tools.len() == 2,
+        "reference proof requires exactly two lent tools"
+    );
+    let mut names = BTreeSet::new();
+    for tool in &config.tools {
+        ensure!(names.insert(&tool.name), "duplicate tool");
+        ensure!(
+            tool.path.starts_with('/') && Hash::of(&std::fs::read(&tool.path)?).0 == tool.hash,
+            "lent tool identity mismatch"
+        );
+        ensure!(
+            std::fs::OpenOptions::new()
+                .write(true)
+                .open(&tool.path)
+                .is_err(),
+            "lent code is writable"
+        );
+    }
+    // These files exist in the signed filesystem but have no member grant.
+    ensure!(
+        std::fs::read("/unselected").is_err(),
+        "unselected tool readable"
+    );
+    let refused = Command::new("/unselected")
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .status();
+    ensure!(
+        matches!(refused, Err(ref e) if e.raw_os_error() == Some(libc::EACCES)),
+        "unselected executable not denied by confinement"
+    );
+    ensure!(
+        std::fs::read("/provider-token").is_err(),
+        "provider credential visible"
+    );
+    println!(
+        "CELLN_HARNESS_EVENT {}",
+        json!({"type":"negative-checks","unselected":"EACCES","toolWrites":"denied"})
+    );
+    let definitions: Vec<Value> = config.tools.iter().map(|t| json!({"type":"function","function":{
+        "name":t.name,"description":t.description,"parameters":{"type":"object","properties":{"args":{"type":"array","items":{"type":"string"},"minItems":2,"maxItems":2}},"required":["args"],"additionalProperties":false}
+    }})).collect();
+    let mut messages = vec![json!({"role":"user","content":config.task})];
+    let mut used = BTreeSet::new();
+    let mut ids = BTreeSet::new();
+    let mut calls = 0;
+    for turn in 0..6 {
+        let wire = serde_json::to_vec(
+            &json!({"apiVersion":"celln.fetch/v1","method":"POST","url":config.url,"body":{
+                "model":config.model,"stream":false,"max_tokens":512,"messages":messages,"tools":definitions,
+                "tool_choice":if used.len() < config.tools.len() { "required" } else { "auto" }
+            }}),
+        )?;
+        ensure!(wire.len() <= 8192, "conversation exceeded broker budget");
+        let response: Value = serde_json::from_slice(&bounded_child(
+            "/pilot-fetch",
+            &["--json-stdin".into()],
+            Some(&wire),
+        )?)?;
+        let message = response
+            .pointer("/choices/0/message")
+            .context("no model message")?
+            .clone();
+        println!(
+            "CELLN_HARNESS_EVENT {}",
+            json!({"type":"model","turn":turn,"id":response["id"],"model":response["model"],"usage":response["usage"]})
+        );
+        let tool_calls = message["tool_calls"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        messages.push(message.clone());
+        if tool_calls.is_empty() {
+            ensure!(
+                used.len() == config.tools.len(),
+                "model stopped before using lent tools"
+            );
+            let answer = message["content"].as_str().context("no final answer")?;
+            println!(
+                "CELLN_HARNESS_EVENT {}",
+                json!({"type":"completed","answer":answer,"toolsUsed":used,"calls":calls})
+            );
+            return Ok(());
+        }
+        for call in tool_calls {
+            calls += 1;
+            ensure!(calls <= 6, "tool call budget exhausted");
+            let id = call["id"].as_str().context("missing call ID")?.to_owned();
+            ensure!(ids.insert(id.clone()), "duplicate call ID");
+            let name = call["function"]["name"]
+                .as_str()
+                .context("missing tool name")?;
+            let tool = config
+                .tools
+                .iter()
+                .find(|t| t.name == name)
+                .context("unselected tool requested")?;
+            #[derive(Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct Arguments {
+                args: Vec<String>,
+            }
+            let args: Arguments = serde_json::from_str(
+                call["function"]["arguments"]
+                    .as_str()
+                    .context("missing arguments")?,
+            )?;
+            ensure!(
+                args.args.len() == 2
+                    && args
+                        .args
+                        .iter()
+                        .all(|a| a.len() <= 16 && a.parse::<i32>().is_ok()),
+                "invalid tool arguments"
+            );
+            let output = bounded_child(&tool.path, &args.args, None)?;
+            ensure!(output.len() <= 1024, "tool result budget exceeded");
+            let result = String::from_utf8(output)?;
+            used.insert(tool.name.clone());
+            println!(
+                "CELLN_HARNESS_EVENT {}",
+                json!({"type":"tool","id":id,"name":name,"hash":tool.hash,"args":args.args,"result":result})
+            );
+            messages.push(json!({"role":"tool","tool_call_id":id,"content":result}));
+        }
+    }
+    bail!("model turn budget exhausted")
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("CELLN_HARNESS_ERROR {error:#}");
+        std::process::exit(1);
+    }
+}

--- a/crates/celln-pilot/tests/fixtures/arithmetic_tool.rs
+++ b/crates/celln-pilot/tests/fixtures/arithmetic_tool.rs
@@ -1,0 +1,8 @@
+//! Independently compiled, statically linked executable tool fixture.
+fn main() {
+    let args: Vec<i32> = std::env::args().skip(1).map(|s| s.parse().expect("integer")).collect();
+    assert_eq!(args.len(), 2);
+    #[cfg(add_tool)] let result = args[0].checked_add(args[1]);
+    #[cfg(not(add_tool))] let result = args[0].checked_mul(args[1]);
+    println!("{}", result.expect("arithmetic overflow"));
+}

--- a/docs/HARNESS_BORROWED_TOOLS_PROOF.md
+++ b/docs/HARNESS_BORROWED_TOOLS_PROOF.md
@@ -1,0 +1,70 @@
+# In-cell reference Harness with lent executable tools
+
+Measured 2026-09-07. Tracks [Sympozium #426](https://github.com/sympozium-ai/sympozium/issues/426).
+This is a prototype prerequisite, not completion of the product epic.
+
+## Actual result
+
+The native Rust reference Harness ran in the agent lane of a real KVM cell,
+spawned by CoW fork of a parked warm mote. The Harness made three model POSTs
+through the host broker; the provider reported `deepseek-v4-flash` for the
+requested `deepseek-chat` alias. The model requested:
+
+1. The separately compiled `/add` executable with `37,5`, returning `42`.
+2. The independently hashed `/multiply` executable with `42,2`, returning `84`.
+3. After receiving both tool results, a final answer of `84`.
+
+Guest code checked the lent executable hashes, attempted writable opens (denied),
+and actually attempted to execute `/unselected` (EACCES). That executable was
+physically present in the sealed filesystem, but excluded from the admitted
+closure member graph and strict Landlock grants. These are guest attempts, not
+host-only assertions. The existing hardware sealing suites cover stage-2 write
+protection; this particular writable-open probe alone does not prove stage-2.
+
+[Committed evidence](evidence/harness-borrowed-tools-2026-09-07.json) includes
+individual binary identities, closure image identity, test publisher, provider
+response IDs, usage, tool arguments/results and host counters: three requests,
+zero rejected requests, 1,708 response bytes. Total reported model usage was
+1,534 tokens. `make ci` passed after the implementation.
+
+## Reproduce
+
+Requires `/dev/kvm`, a readable supported host kernel, ext2/initramfs tooling,
+the Rust musl target and an authorized DeepSeek credential in a private host
+file. This opt-in test makes billable model requests; ordinary CI does not.
+
+```sh
+cargo build --release --target x86_64-unknown-linux-musl -p celln-pilot \
+  --bin celln-pilot --bin pilot-fetch --bin celln-harness-reference
+export CELLN_PILOT_DIR="$PWD/target/x86_64-unknown-linux-musl/release"
+export CELLN_MODEL_TOKEN_FILE=/absolute/path/to/private-provider-token
+cargo run -p celln-pilot --features kvm --bin celln-harness-proof
+```
+
+For an external Cargo target directory, point `CELLN_PILOT_DIR` there instead.
+The launcher prints its evidence directory, retaining console, events, signed
+closure and image files for inspection. It never copies the credential into
+the guest image. Remove your temporary credential copy after testing.
+
+## Scope and remaining work
+
+- This is a narrow reference Harness, not Pi, Hermes or compatibility with an
+  arbitrary OCI AgentRuntime. It invokes binaries directly, not MCP.
+- Tools are separate executable artifacts supplied by the proof launcher, not
+  built-in Harness functions. User upload, catalogue admission, policy approval
+  and composition UX are not implemented by this test.
+- The launcher creates an ephemeral test publisher and trusts it explicitly.
+  This exercises signature verification, not independent operator admission.
+- All descendants share the cell's narrowed authority, including its model
+  broker permission. This does not prove per-tool authority separation or live
+  revocation. Console events are not independently attested per-tool receipts.
+- This is direct host KVM execution, not the deployed Sympozium controller →
+  router → daemon path. Production multi-tool and closure-egress refusal guards
+  are unchanged. The prototype POST grant still needs host-enforced model and
+  parameter budgets before product exposure.
+- The next integration must bind approved runtime identity, execution placement,
+  explicit tool identities and broker grants in a versioned Sympozium contract,
+  then prove that exact path before exposing the Harness + Celln opt-in.
+
+The complete acceptance requirements remain in
+[HARNESS_EXECUTION_REQUIREMENTS.md](HARNESS_EXECUTION_REQUIREMENTS.md).

--- a/docs/HARNESS_EXECUTION_REQUIREMENTS.md
+++ b/docs/HARNESS_EXECUTION_REQUIREMENTS.md
@@ -29,6 +29,11 @@ requested runtime and authority are actually delivered.
 
 ## Current baseline and gaps
 
+Prototype progress: the [borrowed-tools reference proof](HARNESS_BORROWED_TOOLS_PROOF.md)
+now demonstrates a real model/tool/result loop inside a warm-forked cell with
+two separately hashed executables. This does not remove the baseline production
+gaps below or complete the deployed Harness acceptance gates.
+
 Baseline inspected: Celln `4b95a1c`, Sympozium `88a432c`, plus draft M0 router
 changes in [Celln #70](https://github.com/sympozium-ai/celln/pull/70) and ingress
 policy in [Sympozium #427](https://github.com/sympozium-ai/sympozium/pull/427).

--- a/docs/evidence/harness-borrowed-tools-2026-09-07.json
+++ b/docs/evidence/harness-borrowed-tools-2026-09-07.json
@@ -1,0 +1,119 @@
+{
+  "events": [
+    {
+      "toolWrites": "denied",
+      "type": "negative-checks",
+      "unselected": "EACCES"
+    },
+    {
+      "id": "cfc3f951-a884-49bd-b060-37a2dc47e532",
+      "model": "deepseek-v4-flash",
+      "turn": 0,
+      "type": "model",
+      "usage": {
+        "completion_tokens": 40,
+        "prompt_cache_hit_tokens": 0,
+        "prompt_cache_miss_tokens": 425,
+        "prompt_tokens": 425,
+        "prompt_tokens_details": {
+          "cached_tokens": 0
+        },
+        "total_tokens": 465
+      }
+    },
+    {
+      "args": [
+        "37",
+        "5"
+      ],
+      "hash": "blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020",
+      "id": "call_00_98DprAPAMupkrkhxyOWc9665",
+      "name": "add",
+      "result": "42\n",
+      "type": "tool"
+    },
+    {
+      "id": "a39827cc-5185-43ab-8251-c1f387abafbf",
+      "model": "deepseek-v4-flash",
+      "turn": 1,
+      "type": "model",
+      "usage": {
+        "completion_tokens": 41,
+        "prompt_cache_hit_tokens": 384,
+        "prompt_cache_miss_tokens": 102,
+        "prompt_tokens": 486,
+        "prompt_tokens_details": {
+          "cached_tokens": 384
+        },
+        "total_tokens": 527
+      }
+    },
+    {
+      "args": [
+        "42",
+        "2"
+      ],
+      "hash": "blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1",
+      "id": "call_00_Nrwy7RyJjOTngnKN88lx3067",
+      "name": "multiply",
+      "result": "84\n",
+      "type": "tool"
+    },
+    {
+      "id": "950534d1-f97c-44a4-8748-816597d83515",
+      "model": "deepseek-v4-flash",
+      "turn": 2,
+      "type": "model",
+      "usage": {
+        "completion_tokens": 1,
+        "prompt_cache_hit_tokens": 512,
+        "prompt_cache_miss_tokens": 29,
+        "prompt_tokens": 541,
+        "prompt_tokens_details": {
+          "cached_tokens": 512
+        },
+        "total_tokens": 542
+      }
+    },
+    {
+      "answer": "84",
+      "calls": 2,
+      "toolsUsed": [
+        "add",
+        "multiply"
+      ],
+      "type": "completed"
+    }
+  ],
+  "fetchActivity": [
+    3,
+    0,
+    1708
+  ],
+  "members": {
+    "/add": {
+      "dependencies": [],
+      "hash": "blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020"
+    },
+    "/harness": {
+      "dependencies": [
+        "/add",
+        "/multiply",
+        "/pilot-fetch"
+      ],
+      "hash": "blake3:10f6c50b4e012f6caf7c09e9a46a0f7695a2a7f3a4145d81f50c9b1f892c77c3"
+    },
+    "/multiply": {
+      "dependencies": [],
+      "hash": "blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1"
+    },
+    "/pilot-fetch": {
+      "dependencies": [],
+      "hash": "blake3:9afcf605962e29d25fd95fcd3d3a719210f644cd1ee0893ff3d5578eeb86888e"
+    }
+  },
+  "publisher": "ddaed7fc08a8f4c7e27bca04a4d9425de8c9accf4596e8ade9e6692f2a7057f8",
+  "scope": "direct-KVM reference Harness; not Sympozium dispatcher or Pi/Hermes",
+  "spawn": "warm mote CoW fork",
+  "toolfs": "blake3:f06bc97c258da04c7df040838cd51246cf6011166d33b598e1d5b1e0b338310e"
+}


### PR DESCRIPTION
Stacked on #71. Advances sympozium-ai/sympozium#426 without closing it.

Real DeepSeek hardware proof: reference Harness inside a warm-forked KVM cell calls separately compiled and independently hashed add and multiply tools, feeds results back to the model, and receives final answer 84. Guest attempts unselected executable access (EACCES) and writable opens of lent code (denied).

Committed evidence and reproduction: docs/HARNESS_BORROWED_TOOLS_PROOF.md. Three provider responses, two tool calls, 1534 reported tokens. make ci passed.

Scope: experimental direct-KVM reference runtime, not Pi/Hermes or deployed Sympozium. No production dispatcher refusal guards removed; no user tool-admission UX, per-tool authority isolation or independently attested receipts claimed. Host model/parameter budgets remain required before product exposure.