### PR TITLE
feat(harness): dispatch approved in-cell runtime/tool/model bindings

### DIFF
--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -12,6 +12,8 @@ use std::path::Path;
 
 #[path = "dispatch_closure.rs"]
 pub(crate) mod closure;
+#[path = "dispatch_harness.rs"]
+pub(crate) mod harness;
 
 #[path = "dispatch_substrate.rs"]
 mod substrate;
@@ -72,6 +74,12 @@ pub struct ResolvedBundle {
 pub(crate) fn check_supported_authority(request: &ExecutionRequest) -> Result<(), String> {
     celln_control::check().map_err(|e| e.to_string())?;
     inputs::validate(request)?;
+    if request.harness.is_some() {
+        if !request.problems().is_empty() {
+            return Err("invalid Harness binding".into());
+        }
+        return Ok(());
+    }
     if request.tools.iter().any(|tool| tool.closure.is_some())
         && (request.forge.is_some()
             || !request.inputs.is_empty()
@@ -522,7 +530,7 @@ fn run_cell(
         .map(|record| record.id.clone())
         .unwrap_or_default();
 
-    if !request.capabilities.egress.is_empty() {
+    if request.harness.is_none() && !request.capabilities.egress.is_empty() {
         let hosts: Vec<String> = request
             .capabilities
             .egress

--- a/crates/celln-cli/src/dispatch_audit.rs
+++ b/crates/celln-cli/src/dispatch_audit.rs
@@ -37,6 +37,9 @@ pub struct Execution {
     /// Only populated after pilot's installed-grant acknowledgement matches
     /// host-enforced bounds. A refused setup does not grant requested authority.
     pub granted: Option<CapabilityRequest>,
+    /// Operator policy revision, never its credential path or task payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_grant: Option<String>,
     pub inputs: Vec<String>,
     pub broker: BrokerActivity,
     pub exit_code: Option<i32>,
@@ -102,6 +105,11 @@ impl Audit {
                 .execution
                 .as_ref()
                 .map(|_| request.capabilities.clone()),
+            model_grant: outcome
+                .execution
+                .as_ref()
+                .and(request.harness.as_ref())
+                .map(|h| h.model_grant.hash.clone()),
             inputs: outcome.input_hashes.clone(),
             broker: outcome.broker.clone(),
             exit_code: outcome.exit_code,

--- a/crates/celln-cli/src/dispatch_harness.rs
+++ b/crates/celln-cli/src/dispatch_harness.rs
@@ -1,0 +1,253 @@
+//! Operator-owned grants: possessing artifact bytes is not model authority.
+use celln_manifest::Hash;
+use celln_spec::{BorrowedTool, ExecutionRequest};
+use serde::Deserialize;
+use std::{
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Grant {
+    api_version: String,
+    caller: String,
+    mote: String,
+    runtime: String,
+    closure: String,
+    borrowed_tools: Vec<BorrowedTool>,
+    url: String,
+    model: String,
+    credential_file: PathBuf,
+    max_requests: usize,
+    max_output_tokens: u64,
+    max_total_output_tokens: u64,
+}
+pub struct Resolved {
+    pub policy: warden::egress::HttpPolicy,
+    pub args: Vec<String>,
+}
+
+pub fn resolve(
+    request: &ExecutionRequest,
+    closure: Option<&super::closure::Admitted>,
+    root: &Path,
+) -> Result<Option<Resolved>, String> {
+    let Some(binding) = &request.harness else {
+        return Ok(None);
+    };
+    if !request.problems().is_empty() {
+        return Err("invalid Harness binding".into());
+    }
+    let closure = closure.ok_or("Harness requires an admitted closure")?;
+    // Operator-maintained directory, deliberately not an uploadable store.
+    let path = root.join("trusted-harness").join(format!(
+        "{}.json",
+        binding.model_grant.hash.trim_start_matches("blake3:")
+    ));
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)
+        .and_then(|f| f.take(65537).read_to_end(&mut bytes))
+        .map_err(|_| "Harness grant unavailable")?;
+    if bytes.len() > 65536 || Hash::of(&bytes).0 != binding.model_grant.hash {
+        return Err("Harness grant revision mismatch".into());
+    }
+    let grant: Grant = serde_json::from_slice(&bytes).map_err(|_| "invalid Harness grant")?;
+    if grant.api_version != "celln.dev/harness-grant-v1"
+        || grant.caller != request.workload.caller
+        || grant.mote != request.mote.as_ref().unwrap().hash
+        || grant.runtime != request.tools[0].hash
+        || grant.closure != closure.provenance.hash
+        || grant.borrowed_tools != binding.borrowed_tools
+        || grant.model != binding.model
+    {
+        return Err("Harness identity is not authorized by operator grant".into());
+    }
+    let origin = &request.capabilities.egress[0];
+    if grant.url != format!("{origin}/chat/completions")
+        || grant.model.is_empty()
+        || grant.model.len() > 128
+        || !grant.credential_file.is_absolute()
+        || grant.max_requests == 0
+        || grant.max_requests > 6
+        || grant.max_output_tokens != 512
+        || grant.max_total_output_tokens < 512
+        || grant.max_total_output_tokens > 3072
+    {
+        return Err("unsupported Harness model policy".into());
+    }
+    let c = &closure.signed.closure;
+    // Static adapter only. Broader closures require a dependency/tool contract.
+    let mut expected = std::collections::BTreeSet::from([c.entrypoint.as_str(), "/pilot-fetch"]);
+    if expected.len() != 2 {
+        return Err("Harness runtime cannot be the broker client".into());
+    }
+    for tool in &binding.borrowed_tools {
+        if !expected.insert(&tool.path)
+            || c.members
+                .get(&tool.path)
+                .map_or(true, |m| m.hash != tool.hash)
+        {
+            return Err("borrowed tool is not a distinct matching closure member".into());
+        }
+    }
+    if c.interpreter
+        || c.members
+            .keys()
+            .map(String::as_str)
+            .collect::<std::collections::BTreeSet<_>>()
+            != expected
+    {
+        return Err("unsupported Harness closure composition".into());
+    }
+    let mut policy =
+        warden::egress::HttpPolicy::new(vec![origin.trim_start_matches("https://").into()]);
+    policy.max_requests = grant.max_requests;
+    policy.timeout = std::time::Duration::from_secs(45).min(std::time::Duration::from_millis(
+        request.capabilities.timeout_ms,
+    ));
+    policy.json_posts.push(warden::egress::JsonPostGrant {
+        url: grant.url.clone(),
+        bearer_token_file: grant.credential_file,
+        model: grant.model.clone(),
+        max_output_tokens: grant.max_output_tokens,
+        max_total_output_tokens: grant.max_total_output_tokens,
+    });
+    let config = serde_json::json!({"task":binding.task,"url":grant.url,"model":grant.model,"tools":binding.borrowed_tools});
+    Ok(Some(Resolved {
+        policy,
+        args: vec![config.to_string()],
+    }))
+}
+
+/// Conservative durable local tombstone: restart must not recreate allowance
+/// for an ambiguous provider attempt. Not distributed metering or recovery.
+pub fn claim(request: &ExecutionRequest, root: &Path) -> Result<(), String> {
+    if request.harness.is_none() {
+        return Ok(());
+    }
+    let identity = serde_json::to_vec(&(&request.workload.caller, &request.id))
+        .map_err(|_| "invalid attempt identity")?;
+    let dir = root.join("harness-attempts");
+    std::fs::create_dir_all(&dir).map_err(|_| "Harness attempt journal unavailable")?;
+    let file = dir.join(Hash::of(&identity).0.trim_start_matches("blake3:"));
+    let mut record = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(file)
+        .map_err(|_| {
+            "Harness attempt already claimed or journal unavailable; automatic replay refused"
+        })?;
+    record
+        .write_all(
+            Hash::of(&serde_json::to_vec(request).map_err(|_| "invalid Harness request")?)
+                .0
+                .as_bytes(),
+        )
+        .and_then(|_| record.sync_all())
+        .map_err(|_| "Harness attempt journal sync failed")?;
+    std::fs::File::open(&dir)
+        .and_then(|f| f.sync_all())
+        .map_err(|_| "Harness attempt directory sync failed")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use celln_manifest::closure::{Closure, Member};
+    use serde_json::json;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    #[test]
+    fn operator_binding_and_local_replay_fail_closed_without_io_to_provider() {
+        let mut request: ExecutionRequest = serde_json::from_str(include_str!(
+            "../../../examples/execution/harness-reference.json"
+        ))
+        .unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let h = request.harness.as_ref().unwrap();
+        let mut members = BTreeMap::new();
+        for tool in &h.borrowed_tools {
+            members.insert(
+                tool.path.clone(),
+                Member {
+                    hash: tool.hash.clone(),
+                    dependencies: BTreeSet::new(),
+                },
+            );
+        }
+        members.insert(
+            "/pilot-fetch".into(),
+            Member {
+                hash: Hash::of(b"fetch").0,
+                dependencies: BTreeSet::new(),
+            },
+        );
+        members.insert(
+            "/harness".into(),
+            Member {
+                hash: request.tools[0].hash.clone(),
+                dependencies: members.keys().cloned().collect(),
+            },
+        );
+        // Resolve's input is already admitted by the separate signature layer;
+        // this unit test exercises binding, not filesystem/signature admission.
+        let signed = Closure {
+            api_version: "celln.dev/closure-v1".into(),
+            toolfs: Hash::of(b"image").0,
+            entrypoint: "/harness".into(),
+            interpreter: false,
+            members,
+        }
+        .sign(&[19; 32])
+        .unwrap();
+        let closure = super::super::closure::Admitted {
+            provenance: super::super::closure::Provenance {
+                hash: request.tools[0].closure.as_ref().unwrap().hash.clone(),
+                publisher: signed.publisher.clone(),
+                toolfs: signed.closure.toolfs.clone(),
+                members: signed.closure.members.clone(),
+            },
+            signed,
+        };
+        let grant=serde_json::to_vec(&json!({"apiVersion":"celln.dev/harness-grant-v1","caller":request.workload.caller,"mote":request.mote.as_ref().unwrap().hash,"runtime":request.tools[0].hash,"closure":closure.provenance.hash,"borrowedTools":h.borrowed_tools,"url":"https://api.deepseek.com/chat/completions","model":h.model,"credentialFile":"/not-read-by-resolution","maxRequests":3,"maxOutputTokens":512,"maxTotalOutputTokens":1536})).unwrap();
+        request.harness.as_mut().unwrap().model_grant.hash = Hash::of(&grant).0;
+        let dir = root.path().join("trusted-harness");
+        std::fs::create_dir(&dir).unwrap();
+        let path = dir.join(format!(
+            "{}.json",
+            Hash::of(&grant).0.trim_start_matches("blake3:")
+        ));
+        assert!(resolve(&request, Some(&closure), root.path()).is_err());
+        std::fs::write(&path, &grant).unwrap();
+        let resolved = resolve(&request, Some(&closure), root.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.policy.json_posts[0].model, "deepseek-chat");
+        assert!(!resolved.args[0].contains("not-read-by-resolution"));
+        for change in ["caller", "model", "tool", "runtime"] {
+            let mut bad = request.clone();
+            match change {
+                "caller" => bad.workload.caller = "another-caller".into(),
+                "model" => bad.harness.as_mut().unwrap().model = "other-model".into(),
+                "tool" => {
+                    bad.harness.as_mut().unwrap().borrowed_tools[0].hash = Hash::of(b"other").0
+                }
+                _ => bad.tools[0].hash = Hash::of(b"runtime").0,
+            }
+            assert!(
+                resolve(&bad, Some(&closure), root.path()).is_err(),
+                "{change}"
+            );
+        }
+        claim(&request, root.path()).unwrap();
+        assert!(claim(&request, root.path()).is_err());
+        request.harness.as_mut().unwrap().task = "different task, same attempt".into();
+        assert!(claim(&request, root.path()).is_err());
+        std::fs::write(&path, b"tampered").unwrap();
+        assert!(resolve(&request, Some(&closure), root.path()).is_err());
+        std::fs::remove_file(&path).unwrap();
+        assert!(resolve(&request, Some(&closure), root.path()).is_err());
+    }
+}

--- a/crates/celln-cli/src/dispatch_harness_tests.rs
+++ b/crates/celln-cli/src/dispatch_harness_tests.rs
@@ -1,0 +1,241 @@
+//! Explicitly billable HTTP→dispatcher→warm-fork model/tool proof.
+use super::*;
+use celln_manifest::{closure::SignedClosure, Hash};
+use serde_json::{json, Value};
+
+fn http(state: &State, method: &str, path: &str, body: &str) -> (u16, Value) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+    client
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    let (server, _) = listener.accept().unwrap();
+    write!(
+        client,
+        "{method} {path} HTTP/1.1\r\nAuthorization: Bearer {}\r\nContent-Length: {}\r\n\r\n{body}",
+        state.token,
+        body.len()
+    )
+    .unwrap();
+    handle(server, state).unwrap();
+    let mut response = String::new();
+    client.read_to_string(&mut response).unwrap();
+    let status = response.split_whitespace().nth(1).unwrap().parse().unwrap();
+    let body = serde_json::from_str(response.split_once("\r\n\r\n").unwrap().1).unwrap();
+    (status, body)
+}
+
+fn controller_hook(
+    state: &Arc<State>,
+    request: &ExecutionRequest,
+    package: &Path,
+    namespace: &str,
+    hook: &std::ffi::OsStr,
+) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    listener.set_nonblocking(true).unwrap();
+    let stop = Arc::new(AtomicBool::new(false));
+    let server_stop = stop.clone();
+    let server_state = state.clone();
+    let server = thread::spawn(move || {
+        while !server_stop.load(Ordering::SeqCst) {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    handle(stream, &server_state).unwrap();
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(20))
+                }
+                Err(e) => panic!("fixture listener: {e}"),
+            }
+        }
+    });
+    let mut token_file = tempfile::NamedTempFile::new().unwrap();
+    token_file.write_all(state.token.as_bytes()).unwrap();
+    let request_file = package.join("controller-request.json");
+    std::fs::write(&request_file, serde_json::to_vec_pretty(request).unwrap()).unwrap();
+    let output = std::process::Command::new("timeout")
+        .args(["240s", "bash"])
+        .arg(hook)
+        .env("CELLN_ROUTER_URL", url)
+        .env("CELLN_TOKEN_FILE", token_file.path())
+        .env("CELLN_PROOF_REQUEST", request_file)
+        .env("CELLN_PROOF_EVIDENCE", package.join("controller"))
+        .env("CELLN_PROOF_NAMESPACE", namespace)
+        .output();
+    stop.store(true, Ordering::SeqCst);
+    server.join().unwrap();
+    let output = output.unwrap();
+    assert!(
+        output.status.success(),
+        "controller hook failed:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    eprintln!("{}", String::from_utf8_lossy(&output.stdout));
+}
+
+#[test]
+#[ignore = "billable: requires CELLN_HARNESS_PACKAGE, CELLN_MODEL_TOKEN_FILE and real KVM"]
+fn harness_model_over_authenticated_dispatch() {
+    let _lock = crate::dispatch::warm::PROOF_LOCK.lock().unwrap();
+    let package = PathBuf::from(
+        std::env::var_os("CELLN_HARNESS_PACKAGE")
+            .expect("set package directory from celln-harness-proof --package-only"),
+    );
+    let token = PathBuf::from(
+        std::env::var_os("CELLN_MODEL_TOKEN_FILE").expect("set private host credential file"),
+    );
+    assert!(
+        Path::new("/dev/kvm").exists(),
+        "explicit hardware proof requires KVM"
+    );
+    let work = tempfile::tempdir().unwrap();
+    let root = work.path();
+    let namespace = format!("celln-harness-proof-{}", std::process::id());
+    let hook = std::env::var_os("CELLN_HARNESS_CONTROLLER_HOOK");
+    let caller = if hook.is_some() {
+        format!("sympozium:{namespace}/harness-proof")
+    } else {
+        "test:controller".into()
+    };
+    let motes = Store::open(root.join("motes")).unwrap();
+    let tools = Store::open(root.join("tools")).unwrap();
+    let runtime = tools
+        .put(&std::fs::read(package.join("harness")).unwrap())
+        .unwrap();
+    let signed_bytes = std::fs::read(package.join("signed-closure.json")).unwrap();
+    let signed: SignedClosure = serde_json::from_slice(&signed_bytes).unwrap();
+    let closure = Store::open(root.join("closures"))
+        .unwrap()
+        .put(&signed_bytes)
+        .unwrap();
+    std::fs::write(root.join("trusted-closures.json"),json!({"apiVersion":"celln.dev/closure-policy-v1","publishers":[signed.publisher],"revoked":[]}).to_string()).unwrap();
+    let kernel = warden::vmm::boot::BootConfig::host_kernel().expect("kernel");
+    let kernel = motes.put(&std::fs::read(kernel).unwrap()).unwrap();
+    let initrd = motes
+        .put(&std::fs::read(package.join("initramfs.cpio")).unwrap())
+        .unwrap();
+    let toolfs = motes
+        .put(&std::fs::read(package.join("toolfs.img")).unwrap())
+        .unwrap();
+    let mote = motes.put(&serde_json::to_vec(&json!({"apiVersion":"celln.dev/v1alpha1","format":"celln.warm-closure-v1","kernel":kernel.0,"initrd":initrd.0,"toolfs":toolfs.0,"invocation":{"alias":"/harness","toolHash":runtime.0}})).unwrap()).unwrap();
+    std::fs::write(
+        root.join("trusted-motes.json"),
+        json!({"apiVersion":"celln.dev/v1alpha1","bundles":[mote.0]}).to_string(),
+    )
+    .unwrap();
+    let borrowed = json!([
+        {"name":"add","path":"/add","hash":signed.closure.members["/add"].hash,"description":"Add two integer strings."},
+        {"name":"multiply","path":"/multiply","hash":signed.closure.members["/multiply"].hash,"description":"Multiply two integer strings."}
+    ]);
+    let grant = serde_json::to_vec(&json!({"apiVersion":"celln.dev/harness-grant-v1","caller":caller,"mote":mote.0,"runtime":runtime.0,"closure":closure.0,"borrowedTools":borrowed,"url":"https://api.deepseek.com/chat/completions","model":"deepseek-chat","credentialFile":token,"maxRequests":3,"maxOutputTokens":512,"maxTotalOutputTokens":1536})).unwrap();
+    let grant_hash = Hash::of(&grant);
+    let grant_dir = root.join("trusted-harness");
+    std::fs::create_dir(&grant_dir).unwrap();
+    let grant_file = grant_dir.join(format!(
+        "{}.json",
+        grant_hash.0.trim_start_matches("blake3:")
+    ));
+    std::fs::write(&grant_file, &grant).unwrap();
+    let request: ExecutionRequest = serde_json::from_value(json!({"apiVersion":"celln.dev/v1alpha2","id":"harness-dispatch-proof","workload":{"id":"test-run","caller":caller},"mote":{"hash":mote.0},"tools":[{"alias":"/harness","hash":runtime.0,"closure":{"hash":closure.0}}],"invocation":{"alias":"/harness"},"harness":{"model":"deepseek-chat","contractVersion":"celln.reference-functions/v1","modelGrant":{"hash":grant_hash.0},"task":"Use add with args [\"37\",\"5\"], wait for its result, then multiply that result by \"2\". Reply with exactly the final integer.","borrowedTools":borrowed},"capabilities":{"workspace":"none","egress":["https://api.deepseek.com"],"timeoutMs":180000,"memoryBytes":268435456,"outputBytes":65536},"execution":{"lane":"agent","requireHardwareIsolation":true}})).unwrap();
+    assert!(request.problems().is_empty(), "{:?}", request.problems());
+    let state = State {
+        token: "test-token-at-least-24-bytes".into(),
+        egress_policy: EgressPolicy::new(&["api.deepseek.com".into()]).unwrap(),
+        root: root.into(),
+        probe: NodeProbeArgs {
+            node_name: "harness-proof-node".into(),
+            mote_store: root.join("motes"),
+            tool_store: root.join("tools"),
+            max_cells: 1,
+            memory_bytes: 268435456,
+            egress_slots: 1,
+        },
+        executions: Arc::new(Mutex::new(HashMap::new())),
+    };
+    let state = Arc::new(state);
+    let resolved =
+        crate::dispatch::resolve_bundle(&request, &state.probe.mote_store, &state.probe.tool_store)
+            .unwrap();
+    let admitted = crate::dispatch::closure::resolve(&request, &resolved, root).unwrap();
+    for change in ["caller", "tool", "grant"] {
+        let mut bad = request.clone();
+        match change {
+            "caller" => bad.workload.caller = "tenant:other".into(),
+            "tool" => {
+                bad.harness.as_mut().unwrap().borrowed_tools[0].hash = Hash::of(b"wrong tool").0
+            }
+            _ => bad.harness.as_mut().unwrap().model_grant.hash = Hash::of(b"unknown grant").0,
+        }
+        assert!(crate::dispatch::harness::resolve(&bad, admitted.as_ref(), root).is_err());
+    }
+    let (status, body) = http(
+        &state,
+        "POST",
+        "/v1/executions",
+        &serde_json::to_string(&request).unwrap(),
+    );
+    assert_eq!(status, 202, "{body}");
+    let deadline = Instant::now() + Duration::from_secs(190);
+    let terminal = loop {
+        let (_, body) = http(&state, "GET", "/v1/executions/harness-dispatch-proof", "");
+        if matches!(
+            body["phase"].as_str(),
+            Some("Succeeded" | "Failed" | "Refused" | "Cancelled")
+        ) {
+            break body;
+        }
+        assert!(Instant::now() < deadline, "dispatch deadline");
+        thread::sleep(Duration::from_millis(200));
+    };
+    assert_eq!(terminal["phase"], "Succeeded", "{terminal}");
+    assert_eq!(terminal["receipt"]["apiVersion"], "celln.dev/v1alpha2");
+    let events: Vec<Value> = terminal["output"]
+        .as_str()
+        .unwrap()
+        .lines()
+        .filter_map(|line| line.strip_prefix("CELLN_HARNESS_EVENT "))
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    let calls: Vec<_> = events.iter().filter(|e| e["type"] == "tool").collect();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0]["result"], "42\n");
+    assert_eq!(calls[1]["args"], json!(["42", "2"]));
+    assert_eq!(calls[1]["result"], "84\n");
+    assert!(events
+        .iter()
+        .any(|e| e["type"] == "completed" && e["answer"] == "84"));
+    let (_, audit) = http(
+        &state,
+        "GET",
+        "/v1/executions/harness-dispatch-proof/audit",
+        "",
+    );
+    assert_eq!(audit["execution"]["modelGrant"], grant_hash.0);
+    assert_eq!(audit["execution"]["broker"]["requests"], 3);
+    assert!(!serde_json::to_string(&audit)
+        .unwrap()
+        .contains(&token.display().to_string()));
+    // Emulate losing the in-memory registry: disk claim still refuses replay.
+    assert!(crate::dispatch::harness::claim(&request, root)
+        .unwrap_err()
+        .contains("already claimed"));
+    if let Some(hook) = hook {
+        controller_hook(&state, &request, &package, &namespace, &hook);
+    }
+    std::fs::remove_file(&grant_file).unwrap();
+    assert!(crate::dispatch::harness::resolve(&request, admitted.as_ref(), root).is_err());
+    let evidence = json!({"scope":"authenticated host HTTP dispatcher; not router/Sympozium/Kind","request":request,"terminal":terminal,"audit":audit,"callerMismatchDenied":true,"toolMismatchDenied":true,"unknownGrantDenied":true,"localReplayDenied":true,"grantWithdrawalDenied":true});
+    std::fs::write(
+        package.join("dispatch-evidence.json"),
+        serde_json::to_vec_pretty(&evidence).unwrap(),
+    )
+    .unwrap();
+    eprintln!(
+        "PASS: authenticated Harness dispatch; evidence {}",
+        package.join("dispatch-evidence.json").display()
+    );
+}

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -8,6 +8,9 @@
 use crate::NodeProbeArgs;
 #[path = "dispatch_audit.rs"]
 mod audit;
+#[cfg(all(test, target_os = "linux"))]
+#[path = "dispatch_harness_tests.rs"]
+mod harness_tests;
 use anyhow::{bail, Context, Result};
 use celln_spec::{
     ExecutionOutput, ExecutionPhase, ExecutionReceipt, ExecutionRequest, ResolvedExecution,
@@ -745,7 +748,7 @@ fn run_execution(
     let output = outcome.output.as_deref().filter(|bytes| !bytes.is_empty());
     let (phase, stored_output, reason) = collect_result(&outcome, &root.join("outputs"));
     let receipt = ExecutionReceipt {
-        api_version: "celln.dev/v1alpha1".into(),
+        api_version: request.api_version.clone(),
         request_id: request.id.clone(),
         phase,
         node: probe.node_name.clone(),

--- a/crates/celln-cli/src/dispatch_substrate.rs
+++ b/crates/celln-cli/src/dispatch_substrate.rs
@@ -97,6 +97,7 @@ pub(crate) fn launch_declared(
     let resolved = super::resolve_bundle(request, mote_root, tool_root)?;
     let local_agent = local_agent_constraint(&resolved.program_hash, state_root)?;
     let closure = super::closure::resolve(request, &resolved, state_root)?;
+    let harness = super::harness::resolve(request, closure.as_ref(), state_root)?;
     if !matches!(
         resolved.format.as_deref(),
         Some("celln.warm-static-v1" | "celln.warm-closure-v1")
@@ -131,7 +132,7 @@ pub(crate) fn launch_declared(
             "root": closure.as_ref().map(|_| "/tools"),
             "closure_members": closure.as_ref().map(|c| &c.signed.closure.members),
             "alias": invocation.alias,
-            "args": invocation.args, "expected_hash": resolved.program_hash,
+            "args": harness.as_ref().map_or(&invocation.args, |h|&h.args), "expected_hash": resolved.program_hash,
             "agent_authored_input": request.execution.lane == celln_spec::RequestedLane::Agent,
             "force_agent_lane": force_agent,
             "allow_fetch": !request.capabilities.egress.is_empty(),
@@ -171,6 +172,11 @@ pub(crate) fn launch_declared(
             Ok((cfg, resolved.toolfs_bytes.clone()))
         })?;
         cell.set_invocation(&run).map_err(|e| e.to_string())?;
+        // Re-read the operator grant after potentially slow warm preparation.
+        if let Some(h) = super::harness::resolve(request, closure.as_ref(), state_root)? {
+            super::harness::claim(request, state_root)?;
+            cell.enable_http_fetch(h.policy);
+        }
         let mut outcome = super::run_cell(request, &invocation.alias, cell, state_root)?;
         outcome.substrate = Some(identity);
         super::validate_executed_tool(&mut outcome, &resolved.program_hash);

--- a/crates/celln-cli/src/dispatch_warm.rs
+++ b/crates/celln-cli/src/dispatch_warm.rs
@@ -32,7 +32,7 @@ pub(super) fn evict() {
 pub(super) static PREPARATIONS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 #[cfg(test)]
-pub(super) static PROOF_LOCK: Mutex<()> = Mutex::new(());
+pub(crate) static PROOF_LOCK: Mutex<()> = Mutex::new(());
 
 pub(super) fn fork(
     key: String,

--- a/crates/celln-pilot/src/harness_proof.rs
+++ b/crates/celln-pilot/src/harness_proof.rs
@@ -23,10 +23,6 @@ fn main() -> Result<()> {
         std::env::var_os("CELLN_PILOT_DIR")
             .context("set CELLN_PILOT_DIR to static guest binaries")?,
     );
-    let token = PathBuf::from(
-        std::env::var_os("CELLN_MODEL_TOKEN_FILE")
-            .context("set CELLN_MODEL_TOKEN_FILE to a private host credential file")?,
-    );
     let work = std::env::temp_dir().join(format!("celln-harness-proof-{}", std::process::id()));
     std::fs::create_dir(&work)?;
     std::fs::copy(
@@ -118,6 +114,14 @@ fn main() -> Result<()> {
             .success(),
         "initrd build failed"
     );
+    if std::env::args().any(|arg| arg == "--package-only") {
+        println!("PACKAGED: {}", work.display());
+        return Ok(());
+    }
+    let token = PathBuf::from(
+        std::env::var_os("CELLN_MODEL_TOKEN_FILE")
+            .context("set CELLN_MODEL_TOKEN_FILE to a private host credential file")?,
+    );
     let kernel = BootConfig::host_kernel().context("no host kernel")?;
     let mut template = LinuxCell::boot(
         BootConfig::new(kernel)
@@ -149,6 +153,8 @@ fn main() -> Result<()> {
         {"name":"add","path":"/add","hash":members["/add"].hash,"description":"Add two integer strings; returns their sum."},
         {"name":"multiply","path":"/multiply","hash":members["/multiply"].hash,"description":"Multiply two integer strings; returns their product."}
     ]});
+    let mut config = config;
+    config["proof"] = true.into();
     cell.set_invocation(&serde_json::to_vec(&json!({"path":"/harness","alias":"/harness","root":"/tools","args":[config.to_string()],"force_agent_lane":true,"agent_authored_input":true,"allow_fetch":true,"expected_hash":members["/harness"].hash,"workspace_access":"none","closure_members":members}))?)?;
     let report = cell.run()?;
     std::fs::write(work.join("console.log"), &report.console)?;

--- a/crates/celln-pilot/src/harness_reference.rs
+++ b/crates/celln-pilot/src/harness_reference.rs
@@ -22,6 +22,8 @@ struct Config {
     url: String,
     model: String,
     tools: Vec<Tool>,
+    #[serde(default)]
+    proof: bool,
 }
 
 fn bounded_child(path: &str, args: &[String], input: Option<&[u8]>) -> Result<Vec<u8>> {
@@ -82,44 +84,46 @@ fn run() -> Result<()> {
             "lent code is writable"
         );
     }
-    // These files exist in the signed filesystem but have no member grant.
-    ensure!(
-        std::fs::read("/unselected").is_err(),
-        "unselected tool readable"
-    );
-    let refused = Command::new("/unselected")
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .status();
-    ensure!(
-        matches!(refused, Err(ref e) if e.raw_os_error() == Some(libc::EACCES)),
-        "unselected executable not denied by confinement"
-    );
-    ensure!(
-        std::fs::read("/provider-token").is_err(),
-        "provider credential visible"
-    );
-    println!(
-        "CELLN_HARNESS_EVENT {}",
-        json!({"type":"negative-checks","unselected":"EACCES","toolWrites":"denied"})
-    );
-    for (field, value, reason) in [
-        ("model", json!("unapproved-model"), "model not granted"),
-        (
-            "max_tokens",
-            json!(513),
-            "model output token limit exceeded",
-        ),
-        ("n", json!(2), "unsupported model request parameters"),
-        (
-            "stream",
-            json!(true),
-            "unsupported model request parameters",
-        ),
-    ] {
-        let mut body = json!({"model":config.model,"stream":false,"max_tokens":512,"messages":[{"role":"user","content":"budget probe"}]});
-        body[field] = value;
-        prove_model_denial(&config.url, body, reason)?;
+    if config.proof {
+        // These files exist in the signed filesystem but have no member grant.
+        ensure!(
+            std::fs::read("/unselected").is_err(),
+            "unselected tool readable"
+        );
+        let refused = Command::new("/unselected")
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .status();
+        ensure!(
+            matches!(refused, Err(ref e) if e.raw_os_error() == Some(libc::EACCES)),
+            "unselected executable not denied by confinement"
+        );
+        ensure!(
+            std::fs::read("/provider-token").is_err(),
+            "provider credential visible"
+        );
+        println!(
+            "CELLN_HARNESS_EVENT {}",
+            json!({"type":"negative-checks","unselected":"EACCES","toolWrites":"denied"})
+        );
+        for (field, value, reason) in [
+            ("model", json!("unapproved-model"), "model not granted"),
+            (
+                "max_tokens",
+                json!(513),
+                "model output token limit exceeded",
+            ),
+            ("n", json!(2), "unsupported model request parameters"),
+            (
+                "stream",
+                json!(true),
+                "unsupported model request parameters",
+            ),
+        ] {
+            let mut body = json!({"model":config.model,"stream":false,"max_tokens":512,"messages":[{"role":"user","content":"budget probe"}]});
+            body[field] = value;
+            prove_model_denial(&config.url, body, reason)?;
+        }
     }
     let definitions: Vec<Value> = config.tools.iter().map(|t| json!({"type":"function","function":{
         "name":t.name,"description":t.description,"parameters":{"type":"object","properties":{"args":{"type":"array","items":{"type":"string"},"minItems":2,"maxItems":2}},"required":["args"],"additionalProperties":false}
@@ -170,11 +174,13 @@ fn run() -> Result<()> {
                 "model stopped before using lent tools"
             );
             let answer = message["content"].as_str().context("no final answer")?;
-            prove_model_denial(
-                &config.url,
-                json!({"model":config.model,"stream":false,"max_tokens":512,"messages":[{"role":"user","content":"budget probe"}]}),
-                "model cumulative output budget exhausted",
-            )?;
+            if config.proof {
+                prove_model_denial(
+                    &config.url,
+                    json!({"model":config.model,"stream":false,"max_tokens":512,"messages":[{"role":"user","content":"budget probe"}]}),
+                    "model cumulative output budget exhausted",
+                )?;
+            }
             println!(
                 "CELLN_HARNESS_EVENT {}",
                 json!({"type":"completed","answer":answer,"toolsUsed":used,"calls":calls})

--- a/crates/celln-spec/src/harness.rs
+++ b/crates/celln-spec/src/harness.rs
@@ -1,0 +1,130 @@
+use super::*;
+use std::collections::BTreeSet;
+
+/// Experimental text/two-integer-function adapter. Runtime identity is the
+/// enclosing request's single executable and signed precomposed closure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HarnessBinding {
+    pub contract_version: String,
+    pub model_grant: ImmutableRef,
+    pub model: String,
+    pub task: String,
+    pub borrowed_tools: Vec<BorrowedTool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BorrowedTool {
+    pub name: String,
+    pub path: String,
+    pub hash: String,
+    pub description: String,
+}
+
+fn path(value: &str) -> bool {
+    value.starts_with('/')
+        && value.len() <= 256
+        && value[1..].split('/').all(|p| {
+            !p.is_empty()
+                && p != "."
+                && p != ".."
+                && p.bytes()
+                    .all(|c| c.is_ascii_alphanumeric() || b"-_.+".contains(&c))
+        })
+}
+
+pub(super) fn valid(request: &ExecutionRequest) -> bool {
+    let Some(h) = &request.harness else {
+        return request.api_version != "celln.dev/v1alpha2";
+    };
+    let mut names = BTreeSet::new();
+    let mut paths = BTreeSet::new();
+    request.api_version == "celln.dev/v1alpha2"
+        && h.contract_version == "celln.reference-functions/v1"
+        && is_immutable_hash(&h.model_grant.hash)
+        && !h.model.is_empty()
+        && h.model.len() <= 128
+        && !h.task.trim().is_empty()
+        && h.task.len() <= 2048
+        && !h.task.contains('\0')
+        && request.mote.is_some()
+        && request.forge.is_none()
+        && request.inputs.is_empty()
+        && request.tools.len() == 1
+        && request.tools[0].closure.is_some()
+        && request
+            .invocation
+            .as_ref()
+            .is_some_and(|i| i.args.is_empty())
+        && request.execution.lane == RequestedLane::Agent
+        && request.execution.require_hardware_isolation
+        && request.capabilities.workspace == WorkspaceAccess::None
+        && request.capabilities.egress.len() == 1
+        && h.borrowed_tools.len() == 2
+        && h.borrowed_tools.iter().all(|t| {
+            !t.name.is_empty()
+                && t.name.len() <= 64
+                && t.name
+                    .bytes()
+                    .all(|c| c.is_ascii_alphanumeric() || b"_-".contains(&c))
+                && names.insert(&t.name)
+                && paths.insert(&t.path)
+                && path(&t.path)
+                && is_immutable_hash(&t.hash)
+                && !t.description.is_empty()
+                && t.description.len() <= 512
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    fn wire() -> serde_json::Value {
+        let hash = format!("blake3:{}", "a".repeat(64));
+        json!({"apiVersion":"celln.dev/v1alpha2","id":"r","workload":{"id":"r","caller":"controller:test"},
+            "mote":{"hash":hash},"tools":[{"alias":"/harness","hash":hash,"closure":{"hash":hash}}],"invocation":{"alias":"/harness"},
+            "capabilities":{"workspace":"none","egress":["https://api.deepseek.com"],"timeoutMs":180000,"memoryBytes":268435456,"outputBytes":65536},"execution":{"lane":"agent","requireHardwareIsolation":true},
+            "harness":{"contractVersion":"celln.reference-functions/v1","modelGrant":{"hash":hash},"model":"deepseek-chat","task":"use both tools","borrowedTools":[{"name":"add","path":"/add","hash":hash,"description":"add"},{"name":"multiply","path":"/multiply","hash":hash,"description":"multiply"}]}})
+    }
+    #[test]
+    fn versioned_binding_is_strict_and_bounded() {
+        let value = wire();
+        assert!(serde_json::from_value::<ExecutionRequest>(value.clone())
+            .unwrap()
+            .problems()
+            .is_empty());
+        for (pointer, replacement) in [
+            ("/apiVersion", json!("celln.dev/v1alpha1")),
+            ("/harness/contractVersion", json!("arbitrary-oci")),
+            ("/harness/modelGrant/hash", json!("../secret")),
+            ("/harness/task", json!("x".repeat(2049))),
+            ("/harness/borrowedTools/1/path", json!("/add")),
+            ("/harness/borrowedTools/1/name", json!("add")),
+            ("/harness/borrowedTools/1/path", json!("/../secret")),
+            ("/capabilities/workspace", json!("read-write")),
+            ("/capabilities/egress", json!([])),
+            ("/execution/lane", json!("tool")),
+        ] {
+            let mut bad = value.clone();
+            *bad.pointer_mut(pointer).unwrap() = replacement;
+            assert!(
+                !serde_json::from_value::<ExecutionRequest>(bad)
+                    .unwrap()
+                    .problems()
+                    .is_empty(),
+                "{pointer}"
+            );
+        }
+        let mut missing = value.clone();
+        missing.as_object_mut().unwrap().remove("harness");
+        assert!(!serde_json::from_value::<ExecutionRequest>(missing)
+            .unwrap()
+            .problems()
+            .is_empty());
+        let mut injected = value;
+        injected["harness"]["credentialFile"] = json!("/etc/secret");
+        assert!(serde_json::from_value::<ExecutionRequest>(injected).is_err());
+    }
+}

--- a/crates/celln-spec/src/lib.rs
+++ b/crates/celln-spec/src/lib.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+mod harness;
+pub use harness::{BorrowedTool, HarnessBinding};
+
 /// A cell specification.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -199,6 +202,8 @@ pub struct ExecutionRequest {
     pub api_version: String,
     pub id: String,
     pub workload: WorkloadIdentity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness: Option<HarnessBinding>,
     /// The declared mote/tool source. Exactly one of `mote` or `forge` must
     /// be set — a request either names a pre-declared, hash-pinned program,
     /// or asks for one to be written. See [`ExecutionRequest::problems`].
@@ -401,6 +406,7 @@ pub enum ExecutionProblemCode {
     InvalidEgress,
     InvalidLimit,
     InvalidForge,
+    InvalidHarness,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -415,12 +421,18 @@ impl ExecutionRequest {
     /// availability are deliberately separate decisions made by the node agent.
     pub fn problems(&self) -> Vec<ExecutionProblem> {
         let mut problems = Vec::new();
-        if self.api_version != "celln.dev/v1alpha1" {
+        if !matches!(
+            self.api_version.as_str(),
+            "celln.dev/v1alpha1" | "celln.dev/v1alpha2"
+        ) {
             problems.push(ExecutionProblem {
                 code: ExecutionProblemCode::UnsupportedVersion,
                 field: "apiVersion".into(),
-                message: "must be celln.dev/v1alpha1".into(),
+                message: "must be celln.dev/v1alpha1 or celln.dev/v1alpha2".into(),
             });
+        }
+        if !harness::valid(self) {
+            problems.push(ExecutionProblem { code: ExecutionProblemCode::InvalidHarness, field:"harness".into(), message:"v1alpha2 requires a bounded declared reference Harness binding; v1alpha1 forbids one".into() });
         }
         for (field, value) in [
             ("id", self.id.as_str()),
@@ -623,7 +635,10 @@ impl ExecutionReceipt {
     /// Validate a result before a control plane records or forwards it.
     pub fn problems(&self) -> Vec<ExecutionProblem> {
         let mut problems = Vec::new();
-        if self.api_version != "celln.dev/v1alpha1" {
+        if !matches!(
+            self.api_version.as_str(),
+            "celln.dev/v1alpha1" | "celln.dev/v1alpha2"
+        ) {
             problems.push(ExecutionProblem {
                 code: ExecutionProblemCode::UnsupportedVersion,
                 field: "apiVersion".into(),

--- a/docs/HARNESS_DISPATCH.md
+++ b/docs/HARNESS_DISPATCH.md
@@ -1,0 +1,131 @@
+# Experimental reference Harness dispatch
+
+Tracks [Sympozium #426](https://github.com/sympozium-ai/sympozium/issues/426).
+Measured 2026-09-07: **actual Sympozium controller → isolated Kind Kubernetes
+API → authenticated host dispatcher → warm-forked cell → DeepSeek → two lent
+executable tools → persisted AgentRun result/receipt** passed.
+
+This is an advanced one-shot reference adapter, not the completed runtime/tool
+catalogue UX, Pi/Hermes support, persistent HarnessSession or deployed router /
+DaemonSet topology. The model loop is inside the cell, not in the controller.
+
+## Versioned binding
+
+`celln.dev/v1alpha1` requests and receipts retain their existing semantics.
+`celln.dev/v1alpha2` requires a `harness` object containing:
+
+- `contractVersion: celln.reference-functions/v1`: text-only reference loop,
+  exactly two static executable tools accepting two i32 string arguments.
+- `modelGrant.hash`: exact BLAKE3 revision of an operator-owned grant.
+- `model`: the selected provider alias, checked against that grant.
+- `task`: at most 2,048 bytes of data, never executable authority.
+- `borrowedTools`: exactly two unique names/paths, hashes and descriptions.
+
+The enclosing mote and single `tools` entry identify the runtime and signed
+precomposed closure. The closure must contain exactly the runtime, `/pilot-fetch`
+and the two declared tools. Dependencies outside this static profile refuse.
+Each member is hash-checked by pilot before execution; no arbitrary uploaded
+binary becomes trusted just because it is named in the request.
+
+Only agent lane, no workspace/inputs/forge, no invocation arguments, and one
+HTTPS origin are supported. Ordinary v1alpha1 closure-egress and multi-tool
+refusals remain. The new path constructs the runtime's configuration from the
+validated binding; callers cannot inject proof mode or arbitrary runtime args.
+See [example request](../examples/execution/harness-reference.json). Its measured
+artifact references must be replaced with locally provisioned/admitted ones;
+the example does not install authority or include a credential.
+
+## Independent host admission
+
+The operator places a bounded JSON grant in
+`STATE/trusted-harness/<64-hex-blake3>.json`. Hash the exact file bytes to obtain
+the request's `modelGrant.hash`. This is a privileged policy directory, **not**
+an uploadable artifact store. Existing independent mote, publisher/closure and
+local revocation checks also apply.
+
+Grant fields (`camelCase`, unknown fields refuse):
+
+| Field | Binding |
+|---|---|
+| `apiVersion` | `celln.dev/harness-grant-v1` |
+| `caller`, `mote`, `runtime`, `closure` | Exact controller caller and immutable identities |
+| `borrowedTools` | Exact ordered tool definitions from the request |
+| `url`, `model` | Requested HTTPS origin + `/chat/completions`, exact model alias |
+| `credentialFile` | Absolute operator-owned host path, never sent to guest |
+| `maxRequests` | 1–6 requests per cell |
+| `maxOutputTokens` | 512 for this initial adapter |
+| `maxTotalOutputTokens` | 512–3,072 reserved output tokens per cell |
+
+The grant is verified again after warm preparation. Model authority is attached
+only to the forked cell, never the reusable warm mote. Removal/replacement of
+the grant refuses subsequent launches. Host credential files still reload per
+request. This is not live model-grant withdrawal during a running call.
+
+A synced, exclusive-create tombstone under `STATE/harness-attempts/` records the
+caller/request-ID pair before provider authority can be used. Local restart or
+registry eviction cannot replay that attempt with fresh allowance. Failures are
+conservative: an ambiguous attempt needs operator reconciliation, not automatic
+replay. Tombstones are retained. **This is not distributed deduplication or
+tenant/currency metering**; do not advertise safe failover to a different state
+root/node. Operational retention/recovery and fleet coordination remain open.
+
+Receipt v1alpha2 has the existing receipt shape and identifies the primary
+runtime; it does not pretend every selected tool was invoked. Correlated audit
+records the sealed closure/member graph and `modelGrant` revision, without task
+data or credential paths. Runtime-emitted tool-call events are transcript
+evidence, not separately hardware-attested per-tool receipts.
+
+## Actual proof
+
+[Committed evidence](evidence/harness-dispatch-controller-2026-09-07.json)
+contains the direct HTTP test and the actual controller run, including model
+response IDs, tool calls, runtime/closure identities, frozen request, matching
+terminal receipt/audit and controller executable SHA256. It records the tested
+working-tree state honestly; the original base revision is not presented as
+containing this implementation.
+
+The controller run used `add(37,5) → 42`, then `multiply(42,2) → 84`, with three
+model calls and final answer `84`. No Kubernetes Job was created; the audit
+recorded dissolution and the node reported zero live cells afterward. The
+owned namespace and temporary provider credential copy were removed. Kind
+remains running; Framework was untouched.
+
+Negative binding coverage: wrong caller, model, runtime, tool, unknown/tampered
+grant, local replay and grant withdrawal refuse. Existing guest sealing/broker
+escalation proofs remain separate evidence. `make ci`, Sympozium `go build ./...`
+and controller/API/webhook/orchestrator tests (including race tests) passed.
+
+## Reproduce (explicitly billable)
+
+Build static guest binaries as in [the reference proof](HARNESS_BORROWED_TOOLS_PROOF.md).
+Set `CELLN_PILOT_DIR` to that build directory, then package without model I/O:
+
+```sh
+cargo run -p celln-pilot --features kvm --bin celln-harness-proof -- --package-only
+```
+
+Use the printed directory and a private authorized host credential file:
+
+```sh
+CELLN_HARNESS_PACKAGE=/path/to/printed/package \
+CELLN_MODEL_TOKEN_FILE=/private/provider-token \
+cargo test -p celln-cli harness_model_over_authenticated_dispatch -- --ignored --nocapture
+```
+
+To also exercise the actual Sympozium controller, set
+`CELLN_HARNESS_CONTROLLER_HOOK` to the paired Sympozium checkout's
+`test/integration/test-celln-harness-controller.sh`, and
+`CELLN_CONTROLLER_KUBECONFIG` to the isolated `kind-celln-m0` kubeconfig. The hook
+updates CRDs only in that explicitly selected cluster, creates an owned test
+namespace, runs the built controller on the host, and cleans up its namespace
+and process. Evidence stays in the package directory. It makes three additional
+model requests. No default kubeconfig or production context is accepted.
+
+## Remaining main-goal work
+
+The Sympozium advanced binding is disabled by default. Before broad exposure:
+bind approved AgentRuntime and user-selected tools through an admission/catalogue
+workflow; implement the selection UX; prove authenticated router/DaemonSet
+execution on Kind; define fleet retry/cancellation/revocation and conversational
+lifecycle; and complete adversarial/product acceptance in the epic. A narrow
+two-integer-function adapter is not general-purpose Harness compatibility.

--- a/docs/HARNESS_EXECUTION_REQUIREMENTS.md
+++ b/docs/HARNESS_EXECUTION_REQUIREMENTS.md
@@ -29,6 +29,12 @@ requested runtime and authority are actually delivered.
 
 ## Current baseline and gaps
 
+Latest progress: [versioned Harness dispatch](HARNESS_DISPATCH.md) now has an
+actual Sympozium AgentRun/controller + in-cell model/tool proof on the isolated
+Kind API and authenticated host dispatcher. The shipped-selector and deployed
+router/DaemonSet gates remain open; the baseline limitations below describe
+v1alpha1, not the new narrow experimental v1alpha2 binding.
+
 Prototype progress: the [borrowed-tools reference proof](HARNESS_BORROWED_TOOLS_PROOF.md)
 now demonstrates a real model/tool/result loop inside a warm-forked cell with
 two separately hashed executables. This does not remove the baseline production

--- a/docs/evidence/harness-dispatch-controller-2026-09-07.json
+++ b/docs/evidence/harness-dispatch-controller-2026-09-07.json
@@ -1,0 +1,382 @@
+{
+  "measuredAt": "2026-09-07",
+  "sourceState": "working-tree implementation recorded in the accompanying PRs; summary revision is the pre-change base",
+  "dispatcher": {
+    "audit": {
+      "apiVersion": "celln.dev/audit-v1alpha1",
+      "caller": "sympozium:celln-harness-proof-1719787/harness-proof",
+      "events": [
+        {
+          "at": "2026-09-07T09:28:19Z",
+          "phase": "Admitting",
+          "sequence": 0
+        },
+        {
+          "at": "2026-09-07T09:28:19Z",
+          "phase": "Resolving",
+          "sequence": 1
+        },
+        {
+          "at": "2026-09-07T09:28:22Z",
+          "phase": "CellRunning",
+          "sequence": 2
+        },
+        {
+          "at": "2026-09-07T09:28:25Z",
+          "phase": "Dissolved",
+          "sequence": 3
+        },
+        {
+          "at": "2026-09-07T09:28:25Z",
+          "phase": "Succeeded",
+          "sequence": 4
+        }
+      ],
+      "execution": {
+        "broker": {
+          "denied": 0,
+          "requests": 3,
+          "responseBytes": 1710
+        },
+        "cellId": "6c4545198cda",
+        "exitCode": 0,
+        "granted": {
+          "egress": [
+            "https://api.deepseek.com"
+          ],
+          "memoryBytes": 268435456,
+          "outputBytes": 65536,
+          "timeoutMs": 180000,
+          "workspace": "none"
+        },
+        "inputs": [],
+        "modelGrant": "blake3:db2860a06e9003d1cab7908eb325ae517e1fe5fcc96d0991de105bb94d9a1796",
+        "pilot": {
+          "fetch": true,
+          "lane": "agent",
+          "tool": "blake3:7e41c9ea4ea3553de6d835f22a3a411cd6367263d5f3c0a14e885218d657b626",
+          "workspace": "none"
+        },
+        "signal": null,
+        "substrate": {
+          "closure": {
+            "hash": "blake3:93a643e7783169183bf1906be2269412aca0a505470d65f88b24fcee34903bef",
+            "members": {
+              "/add": {
+                "dependencies": [],
+                "hash": "blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020"
+              },
+              "/harness": {
+                "dependencies": [
+                  "/add",
+                  "/multiply",
+                  "/pilot-fetch"
+                ],
+                "hash": "blake3:7e41c9ea4ea3553de6d835f22a3a411cd6367263d5f3c0a14e885218d657b626"
+              },
+              "/multiply": {
+                "dependencies": [],
+                "hash": "blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1"
+              },
+              "/pilot-fetch": {
+                "dependencies": [],
+                "hash": "blake3:9afcf605962e29d25fd95fcd3d3a719210f644cd1ee0893ff3d5578eeb86888e"
+              }
+            },
+            "publisher": "df20a7b76d8b78331f72a085af34b1bc3af43e2eee8004630ec2d850edf571c3",
+            "toolfs": "blake3:aeda5bd5171aa26ae0bbd722e578a5418490d8420a6ed6c76b8a812fee7fddad"
+          },
+          "initrd": "blake3:1707294872258b71bbda52ecd51736a3c07ccab939e3224627b7690250d1473d",
+          "invocation": "blake3:c80ce29ea4e97933e7d18c58d7124178103d292615cea56e29f577dfb2ff8c4b",
+          "kernel": "blake3:93f20d4f258dcf1a567faa54fa5b125a8b55433f5af381ee08530bdd50c78048",
+          "toolfs": "blake3:aeda5bd5171aa26ae0bbd722e578a5418490d8420a6ed6c76b8a812fee7fddad"
+        },
+        "watchdogStopped": false
+      },
+      "node": "harness-proof-node",
+      "receipt": {
+        "apiVersion": "celln.dev/v1alpha2",
+        "cellId": "6c4545198cda",
+        "completedAt": "2026-09-07T09:28:25Z",
+        "node": "harness-proof-node",
+        "output": {
+          "bytes": 1396,
+          "hash": "blake3:57b551e5d95dafdf353e799d279225b7f1d70fc801180792c5942778531fce42",
+          "mediaType": "application/octet-stream"
+        },
+        "phase": "succeeded",
+        "requestId": "harness-dispatch-proof",
+        "resolved": {
+          "inputs": [],
+          "mote": "blake3:2f781f8922e2971f0d4c1dd5e1cf237977985e3d8eddc9fa557930d69bff2530",
+          "tools": [
+            "blake3:7e41c9ea4ea3553de6d835f22a3a411cd6367263d5f3c0a14e885218d657b626"
+          ]
+        },
+        "startedAt": "2026-09-07T09:28:19Z"
+      },
+      "requestId": "harness-dispatch-proof",
+      "workload": "test-run"
+    },
+    "callerMismatchDenied": true,
+    "grantWithdrawalDenied": true,
+    "localReplayDenied": true,
+    "request": {
+      "apiVersion": "celln.dev/v1alpha2",
+      "capabilities": {
+        "egress": [
+          "https://api.deepseek.com"
+        ],
+        "memoryBytes": 268435456,
+        "outputBytes": 65536,
+        "timeoutMs": 180000,
+        "workspace": "none"
+      },
+      "execution": {
+        "lane": "agent",
+        "requireHardwareIsolation": true
+      },
+      "forge": null,
+      "harness": {
+        "borrowedTools": [
+          {
+            "description": "Add two integer strings.",
+            "hash": "blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020",
+            "name": "add",
+            "path": "/add"
+          },
+          {
+            "description": "Multiply two integer strings.",
+            "hash": "blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1",
+            "name": "multiply",
+            "path": "/multiply"
+          }
+        ],
+        "contractVersion": "celln.reference-functions/v1",
+        "model": "deepseek-chat",
+        "modelGrant": {
+          "hash": "blake3:db2860a06e9003d1cab7908eb325ae517e1fe5fcc96d0991de105bb94d9a1796"
+        },
+        "task": "Use add with args [\"37\",\"5\"], wait for its result, then multiply that result by \"2\". Reply with exactly the final integer."
+      },
+      "id": "harness-dispatch-proof",
+      "inputs": [],
+      "invocation": {
+        "alias": "/harness",
+        "args": []
+      },
+      "mote": {
+        "hash": "blake3:2f781f8922e2971f0d4c1dd5e1cf237977985e3d8eddc9fa557930d69bff2530"
+      },
+      "tools": [
+        {
+          "alias": "/harness",
+          "closure": {
+            "hash": "blake3:93a643e7783169183bf1906be2269412aca0a505470d65f88b24fcee34903bef"
+          },
+          "hash": "blake3:7e41c9ea4ea3553de6d835f22a3a411cd6367263d5f3c0a14e885218d657b626"
+        }
+      ],
+      "workload": {
+        "caller": "sympozium:celln-harness-proof-1719787/harness-proof",
+        "id": "test-run"
+      }
+    },
+    "scope": "authenticated host HTTP dispatcher; not router/Sympozium/Kind",
+    "terminal": {
+      "output": "CELLN_HARNESS_EVENT {\"id\":\"fc00efd2-5ac1-455e-9311-e7a0be63e702\",\"model\":\"deepseek-v4-flash\",\"turn\":0,\"type\":\"model\",\"usage\":{\"completion_tokens\":40,\"prompt_cache_hit_tokens\":384,\"prompt_cache_miss_tokens\":25,\"prompt_tokens\":409,\"prompt_tokens_details\":{\"cached_tokens\":384},\"total_tokens\":449}}\nCELLN_HARNESS_EVENT {\"args\":[\"37\",\"5\"],\"hash\":\"blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020\",\"id\":\"call_00_kyIABs68imdajsuf5oOl7827\",\"name\":\"add\",\"result\":\"42\\n\",\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"id\":\"d81fa5f5-024b-4056-8fdd-e88b1a0bfe99\",\"model\":\"deepseek-v4-flash\",\"turn\":1,\"type\":\"model\",\"usage\":{\"completion_tokens\":41,\"prompt_cache_hit_tokens\":384,\"prompt_cache_miss_tokens\":86,\"prompt_tokens\":470,\"prompt_tokens_details\":{\"cached_tokens\":384},\"total_tokens\":511}}\nCELLN_HARNESS_EVENT {\"args\":[\"42\",\"2\"],\"hash\":\"blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1\",\"id\":\"call_00_kDsqZXnGbnI9pOAp36XH2196\",\"name\":\"multiply\",\"result\":\"84\\n\",\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"id\":\"efc8b958-b4a1-45e4-9911-1bd7ace25b20\",\"model\":\"deepseek-v4-flash\",\"turn\":2,\"type\":\"model\",\"usage\":{\"completion_tokens\":1,\"prompt_cache_hit_tokens\":512,\"prompt_cache_miss_tokens\":13,\"prompt_tokens\":525,\"prompt_tokens_details\":{\"cached_tokens\":512},\"total_tokens\":526}}\nCELLN_HARNESS_EVENT {\"answer\":\"84\",\"calls\":2,\"toolsUsed\":[\"add\",\"multiply\"],\"type\":\"completed\"}\n",
+      "phase": "Succeeded",
+      "receipt": {
+        "apiVersion": "celln.dev/v1alpha2",
+        "cellId": "6c4545198cda",
+        "completedAt": "2026-09-07T09:28:25Z",
+        "node": "harness-proof-node",
+        "output": {
+          "bytes": 1396,
+          "hash": "blake3:57b551e5d95dafdf353e799d279225b7f1d70fc801180792c5942778531fce42",
+          "mediaType": "application/octet-stream"
+        },
+        "phase": "succeeded",
+        "requestId": "harness-dispatch-proof",
+        "resolved": {
+          "inputs": [],
+          "mote": "blake3:2f781f8922e2971f0d4c1dd5e1cf237977985e3d8eddc9fa557930d69bff2530",
+          "tools": [
+            "blake3:7e41c9ea4ea3553de6d835f22a3a411cd6367263d5f3c0a14e885218d657b626"
+          ]
+        },
+        "startedAt": "2026-09-07T09:28:19Z"
+      },
+      "requestId": "harness-dispatch-proof"
+    },
+    "toolMismatchDenied": true,
+    "unknownGrantDenied": true
+  },
+  "controller": {
+    "summary": {
+      "status": "passed",
+      "scope": "actual host controller + isolated Kind API + authenticated host dispatcher + KVM; not deployed router topology",
+      "revision": "88a432cad3c976978b4d62f01244ea8b66b6471e",
+      "controllerSha256": "b66247dbf0c3b21f7c0232921b1944037e133a347984dbaa49e33a0f997a1458",
+      "dirty": true
+    },
+    "run": {
+      "name": "harness-proof",
+      "namespace": "celln-harness-proof-1719787",
+      "uid": "b29d1c38-36f4-4a68-8591-95f24cce4c1c",
+      "status": {
+        "cellnActionId": "harness-proof-b29d1c38-36f4-4a68-8591-95f24cce4c1c",
+        "cellnReceipt": "{\"apiVersion\":\"celln.dev/v1alpha2\",\"requestId\":\"harness-proof-b29d1c38-36f4-4a68-8591-95f24cce4c1c\",\"phase\":\"succeeded\",\"node\":\"harness-proof-node\",\"startedAt\":\"2026-09-07T09:28:34Z\",\"completedAt\":\"2026-09-07T09:28:36Z\",\"cellId\":\"4bf8c38c936a\",\"resolved\":{\"mote\":\"blake3:2f781f8922e2971f0d4c1dd5e1cf237977985e3d8eddc9fa557930d69bff2530\",\"tools\":[\"blake3:7e41c9ea4ea3553de6d835f22a3a411cd6367263d5f3c0a14e885218d657b626\"],\"inputs\":[]},\"output\":{\"hash\":\"blake3:473f166fd9d24e9e3662b7c358ee6550310befd321b9ffcf66fa4808757220ac\",\"mediaType\":\"application/octet-stream\",\"bytes\":1396}}",
+        "cellnRequest": "{\"harness\":{\"contractVersion\":\"celln.reference-functions/v1\",\"modelGrant\":{\"hash\":\"blake3:db2860a06e9003d1cab7908eb325ae517e1fe5fcc96d0991de105bb94d9a1796\"},\"model\":\"deepseek-chat\",\"task\":\"Use add with args [\\\"37\\\",\\\"5\\\"], wait for its result, then multiply that result by \\\"2\\\". Reply with exactly the final integer.\",\"borrowedTools\":[{\"name\":\"add\",\"path\":\"/add\",\"hash\":\"blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020\",\"description\":\"Add two integer strings.\"},{\"name\":\"multiply\",\"path\":\"/multiply\",\"hash\":\"blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1\",\"description\":\"Multiply two integer strings.\"}]},\"apiVersion\":\"celln.dev/v1alpha2\",\"id\":\"harness-proof-b29d1c38-36f4-4a68-8591-95f24cce4c1c\",\"workload\":{\"id\":\"reference\",\"caller\":\"sympozium:celln-harness-proof-1719787/harness-proof\"},\"mote\":{\"hash\":\"blake3:2f781f8922e2971f0d4c1dd5e1cf237977985e3d8eddc9fa557930d69bff2530\"},\"tools\":[{\"alias\":\"/harness\",\"hash\":\"blake3:7e41c9ea4ea3553de6d835f22a3a411cd6367263d5f3c0a14e885218d657b626\",\"closure\":{\"hash\":\"blake3:93a643e7783169183bf1906be2269412aca0a505470d65f88b24fcee34903bef\"}}],\"invocation\":{\"alias\":\"/harness\"},\"capabilities\":{\"workspace\":\"none\",\"egress\":[\"https://api.deepseek.com\"],\"timeoutMs\":180000,\"memoryBytes\":268435456,\"outputBytes\":65536},\"execution\":{\"lane\":\"agent\",\"requireHardwareIsolation\":true}}",
+        "completedAt": "2026-09-07T09:28:39Z",
+        "phase": "Succeeded",
+        "result": "CELLN_HARNESS_EVENT {\"id\":\"b8a4fe7d-8fa7-4b6a-af9b-841515e815a4\",\"model\":\"deepseek-v4-flash\",\"turn\":0,\"type\":\"model\",\"usage\":{\"completion_tokens\":40,\"prompt_cache_hit_tokens\":384,\"prompt_cache_miss_tokens\":25,\"prompt_tokens\":409,\"prompt_tokens_details\":{\"cached_tokens\":384},\"total_tokens\":449}}\nCELLN_HARNESS_EVENT {\"args\":[\"37\",\"5\"],\"hash\":\"blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020\",\"id\":\"call_00_LGwwmbCbEXGi7cvW2zmc9064\",\"name\":\"add\",\"result\":\"42\\n\",\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"id\":\"99fdfcdf-4284-4efb-8211-6128bde1a427\",\"model\":\"deepseek-v4-flash\",\"turn\":1,\"type\":\"model\",\"usage\":{\"completion_tokens\":41,\"prompt_cache_hit_tokens\":384,\"prompt_cache_miss_tokens\":86,\"prompt_tokens\":470,\"prompt_tokens_details\":{\"cached_tokens\":384},\"total_tokens\":511}}\nCELLN_HARNESS_EVENT {\"args\":[\"42\",\"2\"],\"hash\":\"blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1\",\"id\":\"call_00_pgTLv7gASqImReg912sM8140\",\"name\":\"multiply\",\"result\":\"84\\n\",\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"id\":\"6ac4ce76-f862-4e0e-8cb4-0d6c74ce3e8f\",\"model\":\"deepseek-v4-flash\",\"turn\":2,\"type\":\"model\",\"usage\":{\"completion_tokens\":1,\"prompt_cache_hit_tokens\":512,\"prompt_cache_miss_tokens\":13,\"prompt_tokens\":525,\"prompt_tokens_details\":{\"cached_tokens\":512},\"total_tokens\":526}}\nCELLN_HARNESS_EVENT {\"answer\":\"84\",\"calls\":2,\"toolsUsed\":[\"add\",\"multiply\"],\"type\":\"completed\"}\n",
+        "startedAt": "2026-09-07T09:28:34Z"
+      }
+    },
+    "audit": {
+      "apiVersion": "celln.dev/audit-v1alpha1",
+      "requestId": "harness-proof-b29d1c38-36f4-4a68-8591-95f24cce4c1c",
+      "caller": "sympozium:celln-harness-proof-1719787/harness-proof",
+      "workload": "reference",
+      "node": "harness-proof-node",
+      "events": [
+        {
+          "sequence": 0,
+          "at": "2026-09-07T09:28:34Z",
+          "phase": "Admitting"
+        },
+        {
+          "sequence": 1,
+          "at": "2026-09-07T09:28:34Z",
+          "phase": "Resolving"
+        },
+        {
+          "sequence": 2,
+          "at": "2026-09-07T09:28:34Z",
+          "phase": "CellRunning"
+        },
+        {
+          "sequence": 3,
+          "at": "2026-09-07T09:28:36Z",
+          "phase": "Dissolved"
+        },
+        {
+          "sequence": 4,
+          "at": "2026-09-07T09:28:36Z",
+          "phase": "Succeeded"
+        }
+      ],
+      "execution": {
+        "cellId": "4bf8c38c936a",
+        "substrate": {
+          "closure": {
+            "hash": "blake3:93a643e7783169183bf1906be2269412aca0a505470d65f88b24fcee34903bef",
+            "publisher": "df20a7b76d8b78331f72a085af34b1bc3af43e2eee8004630ec2d850edf571c3",
+            "toolfs": "blake3:aeda5bd5171aa26ae0bbd722e578a5418490d8420a6ed6c76b8a812fee7fddad",
+            "members": {
+              "/add": {
+                "hash": "blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020",
+                "dependencies": []
+              },
+              "/harness": {
+                "hash": "blake3:7e41c9ea4ea3553de6d835f22a3a411cd6367263d5f3c0a14e885218d657b626",
+                "dependencies": [
+                  "/add",
+                  "/multiply",
+                  "/pilot-fetch"
+                ]
+              },
+              "/multiply": {
+                "hash": "blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1",
+                "dependencies": []
+              },
+              "/pilot-fetch": {
+                "hash": "blake3:9afcf605962e29d25fd95fcd3d3a719210f644cd1ee0893ff3d5578eeb86888e",
+                "dependencies": []
+              }
+            }
+          },
+          "kernel": "blake3:93f20d4f258dcf1a567faa54fa5b125a8b55433f5af381ee08530bdd50c78048",
+          "initrd": "blake3:1707294872258b71bbda52ecd51736a3c07ccab939e3224627b7690250d1473d",
+          "toolfs": "blake3:aeda5bd5171aa26ae0bbd722e578a5418490d8420a6ed6c76b8a812fee7fddad",
+          "invocation": "blake3:c80ce29ea4e97933e7d18c58d7124178103d292615cea56e29f577dfb2ff8c4b"
+        },
+        "pilot": {
+          "tool": "blake3:7e41c9ea4ea3553de6d835f22a3a411cd6367263d5f3c0a14e885218d657b626",
+          "lane": "agent",
+          "workspace": "none",
+          "fetch": true
+        },
+        "granted": {
+          "workspace": "none",
+          "egress": [
+            "https://api.deepseek.com"
+          ],
+          "timeoutMs": 180000,
+          "memoryBytes": 268435456,
+          "outputBytes": 65536
+        },
+        "modelGrant": "blake3:db2860a06e9003d1cab7908eb325ae517e1fe5fcc96d0991de105bb94d9a1796",
+        "inputs": [],
+        "broker": {
+          "requests": 3,
+          "denied": 0,
+          "responseBytes": 1710
+        },
+        "exitCode": 0,
+        "signal": null,
+        "watchdogStopped": false
+      },
+      "receipt": {
+        "apiVersion": "celln.dev/v1alpha2",
+        "requestId": "harness-proof-b29d1c38-36f4-4a68-8591-95f24cce4c1c",
+        "phase": "succeeded",
+        "node": "harness-proof-node",
+        "cellId": "4bf8c38c936a",
+        "resolved": {
+          "mote": "blake3:2f781f8922e2971f0d4c1dd5e1cf237977985e3d8eddc9fa557930d69bff2530",
+          "tools": [
+            "blake3:7e41c9ea4ea3553de6d835f22a3a411cd6367263d5f3c0a14e885218d657b626"
+          ],
+          "inputs": []
+        },
+        "output": {
+          "hash": "blake3:473f166fd9d24e9e3662b7c358ee6550310befd321b9ffcf66fa4808757220ac",
+          "mediaType": "application/octet-stream",
+          "bytes": 1396
+        },
+        "startedAt": "2026-09-07T09:28:34Z",
+        "completedAt": "2026-09-07T09:28:36Z"
+      }
+    },
+    "nodeAfter": {
+      "availability_is_advisory": true,
+      "configured_egress_slots": 1,
+      "configured_memory_bytes": 268435456,
+      "node": {
+        "cpu_virtualization": true,
+        "egress_slots": 1,
+        "guest_kernel": true,
+        "kvm": true,
+        "live_cells": 0,
+        "max_cells": 1,
+        "memory_bytes": 268435456,
+        "mote_store": true,
+        "node_name": "harness-proof-node",
+        "tool_store": true
+      },
+      "preflight_only": true,
+      "warm": [
+        {
+          "guest_memory_bytes": 268435456,
+          "mote": "blake3:2f781f8922e2971f0d4c1dd5e1cf237977985e3d8eddc9fa557930d69bff2530",
+          "tools": [
+            "blake3:7e41c9ea4ea3553de6d835f22a3a411cd6367263d5f3c0a14e885218d657b626"
+          ]
+        }
+      ]
+    },
+    "jobsCreated": 0
+  }
+}

--- a/examples/execution/harness-reference.json
+++ b/examples/execution/harness-reference.json
@@ -1,0 +1,61 @@
+{
+  "apiVersion": "celln.dev/v1alpha2",
+  "id": "reference-harness-example",
+  "workload": {
+    "id": "reference",
+    "caller": "sympozium:example/harness-run"
+  },
+  "harness": {
+    "contractVersion": "celln.reference-functions/v1",
+    "modelGrant": {
+      "hash": "blake3:db2860a06e9003d1cab7908eb325ae517e1fe5fcc96d0991de105bb94d9a1796"
+    },
+    "model": "deepseek-chat",
+    "task": "Use add with args [\"37\",\"5\"], wait for its result, then multiply that result by \"2\". Reply with exactly the final integer.",
+    "borrowedTools": [
+      {
+        "name": "add",
+        "path": "/add",
+        "hash": "blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020",
+        "description": "Add two integer strings."
+      },
+      {
+        "name": "multiply",
+        "path": "/multiply",
+        "hash": "blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1",
+        "description": "Multiply two integer strings."
+      }
+    ]
+  },
+  "mote": {
+    "hash": "blake3:2f781f8922e2971f0d4c1dd5e1cf237977985e3d8eddc9fa557930d69bff2530"
+  },
+  "inputs": [],
+  "tools": [
+    {
+      "alias": "/harness",
+      "hash": "blake3:7e41c9ea4ea3553de6d835f22a3a411cd6367263d5f3c0a14e885218d657b626",
+      "closure": {
+        "hash": "blake3:93a643e7783169183bf1906be2269412aca0a505470d65f88b24fcee34903bef"
+      }
+    }
+  ],
+  "invocation": {
+    "alias": "/harness",
+    "args": []
+  },
+  "forge": null,
+  "capabilities": {
+    "workspace": "none",
+    "egress": [
+      "https://api.deepseek.com"
+    ],
+    "timeoutMs": 180000,
+    "memoryBytes": 268435456,
+    "outputBytes": 65536
+  },
+  "execution": {
+    "lane": "agent",
+    "requireHardwareIsolation": true
+  }
+}


### PR DESCRIPTION
Stacked on #73; implements the narrow v1alpha2 dispatch binding for sympozium-ai/sympozium#426.

Runtime is an independently admitted mote + signed static closure. Explicit borrowed tool definitions and selected model must match a content-pinned operator grant. Grant directory is not an uploadable store; credentials remain host-only. Model authority attaches only after warm fork. A retained local attempt tombstone refuses ambiguous replay after registry loss. Existing v1alpha1 refusal guards remain; only the narrow reference-functions profile uses the new path.

Proof: authenticated HTTP dispatcher test passed. Paired actual Sympozium controller (feat/celln-harness-binding) also reconciled an AgentRun against isolated Kind, ran the in-cell DeepSeek add/multiply loop, persisted matching v1alpha2 receipt/result, and reclaimed the cell without creating a Job. Frozen request, provider IDs, tool results, correlated audit and controller hash are committed in docs/evidence/harness-dispatch-controller-2026-09-07.json. Tested working-tree provenance is labelled explicitly.

Validation: make ci, negative binding/replay tests, real KVM/model dispatcher and controller proofs. Temporary credential copy and owned test namespace removed.

Not production completion: no deployed router/DaemonSet proof, runtime/tool catalogue UX, arbitrary OCI/Pi/Hermes compatibility, fleet deduplication, live model-grant withdrawal or persistent sessions. See docs/HARNESS_DISPATCH.md.