### PR TITLE
fix(router): retain execution ownership and refuse ambiguous replay

### DIFF
--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -124,6 +124,9 @@ enum Cmd {
         /// Both files are reread per request so rotation does not need a restart.
         #[arg(long)]
         client_token_file: PathBuf,
+        /// Durable owner ledger shared by all router replicas (coherent POSIX locks required).
+        #[arg(long)]
+        ownership_dir: PathBuf,
     },
 
     /// Work with cell specs.
@@ -413,6 +416,7 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             mode,
             token_file,
             client_token_file,
+            ownership_dir,
         } => router::serve(
             listen,
             backends.to_vec(),
@@ -420,6 +424,7 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             *mode,
             token_file,
             client_token_file,
+            ownership_dir,
         ),
         Cmd::Node(NodeCmd::Probe { probe }) => node::probe(probe, &root),
         Cmd::Node(NodeCmd::Admit { request, probe }) => node::admit_file(request, probe, &root),

--- a/crates/celln-cli/src/router.rs
+++ b/crates/celln-cli/src/router.rs
@@ -1,7 +1,8 @@
 //! Authenticated router that distributes actions across Celln dispatcher
 //! backends. Each backend is a Celln process with a `/v1/health` endpoint that
 //! reports KVM availability. The router picks a backend, checks its health,
-//! and forwards if healthy; otherwise it tries the next.
+//! and forwards if healthy; otherwise it tries the next BEFORE claiming an
+//! owner. Claimed executions are never reselected or automatically replayed.
 //!
 //! The router is intentionally not a load tracker. It relies on per-node
 //! admission ("can this node spawn another cell?") via the health check.
