### PR TITLE
feat(harness): enforce model grants and prove guest budget denials

### DIFF
--- a/crates/celln-pilot/src/fetch_proof.rs
+++ b/crates/celln-pilot/src/fetch_proof.rs
@@ -111,6 +111,9 @@ fn main() -> Result<()> {
         policy.json_posts.push(JsonPostGrant {
             url,
             bearer_token_file,
+            model: "deepseek-chat".into(),
+            max_output_tokens: 64,
+            max_total_output_tokens: 64,
         });
         policy.timeout = std::time::Duration::from_secs(45);
         cell.set_timeout(std::time::Duration::from_secs(90));

--- a/crates/celln-pilot/src/harness_proof.rs
+++ b/crates/celln-pilot/src/harness_proof.rs
@@ -140,6 +140,9 @@ fn main() -> Result<()> {
     policy.json_posts.push(JsonPostGrant {
         url: url.into(),
         bearer_token_file: token,
+        model: "deepseek-chat".into(),
+        max_output_tokens: 512,
+        max_total_output_tokens: 1536,
     });
     cell.enable_http_fetch(policy);
     let config = json!({"task":"Use add with args [\"37\",\"5\"], then use multiply with the returned result and \"2\". Wait for each tool result. Finally reply with exactly the final integer, no explanation.", "url":url,"model":"deepseek-chat","tools":[
@@ -200,7 +203,24 @@ fn main() -> Result<()> {
         "model did not consume results; {}",
         work.display()
     );
-    let evidence = json!({"scope":"direct-KVM reference Harness; not Sympozium dispatcher or Pi/Hermes","spawn":"warm mote CoW fork","publisher":signed.publisher,"toolfs":signed.closure.toolfs,"members":members,"fetchActivity":cell.fetch_activity(),"events":events});
+    for reason in [
+        "model not granted",
+        "model output token limit exceeded",
+        "unsupported model request parameters",
+        "model cumulative output budget exhausted",
+    ] {
+        ensure!(
+            events
+                .iter()
+                .any(|e| e["type"] == "model-denied" && e["reason"] == reason),
+            "missing guest model-policy denial: {reason}"
+        );
+    }
+    ensure!(
+        cell.fetch_activity().0 == 8 && cell.fetch_activity().1 == 5,
+        "unexpected broker attempts or denials"
+    );
+    let evidence = json!({"scope":"direct-KVM reference Harness; not Sympozium dispatcher or Pi/Hermes","spawn":"warm mote CoW fork","publisher":signed.publisher,"toolfs":signed.closure.toolfs,"members":members,"fetchActivity":cell.fetch_activity(),"modelPolicy":{"model":"deepseek-chat","maxOutputTokens":512,"maxTotalOutputTokens":1536,"stream":false},"events":events});
     std::fs::write(
         work.join("evidence.json"),
         serde_json::to_vec_pretty(&evidence)?,

--- a/crates/celln-pilot/src/harness_reference.rs
+++ b/crates/celln-pilot/src/harness_reference.rs
@@ -103,6 +103,24 @@ fn run() -> Result<()> {
         "CELLN_HARNESS_EVENT {}",
         json!({"type":"negative-checks","unselected":"EACCES","toolWrites":"denied"})
     );
+    for (field, value, reason) in [
+        ("model", json!("unapproved-model"), "model not granted"),
+        (
+            "max_tokens",
+            json!(513),
+            "model output token limit exceeded",
+        ),
+        ("n", json!(2), "unsupported model request parameters"),
+        (
+            "stream",
+            json!(true),
+            "unsupported model request parameters",
+        ),
+    ] {
+        let mut body = json!({"model":config.model,"stream":false,"max_tokens":512,"messages":[{"role":"user","content":"budget probe"}]});
+        body[field] = value;
+        prove_model_denial(&config.url, body, reason)?;
+    }
     let definitions: Vec<Value> = config.tools.iter().map(|t| json!({"type":"function","function":{
         "name":t.name,"description":t.description,"parameters":{"type":"object","properties":{"args":{"type":"array","items":{"type":"string"},"minItems":2,"maxItems":2}},"required":["args"],"additionalProperties":false}
     }})).collect();
@@ -135,13 +153,28 @@ fn run() -> Result<()> {
             .as_array()
             .cloned()
             .unwrap_or_default();
-        messages.push(message.clone());
+        // Provider responses can contain response-only extensions (e.g.
+        // reasoning metadata). Do not reflect arbitrary provider fields back
+        // into the host's deliberately narrow request contract.
+        let mut next_message = json!({"role":"assistant","content":message["content"]});
+        if !tool_calls.is_empty() {
+            next_message["tool_calls"] = json!(tool_calls.iter().map(|call| json!({
+                "id":call["id"],"type":call["type"],
+                "function":{"name":call["function"]["name"],"arguments":call["function"]["arguments"]}
+            })).collect::<Vec<_>>());
+        }
+        messages.push(next_message);
         if tool_calls.is_empty() {
             ensure!(
                 used.len() == config.tools.len(),
                 "model stopped before using lent tools"
             );
             let answer = message["content"].as_str().context("no final answer")?;
+            prove_model_denial(
+                &config.url,
+                json!({"model":config.model,"stream":false,"max_tokens":512,"messages":[{"role":"user","content":"budget probe"}]}),
+                "model cumulative output budget exhausted",
+            )?;
             println!(
                 "CELLN_HARNESS_EVENT {}",
                 json!({"type":"completed","answer":answer,"toolsUsed":used,"calls":calls})
@@ -191,6 +224,41 @@ fn run() -> Result<()> {
         }
     }
     bail!("model turn budget exhausted")
+}
+
+fn prove_model_denial(url: &str, body: Value, reason: &str) -> Result<()> {
+    let wire = serde_json::to_vec(
+        &json!({"apiVersion":"celln.fetch/v1","method":"POST","url":url,"body":body}),
+    )?;
+    let mut child = Command::new("/pilot-fetch")
+        .arg("--json-stdin")
+        .env_clear()
+        .stdin(Stdio::piped())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .take()
+        .context("probe stdin")?
+        .write_all(&wire)?;
+    let mut error = String::new();
+    child
+        .stderr
+        .take()
+        .context("probe stderr")?
+        .take(4096)
+        .read_to_string(&mut error)?;
+    ensure!(
+        !child.wait()?.success()
+            && error.contains(&format!("CELLN_FETCH_ERROR:host fetch failed: {reason}")),
+        "model policy probe did not receive expected refusal: {reason}"
+    );
+    println!(
+        "CELLN_HARNESS_EVENT {}",
+        json!({"type":"model-denied","reason":reason})
+    );
+    Ok(())
 }
 
 fn main() {

--- a/crates/celln-warden/src/egress.rs
+++ b/crates/celln-warden/src/egress.rs
@@ -56,11 +56,16 @@ pub enum FetchDenied {
 pub struct HttpBroker {
     policy: HttpPolicy,
     used: usize,
+    post_output_reserved: std::collections::BTreeMap<String, u64>,
 }
 
 impl HttpBroker {
     pub fn new(policy: HttpPolicy) -> Self {
-        Self { policy, used: 0 }
+        Self {
+            policy,
+            used: 0,
+            post_output_reserved: Default::default(),
+        }
     }
 
     pub fn used(&self) -> usize {

--- a/crates/celln-warden/src/egress_post.rs
+++ b/crates/celln-warden/src/egress_post.rs
@@ -13,6 +13,120 @@ pub struct JsonPostGrant {
     pub url: String,
     /// Operator-controlled file, read per request. Never delivered to guest.
     pub bearer_token_file: PathBuf,
+    /// Exact provider model alias; mandatory, never supplied as authority by guest.
+    pub model: String,
+    pub max_output_tokens: u64,
+    /// Sum of requested output ceilings, reserved before network I/O. Failed
+    /// or interrupted requests are not refunded because they may be billed.
+    pub max_total_output_tokens: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChatRequest {
+    model: String,
+    max_tokens: u64,
+    stream: bool,
+    messages: Vec<ChatMessage>,
+    #[serde(default)]
+    tools: Option<Vec<ChatTool>>,
+    #[serde(default)]
+    tool_choice: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChatMessage {
+    role: String,
+    // Text-only: no provider-fetched URLs or multimodal input objects.
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<ChatToolCall>>,
+    #[serde(default)]
+    tool_call_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChatTool {
+    #[serde(rename = "type")]
+    kind: String,
+    function: ChatFunction,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChatFunction {
+    name: String,
+    description: String,
+    parameters: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChatToolCall {
+    id: String,
+    #[serde(rename = "type")]
+    kind: String,
+    function: ChatFunctionCall,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChatFunctionCall {
+    name: String,
+    arguments: String,
+}
+
+fn validate_chat(body: &serde_json::Value, grant: &JsonPostGrant) -> Result<u64, FetchDenied> {
+    let chat: ChatRequest = serde_json::from_value(body.clone())
+        .map_err(|_| refused("unsupported model request parameters"))?;
+    if grant.model.is_empty() || chat.model != grant.model {
+        return Err(refused("model not granted"));
+    }
+    if chat.max_tokens == 0
+        || chat.max_tokens > grant.max_output_tokens
+        || chat.max_tokens > grant.max_total_output_tokens
+    {
+        return Err(refused("model output token limit exceeded"));
+    }
+    if chat.stream
+        || chat.messages.is_empty()
+        || chat.messages.len() > 128
+        || chat.messages.iter().any(|m| {
+            !matches!(m.role.as_str(), "system" | "user" | "assistant" | "tool")
+                || (m.content.is_none() && m.tool_calls.is_none())
+                || (m.tool_calls.is_some() && m.role != "assistant")
+                || (m.tool_call_id.is_some() != (m.role == "tool"))
+                || m.tool_calls.as_ref().is_some_and(|calls| {
+                    calls.is_empty()
+                        || calls.len() > 16
+                        || calls.iter().any(|c| {
+                            c.kind != "function"
+                                || c.id.is_empty()
+                                || c.function.name.is_empty()
+                                || c.function.arguments.len() > 4096
+                        })
+                })
+        })
+        || chat.tools.as_ref().is_some_and(|tools| {
+            tools.is_empty()
+                || tools.len() > 16
+                || tools.iter().any(|t| {
+                    t.kind != "function"
+                        || t.function.name.is_empty()
+                        || t.function.description.len() > 4096
+                        || !t.function.parameters.is_object()
+                })
+        })
+        || chat
+            .tool_choice
+            .as_ref()
+            .is_some_and(|choice| !matches!(choice.as_str(), "auto" | "required" | "none"))
+    {
+        return Err(refused("unsupported model request parameters"));
+    }
+    Ok(chat.max_tokens)
 }
 
 #[derive(Deserialize)]
@@ -74,11 +188,22 @@ impl HttpBroker {
     pub(super) fn post_json(&mut self, raw: &str) -> Result<Vec<u8>, FetchDenied> {
         let request = parse(raw)?;
         let grant = self.grant_for(&request)?.clone();
+        let output_tokens = validate_chat(&request.body, &grant)?;
         if self.used >= self.policy.max_requests {
             return Err(FetchDenied::Budget);
         }
+        let reserved = self
+            .post_output_reserved
+            .get(&request.url)
+            .copied()
+            .unwrap_or(0);
+        let next = reserved
+            .checked_add(output_tokens)
+            .filter(|total| *total <= grant.max_total_output_tokens)
+            .ok_or_else(|| refused("model cumulative output budget exhausted"))?;
         let (host, ip) = self.authorize(&request.url)?;
         self.used += 1;
+        self.post_output_reserved.insert(request.url.clone(), next);
         let credential = credential_header(&grant.bearer_token_file)?;
         let mut body =
             tempfile::NamedTempFile::new().map_err(|_| refused("request staging failed"))?;
@@ -148,6 +273,150 @@ mod tests {
         serde_json::json!({"apiVersion":"celln.fetch/v1","method":"POST","url":"https://example.com/model","body":{"messages":[]}}).to_string()
     }
 
+    fn model_policy() -> HttpPolicy {
+        // .invalid plus an absent credential make accidental I/O visible:
+        // every refusal below must occur before DNS or credential access.
+        let mut policy = HttpPolicy::new(vec!["provider.invalid".into()]);
+        policy.json_posts.push(JsonPostGrant {
+            url: "https://provider.invalid/chat".into(),
+            bearer_token_file: "/must-not-be-read".into(),
+            model: "approved".into(),
+            max_output_tokens: 512,
+            max_total_output_tokens: 1024,
+        });
+        policy
+    }
+
+    fn chat_body() -> serde_json::Value {
+        serde_json::json!({"model":"approved","stream":false,"max_tokens":512,
+            "messages":[{"role":"user","content":"hello"}]})
+    }
+
+    #[test]
+    fn model_policy_rejects_escalations_before_io() {
+        let cases = [
+            ("model", serde_json::json!("other"), "model not granted"),
+            (
+                "max_tokens",
+                serde_json::json!(513),
+                "model output token limit exceeded",
+            ),
+            (
+                "max_tokens",
+                serde_json::json!(0),
+                "model output token limit exceeded",
+            ),
+            (
+                "max_tokens",
+                serde_json::json!(-1),
+                "unsupported model request parameters",
+            ),
+            (
+                "max_tokens",
+                serde_json::json!(1.5),
+                "unsupported model request parameters",
+            ),
+            (
+                "stream",
+                serde_json::json!(true),
+                "unsupported model request parameters",
+            ),
+            (
+                "n",
+                serde_json::json!(8),
+                "unsupported model request parameters",
+            ),
+            (
+                "max_completion_tokens",
+                serde_json::json!(9999),
+                "unsupported model request parameters",
+            ),
+            (
+                "temperature",
+                serde_json::json!(2),
+                "unsupported model request parameters",
+            ),
+            (
+                "messages",
+                serde_json::json!([{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://example.com"}}]}]),
+                "unsupported model request parameters",
+            ),
+            (
+                "tools",
+                serde_json::json!([{"type":"web_search"}]),
+                "unsupported model request parameters",
+            ),
+        ];
+        for (field, value, reason) in cases {
+            let mut body = chat_body();
+            body[field] = value;
+            let mut broker = HttpBroker::new(model_policy());
+            let raw = serde_json::json!({"apiVersion":"celln.fetch/v1","method":"POST","url":"https://provider.invalid/chat","body":body}).to_string();
+            assert_eq!(broker.fetch(&raw).unwrap_err(), refused(reason), "{field}");
+            assert_eq!(broker.used(), 0);
+            assert!(broker.post_output_reserved.is_empty());
+        }
+    }
+
+    #[test]
+    fn output_reservations_are_cumulative_and_overflow_safe() {
+        for reserved in [513, 1024, u64::MAX] {
+            let mut broker = HttpBroker::new(model_policy());
+            broker
+                .post_output_reserved
+                .insert("https://provider.invalid/chat".into(), reserved);
+            let raw = serde_json::json!({"apiVersion":"celln.fetch/v1","method":"POST","url":"https://provider.invalid/chat","body":chat_body()}).to_string();
+            assert_eq!(
+                broker.fetch(&raw).unwrap_err(),
+                refused("model cumulative output budget exhausted")
+            );
+            assert_eq!(broker.used(), 0);
+        }
+    }
+
+    #[test]
+    fn failed_requests_do_not_refund_reserved_output() {
+        let mut policy = model_policy();
+        policy.allow_hosts = vec!["8.8.8.8".into()];
+        policy.json_posts[0].url = "https://8.8.8.8/chat".into();
+        policy.json_posts[0].max_total_output_tokens = 512;
+        let mut broker = HttpBroker::new(policy);
+        let raw = serde_json::json!({"apiVersion":"celln.fetch/v1","method":"POST","url":"https://8.8.8.8/chat","body":chat_body()}).to_string();
+        // Literal IP authorization needs no DNS, then missing credentials fail
+        // before curl starts. No network request is made by this test.
+        assert_eq!(
+            broker.fetch(&raw).unwrap_err(),
+            refused("provider credential unavailable")
+        );
+        assert_eq!(broker.used(), 1);
+        assert_eq!(
+            broker.fetch(&raw).unwrap_err(),
+            refused("model cumulative output budget exhausted")
+        );
+        assert_eq!(broker.post_output_reserved["https://8.8.8.8/chat"], 512);
+    }
+
+    #[test]
+    fn text_and_function_results_fit_the_narrow_contract() {
+        let mut body = chat_body();
+        body["tools"] = serde_json::json!([{"type":"function","function":{"name":"add","description":"add integers","parameters":{"type":"object"}}}]);
+        body["tool_choice"] = "required".into();
+        body["messages"] = serde_json::json!([
+            {"role":"user","content":"add"},
+            {"role":"assistant","content":null,"tool_calls":[{"id":"call1","type":"function","function":{"name":"add","arguments":"{}"}}]},
+            {"role":"tool","tool_call_id":"call1","content":"42"}
+        ]);
+        assert_eq!(
+            validate_chat(&body, &model_policy().json_posts[0]).unwrap(),
+            512
+        );
+        for field in ["model", "max_tokens", "stream", "messages"] {
+            let mut missing = body.clone();
+            missing.as_object_mut().unwrap().remove(field);
+            assert!(validate_chat(&missing, &model_policy().json_posts[0]).is_err());
+        }
+    }
+
     #[test]
     fn get_authority_does_not_imply_post_or_credentials() {
         let mut broker = HttpBroker::new(HttpPolicy::new(vec!["example.com".into()]));
@@ -164,6 +433,9 @@ mod tests {
         policy.json_posts.push(JsonPostGrant {
             url: "https://example.com/model".into(),
             bearer_token_file: "/not-read".into(),
+            model: "approved-model".into(),
+            max_output_tokens: 512,
+            max_total_output_tokens: 1536,
         });
         let broker = HttpBroker::new(policy);
         assert!(broker.grant_for(&parse(&wire()).unwrap()).is_ok());

--- a/docs/HARNESS_BORROWED_TOOLS_PROOF.md
+++ b/docs/HARNESS_BORROWED_TOOLS_PROOF.md
@@ -60,8 +60,9 @@ the guest image. Remove your temporary credential copy after testing.
   revocation. Console events are not independently attested per-tool receipts.
 - This is direct host KVM execution, not the deployed Sympozium controller →
   router → daemon path. Production multi-tool and closure-egress refusal guards
-  are unchanged. The prototype POST grant still needs host-enforced model and
-  parameter budgets before product exposure.
+  are unchanged. [Host-enforced model policy](HARNESS_MODEL_POLICY.md) now adds
+  model/parameter and output-reservation limits; product exposure still needs
+  trusted Sympozium binding, tenant accounting and lifecycle handling.
 - The next integration must bind approved runtime identity, execution placement,
   explicit tool identities and broker grants in a versioned Sympozium contract,
   then prove that exact path before exposing the Harness + Celln opt-in.

--- a/docs/HARNESS_EXECUTION_REQUIREMENTS.md
+++ b/docs/HARNESS_EXECUTION_REQUIREMENTS.md
@@ -34,6 +34,10 @@ now demonstrates a real model/tool/result loop inside a warm-forked cell with
 two separately hashed executables. This does not remove the baseline production
 gaps below or complete the deployed Harness acceptance gates.
 
+The prototype now also has [host-enforced model/parameter and output-reservation
+limits](HARNESS_MODEL_POLICY.md), with real guest escalation attempts. These
+are not yet bound to Sympozium runtime/model selection or tenant accounting.
+
 Baseline inspected: Celln `4b95a1c`, Sympozium `88a432c`, plus draft M0 router
 changes in [Celln #70](https://github.com/sympozium-ai/celln/pull/70) and ingress
 policy in [Sympozium #427](https://github.com/sympozium-ai/sympozium/pull/427).

--- a/docs/HARNESS_MODEL_POLICY.md
+++ b/docs/HARNESS_MODEL_POLICY.md
@@ -1,0 +1,91 @@
+# Host-enforced model grant: integration prerequisite
+
+Tracks [Sympozium #426](https://github.com/sympozium-ai/sympozium/issues/426).
+Status: implemented and hardware-tested in the direct-KVM prototype, not yet
+available through the production dispatcher or Sympozium API.
+
+## Authority
+
+Every `JsonPostGrant` now requires an exact model alias, a positive per-request
+output token ceiling and a cumulative output reservation ceiling, in addition
+to its exact endpoint and host-owned credential file. No unrestricted POST
+variant or default model bypass exists. The ordinary GET ABI is unchanged.
+
+The broker validates the guest body before DNS, credential access or curl:
+
+- Only `model`, `max_tokens`, `stream`, `messages`, `tools` and `tool_choice`
+  are supported. Required fields must be present with the right JSON types.
+- Model must match the grant; `max_tokens` must be a positive integer within
+  both grant limits; `stream` must be false. Alternate token parameters,
+  multiple completions (`n`) and unrecognised provider parameters refuse.
+- Messages are text-only. Function tools/calls are narrowly structured;
+  provider-managed search tools and multimodal URL inputs refuse.
+- Existing 8,192-byte request, bounded response, request-count and timeout
+  controls still apply. Invalid policy/requests fail closed.
+
+For each authorized outgoing attempt, the broker reserves the requested
+`max_tokens`, not the provider-reported actual usage, against the endpoint's
+cumulative allowance. Reservations use checked arithmetic. Failed requests
+are not refunded: a timeout does not establish that the provider did no work.
+The state belongs to the live cell's host broker, not guest memory.
+
+This is **not a currency budget or exact model-version pin**. A provider alias
+can resolve to another reported model. Prompt bytes and call count are bounded,
+but provider input-token accounting, pricing, fleet/tenant budgets, durable
+metering and live grant withdrawal remain separate requirements. Output limits
+are enforced on requests; generation semantics still depend on the provider
+honouring its API contract. Each tool process inherits the cell's broker grant;
+this is not per-tool network authority separation.
+
+## Measured proof, 2026-09-07
+
+The warm-forked reference Harness made five requests that the host refused:
+model substitution, output ceiling 513 against 512, `n:2`, streaming, and a
+fourth valid-shaped model request after three reservations consumed 1,536.
+Guest code checked specific broker errors for each attempt. Between those
+negative probes the real DeepSeek loop executed `add(37,5) → 42`, then
+`multiply(42,2) → 84`, and returned `84`.
+
+[Committed evidence](evidence/harness-model-policy-2026-09-07.json) records
+eight attempts, five denials, three successful provider responses, tool hashes,
+arguments/results and the exact model policy. Reproduce using
+[the borrowed-tools launcher](HARNESS_BORROWED_TOOLS_PROOF.md#reproduce).
+
+Two earlier development runs stopped after the first tool result: reflecting
+provider response extensions into the next request violated the new strict
+schema. The reference client now projects both assistant messages and tool
+calls onto the supported request fields. The host checks were not relaxed.
+Those failed runs each incurred one model request; they are not counted as
+passing proofs. Temporary credential copies were removed after testing.
+
+Offline tests cover parameter/model escalation, required fields, multimodal
+and provider-tool refusal, cumulative exhaustion, integer overflow, and no
+refund after failure. The normal GET hardware probe and `make ci` are regression
+checks; the billable Harness proof remains explicitly opt-in.
+
+## Required Sympozium binding
+
+The next contract must resolve model authority on the trusted side:
+
+1. Resolve a namespace-authorized approved runtime separately from execution
+   placement. An OCI image is not a Celln closure. Freeze runtime/closure and
+   selected tool identities before dispatch, along with the adapter version.
+2. Resolve the Agent's selected provider/model and allowed credential reference.
+   Map that to an operator-provisioned broker grant ID/revision; never accept a
+   guest or AgentRun-supplied credential file path. Do not silently fall back to
+   the dispatcher's ambient provider configuration.
+3. Freeze the grant identity and requested limits in the versioned dispatch
+   record. The Celln operator independently authorizes the workload, runtime,
+   endpoint and model and intersects requested limits with host maxima.
+   Restart/retry must preserve identity and must not reset an ambiguous billed
+   execution into a fresh allowance. A revoked grant must refuse on resume.
+4. Provision the broker only on the forked cell, never the reusable warm mote.
+   Correlate grant/policy revision, runtime/tool identities and provider usage
+   with execution audit. Receipt v1alpha1 must not silently gain incompatible
+   fields. Version any new request/receipt contract explicitly.
+5. Prove controller → authenticated router → dispatcher → in-cell loop on the
+   isolated Kind deployment, including bad grant, stale retry, cancellation and
+   missing-hardware cases, before enabling the Harness + Celln UI option.
+
+The existing production closure-egress, multi-tool and container-Harness/Celln
+refusals remain intact. This work does not justify removing them by themselves.

--- a/docs/HARNESS_MODEL_PROOF.md
+++ b/docs/HARNESS_MODEL_PROOF.md
@@ -54,6 +54,11 @@ must validate selected model and permitted request parameters, add per-run
 budget/usage accounting, address credential lifecycle/withdrawal and durable
 audit, and define ambiguous POST failures. This increment remains experimental.
 
+Follow-up: [host model policy](HARNESS_MODEL_POLICY.md) now enforces exact model
+aliases, narrow request parameters and cumulative output reservations in the
+prototype. The original result above is historical; tenant/currency budgets and
+the Sympozium grant binding remain undelivered.
+
 ## Reproduce
 
 Requires real KVM, a readable kernel, the static guest toolchain and a separately

--- a/docs/evidence/harness-model-policy-2026-09-07.json
+++ b/docs/evidence/harness-model-policy-2026-09-07.json
@@ -1,0 +1,145 @@
+{
+  "events": [
+    {
+      "toolWrites": "denied",
+      "type": "negative-checks",
+      "unselected": "EACCES"
+    },
+    {
+      "reason": "model not granted",
+      "type": "model-denied"
+    },
+    {
+      "reason": "model output token limit exceeded",
+      "type": "model-denied"
+    },
+    {
+      "reason": "unsupported model request parameters",
+      "type": "model-denied"
+    },
+    {
+      "reason": "unsupported model request parameters",
+      "type": "model-denied"
+    },
+    {
+      "id": "1f55dba6-7a49-47b3-be4d-4ddf23d045f9",
+      "model": "deepseek-v4-flash",
+      "turn": 0,
+      "type": "model",
+      "usage": {
+        "completion_tokens": 40,
+        "prompt_cache_hit_tokens": 384,
+        "prompt_cache_miss_tokens": 41,
+        "prompt_tokens": 425,
+        "prompt_tokens_details": {
+          "cached_tokens": 384
+        },
+        "total_tokens": 465
+      }
+    },
+    {
+      "args": [
+        "37",
+        "5"
+      ],
+      "hash": "blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020",
+      "id": "call_00_zxpFgkOIRGf5bS1B3uPP7899",
+      "name": "add",
+      "result": "42\n",
+      "type": "tool"
+    },
+    {
+      "id": "f7651584-568a-491b-b2f9-a332f4f0f0ff",
+      "model": "deepseek-v4-flash",
+      "turn": 1,
+      "type": "model",
+      "usage": {
+        "completion_tokens": 41,
+        "prompt_cache_hit_tokens": 384,
+        "prompt_cache_miss_tokens": 102,
+        "prompt_tokens": 486,
+        "prompt_tokens_details": {
+          "cached_tokens": 384
+        },
+        "total_tokens": 527
+      }
+    },
+    {
+      "args": [
+        "42",
+        "2"
+      ],
+      "hash": "blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1",
+      "id": "call_00_aY1PlI5IJiGFg6FMx26k5166",
+      "name": "multiply",
+      "result": "84\n",
+      "type": "tool"
+    },
+    {
+      "id": "beb556fb-390c-4117-bc9c-aab9409d9a5d",
+      "model": "deepseek-v4-flash",
+      "turn": 2,
+      "type": "model",
+      "usage": {
+        "completion_tokens": 1,
+        "prompt_cache_hit_tokens": 512,
+        "prompt_cache_miss_tokens": 29,
+        "prompt_tokens": 541,
+        "prompt_tokens_details": {
+          "cached_tokens": 512
+        },
+        "total_tokens": 542
+      }
+    },
+    {
+      "reason": "model cumulative output budget exhausted",
+      "type": "model-denied"
+    },
+    {
+      "answer": "84",
+      "calls": 2,
+      "toolsUsed": [
+        "add",
+        "multiply"
+      ],
+      "type": "completed"
+    }
+  ],
+  "fetchActivity": [
+    8,
+    5,
+    1711
+  ],
+  "members": {
+    "/add": {
+      "dependencies": [],
+      "hash": "blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020"
+    },
+    "/harness": {
+      "dependencies": [
+        "/add",
+        "/multiply",
+        "/pilot-fetch"
+      ],
+      "hash": "blake3:962b5dc9a59b27cc0e519075500b167434dff0e8d1938e4d40aa4f8eb6421311"
+    },
+    "/multiply": {
+      "dependencies": [],
+      "hash": "blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1"
+    },
+    "/pilot-fetch": {
+      "dependencies": [],
+      "hash": "blake3:9afcf605962e29d25fd95fcd3d3a719210f644cd1ee0893ff3d5578eeb86888e"
+    }
+  },
+  "modelPolicy": {
+    "maxOutputTokens": 512,
+    "maxTotalOutputTokens": 1536,
+    "model": "deepseek-chat",
+    "stream": false
+  },
+  "publisher": "67be0d645c0c4236f134a6a3e04cb3585082058cc4783f988cdeb717ed75ada8",
+  "scope": "direct-KVM reference Harness; not Sympozium dispatcher or Pi/Hermes",
+  "spawn": "warm mote CoW fork",
+  "toolfs": "blake3:2d6d4e297933d471187a27e9f16773e709235101554910fc7e69e49bef1a7c4a"
+}


### PR DESCRIPTION
Stacked on #72; advances sympozium-ai/sympozium#426.

Mandatory exact model alias, per-request output ceiling and cumulative output reservation on every prototype POST grant. Strict text/function request schema rejects streaming, multiple completions, alternate token parameters, multimodal inputs and unknown fields before I/O. Reservations are overflow-safe and failures are not refunded.

Real warm-forked KVM/DeepSeek proof: three valid model calls consume two separate tool results and answer 84; five guest policy escalation attempts denied. Fixes reference-client response projection uncovered by the strict schema. Two development runs failed after one provider response before the projection fix; final proof passed. Evidence and reproduction committed in docs/HARNESS_MODEL_POLICY.md.

Validation: make ci, offline policy tests and existing GET hardware proof passed. Temporary credential copy removed.

Not a completed Sympozium integration, currency budget or provider-version pin. Production refusal guards unchanged. Documentation specifies the trusted runtime/model/grant binding needed next.