@@ -12,15 +13,16 @@ use crate::dispatch_http::{
 };
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::io::{BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 const ROUTER_TOKEN_BYTES: usize = 24;
+#[path = "router_ownership.rs"]
+mod ownership;
 
 // Credentials are bounded and never echoed in errors. Reload on each request
 // to support atomic file/Secret rotation; an unreadable file fails closed.
@@ -84,6 +86,7 @@ pub fn serve(
     mode: RoutingMode,
     token_file: &Path,
     client_token_file: &Path,
+    ownership_dir: &Path,
 ) -> Result<u8> {
     let mut urls: Vec<String> = backends
         .into_iter()
@@ -121,7 +124,7 @@ pub fn serve(
         backends: urls.clone(),
         mode,
         cursor: AtomicUsize::new(0),
-        executions: Mutex::new(HashMap::new()),
+        executions: ownership::Ledger::open(ownership_dir, 100_000)?,
         token_file: token_file.to_owned(),
         client_token_file: client_token_file.to_owned(),
     });
@@ -151,9 +154,8 @@ struct RouterState {
     backends: Vec<String>,
     mode: RoutingMode,
     cursor: AtomicUsize,
-    /// Which backend owns each in-flight `/v1/executions` id, so a later
-    /// GET can find it.
-    executions: Mutex<HashMap<String, String>>,
+    /// Shared durable ownership and anti-replay tombstones.
+    executions: ownership::Ledger,
     token_file: PathBuf,
     client_token_file: PathBuf,
 }
@@ -265,7 +267,6 @@ fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
             &mut reader,
             length,
             "/v1/executions",
-            &state.executions,
             &backend_token,
         )?,
         ("POST", path) if execution_path_id(path, true).is_some() => {
@@ -290,15 +291,14 @@ fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
 
 /// `POST <endpoint>`: pick a healthy backend deterministically by the
 /// request's own `id` field, forward the body verbatim, and — on
-/// acceptance — remember which backend owns that id so a later poll can
-/// find it.
+/// before forwarding — durably bind the body and owner. Lost responses must
+/// not let another router replica replay a possibly executed POST.
 fn forward_submission(
     state: &RouterState,
     stream: &mut TcpStream,
     reader: &mut BufReader<TcpStream>,
     length: usize,
     endpoint: &str,
-    tracker: &Mutex<HashMap<String, String>>,
     token: &Option<String>,
 ) -> Result<()> {
     if length == 0 || length > 64 * 1024 {
@@ -322,18 +322,49 @@ fn forward_submission(
         }
     };
 
-    let backend = pick_backend(state, &id, token)?;
-    let resp = forward_post(&backend, endpoint, &body, token)?;
-    let status = parse_status(&resp);
-
-    if status == 202 || status == 200 {
-        tracker
-            .lock()
-            .expect("router tracking map not poisoned")
-            .insert(id, backend);
+    let claim = match state
+        .executions
+        .claim(&id, &body, || pick_backend(state, &id, token))
+    {
+        Ok(claim) => claim,
+        Err(_) => {
+            return reply(
+                stream,
+                503,
+                &serde_json::json!({"error":"ownership unavailable; retry same request without changing id"}),
+            )
+        }
+    };
+    match claim {
+        ownership::Claim::Conflict => reply(
+            stream,
+            409,
+            &serde_json::json!({"error":"execution id already binds different request bytes"}),
+        ),
+        ownership::Claim::Full => reply(
+            stream,
+            503,
+            &serde_json::json!({"error":"ownership capacity exhausted; operator reconciliation required"}),
+        ),
+        ownership::Claim::Existing(owner) => forward_owned(
+            state,
+            stream,
+            &owner.backend,
+            "GET",
+            &format!("/v1/executions/{id}"),
+            token,
+        ),
+        ownership::Claim::New(owner) => {
+            match forward_post(&owner.backend, endpoint, &body, token) {
+                Ok(resp) => raw_reply(stream, &resp),
+                Err(_) => reply(
+                    stream,
+                    503,
+                    &serde_json::json!({"error":"submission outcome unknown; owner retained; POST will not be replayed"}),
+                ),
+            }
+        }
     }
-
-    raw_reply(stream, &resp)
 }
 
 /// `GET <endpoint>/:id`: forward to whichever backend `forward_submission`
@@ -347,25 +378,52 @@ fn forward_existing(
     token: &Option<String>,
 ) -> Result<()> {
     let id = execution_path_id(path, cancel).context("invalid execution path")?;
-    let backend = state
-        .executions
-        .lock()
-        .expect("router tracking map not poisoned")
-        .get(id)
-        .cloned();
-    match backend {
-        Some(backend_url) => {
-            let resp = if method == "POST" {
-                forward_post(&backend_url, path, &[], token)?
-            } else {
-                forward_get(&backend_url, path, token)?
-            };
-            raw_reply(stream, &resp)
+    let backend = match state.executions.lookup(id) {
+        Ok(owner) => owner,
+        Err(_) => {
+            return reply(
+                stream,
+                503,
+                &serde_json::json!({"error":"execution ownership unavailable"}),
+            )
         }
+    };
+    match backend {
+        Some(owner) => forward_owned(state, stream, &owner.backend, method, path, token),
         None => reply(
             stream,
             404,
             &serde_json::json!({"error": "unknown execution"}),
+        ),
+    }
+}
+
+fn forward_owned(
+    state: &RouterState,
+    stream: &mut TcpStream,
+    backend: &str,
+    method: &str,
+    path: &str,
+    token: &Option<String>,
+) -> Result<()> {
+    if !state.backends.iter().any(|url| url == backend) {
+        return reply(
+            stream,
+            503,
+            &serde_json::json!({"error":"recorded owner removed from configured backends; no reroute"}),
+        );
+    }
+    let response = if method == "POST" {
+        forward_post(backend, path, &[], token)
+    } else {
+        forward_get(backend, path, token)
+    };
+    match response {
+        Ok(resp) if parse_status(&resp) != 404 => raw_reply(stream, &resp),
+        _ => reply(
+            stream,
+            503,
+            &serde_json::json!({"error":"recorded owner unavailable or outcome lost; no reroute or replay"}),
         ),
     }
 }
@@ -382,6 +440,7 @@ fn execution_path_id(path: &str, cancel: bool) -> Option<&str> {
 
 fn valid_path_id(id: &str) -> bool {
     !id.is_empty()
+        && id.len() <= 512
         && id != "."
         && id != ".."
         && id
@@ -406,7 +465,7 @@ fn pick_backend(state: &RouterState, action_id: &str, token: &Option<String>) ->
 
     for offset in 0..n {
         let backend = &state.backends[(start + offset) % n];
-        if is_healthy(backend, token)? {
+        if is_healthy(backend, token).unwrap_or(false) {
             return Ok(backend.clone());
         }
     }
@@ -613,6 +672,101 @@ mod tests {
     const CLIENT_TOKEN: &str = "client-test-credential-at-least-24";
     const BACKEND_TOKEN: &str = "backend-test-credential-at-least-24";
 
+    #[test]
+    fn lost_acceptance_is_not_replayed_and_fresh_replica_recovers_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut first = state(dir.path());
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let backend = format!("http://{}", listener.local_addr().unwrap());
+        first.backends.push(backend.clone());
+        let server = std::thread::spawn(move || {
+            // Any second POST /v1/executions would violate this transcript.
+            for (method, path, status) in [
+                ("GET", "/v1/health", 200),
+                ("POST", "/v1/executions", 0),
+                ("GET", "/v1/executions/lost", 200),
+                ("GET", "/v1/executions/lost", 200),
+                ("GET", "/v1/executions/lost/audit", 200),
+                ("POST", "/v1/executions/lost/cancel", 202),
+            ] {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                assert_eq!(
+                    read_bounded_line(&mut reader, MAX_REQUEST_LINE).unwrap(),
+                    format!("{method} {path} HTTP/1.1\r\n")
+                );
+                let mut length = 0;
+                loop {
+                    let line = read_bounded_line(&mut reader, MAX_HEADER_LINE).unwrap();
+                    if line == "\r\n" {
+                        break;
+                    }
+                    if let Some(n) = line.strip_prefix("Content-Length: ") {
+                        length = n.trim().parse().unwrap();
+                    }
+                }
+                let mut body = vec![0; length];
+                reader.read_exact(&mut body).unwrap();
+                if status == 0 {
+                    continue;
+                } // accepted backend work, lost reply
+                let payload = if path == "/v1/health" {
+                    r#"{"ok":true,"kvm":true}"#
+                } else {
+                    r#"{"requestId":"lost","phase":"Running"}"#
+                };
+                write!(stream,"HTTP/1.1 {status} OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",payload.len()).unwrap();
+            }
+        });
+        let auth = format!("Authorization: Bearer {CLIENT_TOKEN}\r\n");
+        let body = r#"{"id":"lost"}"#;
+        let headers = format!("{auth}Content-Length: {}\r\n", body.len());
+        assert_eq!(
+            parse_status(&request(&first, "POST", "/v1/executions", &headers, body)),
+            503
+        );
+        drop(first);
+        let mut replica = state(dir.path());
+        replica.backends = vec!["http://127.0.0.1:1".into(), backend];
+        assert_eq!(
+            parse_status(&request(&replica, "POST", "/v1/executions", &headers, body)),
+            200
+        );
+        for path in ["/v1/executions/lost", "/v1/executions/lost/audit"] {
+            assert_eq!(
+                parse_status(&request(&replica, "GET", path, &auth, "")),
+                200
+            );
+        }
+        assert_eq!(
+            parse_status(&request(
+                &replica,
+                "POST",
+                "/v1/executions/lost/cancel",
+                &auth,
+                ""
+            )),
+            202
+        );
+        server.join().unwrap();
+        // A lost node does not send this request to the spare backend.
+        assert_eq!(
+            parse_status(&request(&replica, "POST", "/v1/executions", &headers, body)),
+            503
+        );
+        let changed = r#"{"id":"lost","task":"changed"}"#;
+        assert_eq!(
+            parse_status(&request(
+                &replica,
+                "POST",
+                "/v1/executions",
+                &format!("{auth}Content-Length: {}\r\n", changed.len()),
+                changed
+            )),
+            409
+        );
+    }
+
     fn state(dir: &Path) -> RouterState {
         let client_token_file = dir.join("client");
         let token_file = dir.join("backend");
@@ -622,7 +776,7 @@ mod tests {
             backends: vec![],
             mode: RoutingMode::RoundRobin,
             cursor: AtomicUsize::new(0),
-            executions: Mutex::new(HashMap::new()),
+            executions: ownership::Ledger::open(&dir.join("ownership"), 100).unwrap(),
             token_file,
             client_token_file,
         }

--- a/crates/celln-cli/src/router_ownership.rs
+++ b/crates/celln-cli/src/router_ownership.rs
@@ -1,0 +1,195 @@
+//! Durable, shared owner binding. Requires a POSIX filesystem with coherent
+//! flock, atomic rename and fsync semantics across every router replica.
+use anyhow::{bail, Context, Result};
+use celln_manifest::Hash;
+use serde::{Deserialize, Serialize};
+use std::{
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Owner {
+    version: u8,
+    pub backend: String,
+    body_hash: String,
+}
+
+pub(super) struct Ledger {
+    dir: PathBuf,
+    capacity: usize,
+}
+pub(super) enum Claim {
+    New(Owner),
+    Existing(Owner),
+    Conflict,
+    Full,
+}
+
+impl Ledger {
+    pub fn open(dir: &Path, capacity: usize) -> Result<Self> {
+        if capacity == 0 {
+            bail!("ownership capacity must be positive");
+        }
+        std::fs::create_dir_all(dir).context("creating router ownership directory")?;
+        // Persist newly created directory links as well as subsequent records.
+        // A filesystem that refuses directory fsync is not this backend.
+        let canonical = std::fs::canonicalize(dir)?;
+        for ancestor in canonical.ancestors() {
+            std::fs::File::open(ancestor)?
+                .sync_all()
+                .context("Unsupported: ownership filesystem must support directory fsync")?;
+        }
+        Ok(Self {
+            dir: dir.into(),
+            capacity,
+        })
+    }
+    fn path(&self, id: &str) -> PathBuf {
+        self.dir.join(format!(
+            "{}.json",
+            Hash::of(id.as_bytes()).0.trim_start_matches("blake3:")
+        ))
+    }
+    pub fn lookup(&self, id: &str) -> Result<Option<Owner>> {
+        let file = match std::fs::File::open(self.path(id)) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+        let mut bytes = Vec::new();
+        file.take(4097).read_to_end(&mut bytes)?;
+        if bytes.len() > 4096 {
+            bail!("invalid owner record");
+        }
+        let owner: Owner = serde_json::from_slice(&bytes).context("invalid owner record")?;
+        if owner.version != 1 || owner.backend.len() > 1024 {
+            bail!("unsupported owner record");
+        }
+        super::backend_to_addr(&owner.backend)?;
+        Ok(Some(owner))
+    }
+    pub fn claim(
+        &self,
+        id: &str,
+        body: &[u8],
+        choose: impl FnOnce() -> Result<String>,
+    ) -> Result<Claim> {
+        let _lock = self.lock()?;
+        let body_hash = Hash::of(body).0;
+        if let Some(owner) = self.lookup(id)? {
+            return Ok(if owner.body_hash == body_hash {
+                Claim::Existing(owner)
+            } else {
+                Claim::Conflict
+            });
+        }
+        let count = std::fs::read_dir(&self.dir)?
+            .filter(|entry| {
+                entry
+                    .as_ref()
+                    .map_or(true, |e| e.path().extension().is_some_and(|s| s == "json"))
+            })
+            .take(self.capacity)
+            .count();
+        if count >= self.capacity {
+            return Ok(Claim::Full);
+        }
+        let owner = Owner {
+            version: 1,
+            backend: choose()?,
+            body_hash,
+        };
+        if owner.backend.len() > 1024 {
+            bail!("backend URL exceeds owner record bound");
+        }
+        let mut staged = tempfile::NamedTempFile::new_in(&self.dir)?;
+        serde_json::to_writer(&mut staged, &owner)?;
+        staged.flush()?;
+        staged.as_file().sync_all()?;
+        staged
+            .persist_noclobber(self.path(id))
+            .map_err(|e| e.error)?;
+        std::fs::File::open(&self.dir)?.sync_all()?;
+        // Publication is durable BEFORE any side-effecting POST. A crash in
+        // the following gap is ambiguous and must not authorize replay.
+        Ok(Claim::New(owner))
+    }
+    #[cfg(target_os = "linux")]
+    fn lock(&self) -> Result<std::fs::File> {
+        use std::os::fd::AsRawFd;
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(self.dir.join("ownership.lock"))?;
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+            bail!("ownership ledger busy or locking unsupported");
+        }
+        Ok(file)
+    }
+    #[cfg(not(target_os = "linux"))]
+    fn lock(&self) -> Result<std::fs::File> {
+        bail!("Unsupported: router ownership requires Linux flock");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn replicas_restart_conflicts_and_capacity_are_durable() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = Ledger::open(dir.path(), 1).unwrap();
+        assert!(matches!(
+            a.claim("id", b"original", || Ok("http://node-a:8787".into()))
+                .unwrap(),
+            Claim::New(_)
+        ));
+        let b = Ledger::open(dir.path(), 1).unwrap();
+        assert_eq!(
+            b.lookup("id").unwrap().unwrap().backend,
+            "http://node-a:8787"
+        );
+        assert!(matches!(
+            b.claim("id", b"original", || panic!("must not reselect owner"))
+                .unwrap(),
+            Claim::Existing(_)
+        ));
+        assert!(matches!(
+            b.claim("id", b"changed", || panic!("must not contact backend"))
+                .unwrap(),
+            Claim::Conflict
+        ));
+        assert!(matches!(
+            b.claim("new", b"new", || panic!("full ledger")).unwrap(),
+            Claim::Full
+        ));
+        drop(a);
+        drop(b);
+        assert_eq!(
+            Ledger::open(dir.path(), 1)
+                .unwrap()
+                .lookup("id")
+                .unwrap()
+                .unwrap()
+                .backend,
+            "http://node-a:8787"
+        );
+    }
+    #[test]
+    fn lock_contention_and_corruption_refuse() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = Ledger::open(dir.path(), 10).unwrap();
+        let guard = a.lock().unwrap();
+        let b = Ledger::open(dir.path(), 10).unwrap();
+        assert!(b.claim("x", b"x", || panic!("locked")).is_err());
+        drop(guard);
+        std::fs::write(a.path("x"), b"partial").unwrap();
+        assert!(a
+            .claim("x", b"x", || panic!("corrupt owner cannot be replaced"))
+            .is_err());
+    }
+}

--- a/docs/ROUTER_OWNERSHIP.md
+++ b/docs/ROUTER_OWNERSHIP.md
@@ -1,0 +1,80 @@
+# Router ownership and ambiguous submissions (M0)
+
+Tracks [Sympozium epic #426](https://github.com/sympozium-ai/sympozium/issues/426).
+This increment builds on inbound authentication/cancellation in Celln PR #70.
+It is not the full deployed-path acceptance gate.
+
+## Contract
+
+`celln route` now requires `--ownership-dir`. All replicas must mount the same
+durable operator-controlled POSIX filesystem, with coherent `flock`, atomic
+publication and directory/file `fsync` across those replicas. Per-pod emptyDir
+or independent per-node hostPath directories do **not** meet this requirement.
+This storage contract must be verified on the selected deployment backend;
+local tests do not certify a Kubernetes storage driver or multi-host filesystem.
+
+The router uses an exclusive nonblocking filesystem lock while creating a new
+owner record. It writes and syncs the selected backend and request-body hash,
+publishes the record atomically, and syncs its directory **before** forwarding
+the first POST. Concurrent lock contention returns 503 rather than waiting
+indefinitely. IDs are bounded to 512 safe ASCII path-component bytes; filenames
+are content hashes, not request-provided paths. Records contain neither bearer
+tokens nor task bodies. Only operators may write the ledger.
+
+| Event | Behavior |
+|---|---|
+| First request ID | Choose a healthy backend, durably claim, send POST once |
+| Same ID and exact request bytes | Poll the recorded backend; never send another execution POST |
+| Same ID, changed bytes | 409 before contacting any backend |
+| Lost acceptance response | 503; owner retained; retry recovers by polling |
+| Fresh router replica/restart | Read owner from shared ledger for retry, poll, audit and cancellation |
+| Owner unavailable or dispatcher lost its record | 503; no reroute/replay |
+| Owner removed from configured backends | 503; do not forward credentials to the removed endpoint |
+| Corrupt/unreadable ledger or unsupported locking/sync | Refuse, never manufacture a fresh owner |
+
+Health-based fallback is allowed only **before** ownership exists. Backend
+order or routing-mode changes do not move an existing execution. All replicas
+must retain the same authorized backend set while old executions need access.
+Backend URLs must identify stable dispatcher endpoints; changing DNS/IP reuse,
+TLS/proxy identity and deployment topology remain operator/deployment concerns.
+
+The dispatcher remains responsible for actual cell admission, immutable
+artifact checks, execution, cancellation, and receipts. Retrying a cancellation
+request is allowed; replaying an execution POST is not. This avoids duplicate
+model/tool side effects at the cost of conservative refusal when a crash occurs
+between durable claim and dispatch. It does not claim exactly-once external
+effects or automatic recovery of an ambiguous provider transaction.
+
+## Retention and operations
+
+The ledger has a hard limit of 100,000 owner/tombstone records. Existing IDs
+remain routable at capacity; new IDs receive 503. It is not an unbounded memory
+map. No automatic expiry deletes replay protection. **Do not purge the ledger
+as routine cleanup or during an upgrade.** Preserve/back up the mounted state
+with the dispatcher state and keep replicas on compatible schemas.
+
+Administrative reclamation needs a confirmed request-ID retirement boundary:
+no client may retry retired IDs, and external effects must be reconciled first.
+That lifecycle/GC protocol is not implemented here. Capacity exhaustion requires
+operator reconciliation; blindly deleting old records permits duplicate work.
+Storage-driver qualification, a chart/PVC topology, verifiable rollout/rollback,
+terminal retention and distributed node-loss tests remain M0 work. This CLI
+change requires coordinated chart arguments/volumes before deployment.
+
+## Evidence (2026-09-07)
+
+Actual TCP protocol tests deliberately accept an execution at a backend and
+drop its response. A fresh router state using the same disk ledger and reordered
+backends retries by GET, polls, fetches audit and forwards cancellation. The
+backend's expected transcript permits exactly one execution POST. After that
+backend stops, the router refuses rather than submitting to the spare. Changed
+request bytes return 409.
+
+Additional tests cover reload across fresh ledger instances, bounded capacity,
+nonblocking lock contention and corrupt records. Existing inbound missing/wrong/
+rotated credential, cancellation and parser-bound tests remain green.
+Run `cargo test -p celln-cli router::` and `make ci`.
+
+These are local TCP/filesystem correctness tests, not a KVM, shared-volume,
+multi-node failover or deployed Sympozium proof. Keep the epic open until the
+actual controller → Service/router → dispatcher → KVM release gates pass.


### PR DESCRIPTION
M0 continuation for sympozium-ai/sympozium#426; stacked on #70.

Replaces the in-memory owner map with a bounded durable ownership ledger. Required --ownership-dir must be shared by replicas on an operator-controlled filesystem with coherent POSIX locking/publication/fsync. Owner and request-body hash are persisted before the first execution POST. Same-ID retries poll the recorded owner, never replay POST. Changed bytes return 409. Lost owner/outcome returns 503 with no failover. Removed backends are not contacted.

Actual TCP test drops the acceptance response, recreates router state with reordered backends, then recovers status/audit/cancellation; expected backend transcript permits exactly one execution POST. Node loss and changed bodies refuse. Ledger tests cover restart, capacity, lock contention and corruption. make ci passed.

Explicit limits: local filesystem/TCP evidence, not shared-volume or deployed Kubernetes acceptance. Chart needs coordinated ownership volume/argument changes. 100000-record bound retains tombstones; automatic GC and administrative request-ID retirement remain unfinished. No exactly-once external-effects claim. See docs/ROUTER_OWNERSHIP.md. Keep M0/epic open.