### PR TITLE
fix(dispatcher): persist execution claims receipts and audits across restart

### DIFF
--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -11,12 +11,14 @@ mod audit;
 #[cfg(all(test, target_os = "linux"))]
 #[path = "dispatch_harness_tests.rs"]
 mod harness_tests;
+#[path = "dispatch_journal.rs"]
+mod journal;
 use anyhow::{bail, Context, Result};
 use celln_spec::{
     ExecutionOutput, ExecutionPhase, ExecutionReceipt, ExecutionRequest, ResolvedExecution,
 };
 use celln_store::Store;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
@@ -34,9 +36,8 @@ pub(crate) const MAX_REQUEST_LINE: usize = 8 * 1024;
 pub(crate) const MAX_HEADER_LINE: usize = 8 * 1024;
 pub(crate) const MAX_HEADER_COUNT: usize = 64;
 
-/// How long a finished execution record is kept before it is evicted on the
-/// next insert. The registry is otherwise unbounded — every unique id a
-/// caller submits stays in memory for the life of the process.
+/// Terminal memory-cache TTL only. Durable records/tombstones are not expired;
+/// new admission stops at the journal's bounded record capacity.
 const RECORD_TTL: Duration = Duration::from_secs(3600);
 
 /// Read one line with a hard byte cap, so a peer that never sends `\n`
@@ -90,15 +91,15 @@ fn read_headers(reader: &mut impl BufRead) -> Result<(usize, Option<String>)> {
     Ok((length, authorization))
 }
 
-/// A registry entry tagged with its insertion time, so a background sweep
-/// can evict entries older than [`RECORD_TTL`]. The registry is otherwise
-/// unbounded for the life of the process.
+/// A registry entry with terminal cache age. Admission sweeps expired terminal
+/// entries only after persistence; active or unpersisted records remain live.
 struct Entry<T> {
     at: Instant,
     value: T,
     control: Option<celln_control::Control>,
     reservation: Option<Reservation>,
     audit: Option<audit::Audit>,
+    journal_root: Option<PathBuf>,
 }
 
 impl<T> Entry<T> {
@@ -109,6 +110,7 @@ impl<T> Entry<T> {
             control: None,
             reservation: None,
             audit: None,
+            journal_root: None,
         }
     }
 }
@@ -116,14 +118,19 @@ impl<T> Entry<T> {
 fn evict_expired(registry: &mut HashMap<String, Entry<ExecutionRecord>>) {
     let now = Instant::now();
     registry.retain(|_, entry| {
-        execution_is_active(&entry.value) || now.duration_since(entry.at) < RECORD_TTL
+        execution_is_active(&entry.value)
+            || now.duration_since(entry.at) < RECORD_TTL
+            || entry.journal_root.as_ref().is_some_and(|root| {
+                !journal::read(root, &entry.value.request_id)
+                    .is_ok_and(|snapshot| snapshot.is_some_and(|s| !execution_is_active(&s.record)))
+            })
     });
 }
 
 /// One `celln.dev/v1alpha1` execution in flight or finished on this node.
 /// This is the dispatcher's own bookkeeping, not the wire receipt — it has
 /// room for a human-readable reason a receipt does not.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecutionRecord {
     pub request_id: String,
@@ -298,6 +305,7 @@ pub fn serve(
     // Reservations are process-local. Two dispatchers must not independently
     // advertise the same state root's capacity while neither has a cell yet.
     let _ownership = own_dispatch_root(&root)?;
+    journal::prepare(&root)?;
     let listener = TcpListener::bind(listen_address)
         .with_context(|| format!("binding dispatcher {listen_address}"))?;
     let state = Arc::new(State {
@@ -482,6 +490,32 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
                 .executions
                 .lock()
                 .expect("dispatcher registry not poisoned");
+            match journal::read(&state.root, &request.id) {
+                Ok(Some(snapshot)) => {
+                    if snapshot.request_hash != celln_manifest::Hash::of(&body).0 {
+                        return reply(
+                            &mut stream,
+                            409,
+                            &serde_json::json!({"error":"execution id already bound to different request bytes"}),
+                        );
+                    }
+                    if let Some(existing) = registry.get(&request.id) {
+                        if execution_is_active(&existing.value) {
+                            return reply(&mut stream, 202, &existing.value);
+                        }
+                        return reply_entry(&mut stream, existing, false);
+                    }
+                    return reply_snapshot(&mut stream, snapshot, false);
+                }
+                Ok(None) => {}
+                Err(_) => {
+                    return reply(
+                        &mut stream,
+                        503,
+                        &serde_json::json!({"error":"execution journal unavailable; do not replay"}),
+                    )
+                }
+            }
             if let Some(existing) = registry.get(&request.id) {
                 return reply(&mut stream, 202, &existing.value);
             }
@@ -514,6 +548,21 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
             entry.control = Some(control.clone());
             entry.reservation = Some(Reservation::for_request(&request));
             entry.audit = Some(audit::Audit::new(&request, &state.probe.node_name));
+            if journal::claim(
+                &state.root,
+                &body,
+                &entry.value,
+                entry.audit.as_ref().unwrap(),
+            )
+            .is_err()
+            {
+                return reply(
+                    &mut stream,
+                    503,
+                    &serde_json::json!({"error":"durable admission unavailable; retry same id"}),
+                );
+            }
+            entry.journal_root = Some(state.root.clone());
             registry.insert(request.id.clone(), entry);
             drop(registry);
             let worker_executions = Arc::clone(&state.executions);
@@ -555,11 +604,7 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
                 .lock()
                 .expect("dispatcher registry not poisoned");
             let Some(entry) = registry.get_mut(id) else {
-                return reply(
-                    &mut stream,
-                    404,
-                    &serde_json::json!({"error": "unknown execution"}),
-                );
+                return reply_archived(&mut stream, state, id, false);
             };
             if execution_is_active(&entry.value) {
                 if let Some(control) = &entry.control {
@@ -574,7 +619,7 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
                 // subprocesses, VM handles and preparation state.
                 reply(&mut stream, 202, &entry.value)
             } else {
-                reply(&mut stream, 200, &entry.value)
+                reply_entry(&mut stream, entry, false)
             }
         }
         ("GET", path) if path.starts_with("/v1/executions/") && path.ends_with("/audit") => {
@@ -583,13 +628,9 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
                 .executions
                 .lock()
                 .expect("dispatcher registry not poisoned");
-            match registry.get(id).and_then(|entry| entry.audit.as_ref()) {
-                Some(audit) => reply(&mut stream, 200, audit),
-                None => reply(
-                    &mut stream,
-                    404,
-                    &serde_json::json!({"error": "unknown execution audit"}),
-                ),
+            match registry.get(id) {
+                Some(entry) => reply_entry(&mut stream, entry, true),
+                None => reply_archived(&mut stream, state, id, true),
             }
         }
         ("GET", path) if path.starts_with("/v1/executions/") => {
@@ -599,15 +640,77 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
                 .lock()
                 .expect("dispatcher registry not poisoned");
             match registry.get(id) {
-                Some(entry) => reply(&mut stream, 200, &entry.value),
-                None => reply(
-                    &mut stream,
-                    404,
-                    &serde_json::json!({"error":"unknown execution"}),
-                ),
+                Some(entry) => reply_entry(&mut stream, entry, false),
+                None => reply_archived(&mut stream, state, id, false),
             }
         }
         _ => reply(&mut stream, 404, &serde_json::json!({"error":"not found"})),
+    }
+}
+
+fn persist_terminal(entry: &Entry<ExecutionRecord>) -> Result<()> {
+    if !execution_is_active(&entry.value) {
+        if let Some(root) = &entry.journal_root {
+            journal::complete(
+                root,
+                &entry.value,
+                entry.audit.as_ref().context("missing audit")?,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn reply_entry(stream: &mut TcpStream, entry: &Entry<ExecutionRecord>, audit: bool) -> Result<()> {
+    if persist_terminal(entry).is_err() {
+        return reply(
+            stream,
+            503,
+            &serde_json::json!({"error":"terminal record not durable; do not replay"}),
+        );
+    }
+    if audit {
+        match &entry.audit {
+            Some(value) => reply(stream, 200, value),
+            None => reply(
+                stream,
+                404,
+                &serde_json::json!({"error":"unknown execution audit"}),
+            ),
+        }
+    } else {
+        reply(stream, 200, &entry.value)
+    }
+}
+
+fn reply_snapshot(stream: &mut TcpStream, snapshot: journal::Snapshot, audit: bool) -> Result<()> {
+    if execution_is_active(&snapshot.record) {
+        return reply(
+            stream,
+            503,
+            &serde_json::json!({"error":"interrupted execution requires operator reconciliation; teardown is unproven; do not replay"}),
+        );
+    }
+    if audit {
+        reply(stream, 200, &snapshot.audit)
+    } else {
+        reply(stream, 200, &snapshot.record)
+    }
+}
+
+fn reply_archived(stream: &mut TcpStream, state: &State, id: &str, audit: bool) -> Result<()> {
+    match journal::read(&state.root, id) {
+        Ok(Some(snapshot)) => reply_snapshot(stream, snapshot, audit),
+        Ok(None) => reply(
+            stream,
+            404,
+            &serde_json::json!({"error":"unknown execution"}),
+        ),
+        Err(_) => reply(
+            stream,
+            503,
+            &serde_json::json!({"error":"execution journal unavailable; do not replay"}),
+        ),
     }
 }
 
@@ -639,6 +742,9 @@ fn update_execution(executions: &Executions, id: &str, f: impl FnOnce(&mut Execu
         if let Some(audit) = &mut entry.audit {
             audit.phase(&entry.value.phase);
             audit.receipt = entry.value.receipt.clone();
+        }
+        if let Err(error) = persist_terminal(entry) {
+            eprintln!("dispatcher terminal journal unavailable: {error:#}");
         }
     }
 }
@@ -851,6 +957,105 @@ mod tests {
             },
             executions: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_records_survive_empty_registry_without_replaying_interrupted_claims() {
+        fn http(state: &State, method: &str, path: &str, body: &[u8], token: &str) -> String {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+            client
+                .set_read_timeout(Some(Duration::from_secs(3)))
+                .unwrap();
+            let (server, _) = listener.accept().unwrap();
+            write!(client, "{method} {path} HTTP/1.1\r\nAuthorization: Bearer {token}\r\nContent-Length: {}\r\n\r\n", body.len()).unwrap();
+            client.write_all(body).unwrap();
+            handle(server, state).unwrap();
+            let mut response = String::new();
+            client.read_to_string(&mut response).unwrap();
+            response
+        }
+        let root = tempfile::tempdir().unwrap();
+        let state = lifecycle_state(root.path());
+        let request = request_with_egress(&[]);
+        let body = serde_json::to_vec(&request).unwrap();
+        let mut record = empty_record(&request.id);
+        let mut audit = audit::Audit::new(&request, "test");
+        journal::claim(root.path(), &body, &record, &audit).unwrap();
+        // No live registry/worker exists, as after a restart. A durable claim
+        // cannot be interpreted as a fresh request, success or teardown.
+        for (method, suffix) in [("GET", ""), ("GET", "/audit"), ("POST", "/cancel")] {
+            let path = format!("/v1/executions/{}{suffix}", request.id);
+            assert!(http(&state, method, &path, b"", "wrong").starts_with("HTTP/1.1 401"));
+            assert!(http(&state, method, &path, b"", &state.token).starts_with("HTTP/1.1 503"));
+        }
+        assert!(
+            http(&state, "POST", "/v1/executions", &body, &state.token).starts_with("HTTP/1.1 503")
+        );
+        let mut changed = request.clone();
+        changed.workload.id.push_str("-changed");
+        assert!(http(
+            &state,
+            "POST",
+            "/v1/executions",
+            &serde_json::to_vec(&changed).unwrap(),
+            &state.token
+        )
+        .starts_with("HTTP/1.1 409"));
+        assert!(state.executions.lock().unwrap().is_empty());
+
+        record.phase = "Refused".into();
+        record.reason = Some("fixture refused before execution".into());
+        audit.phase("Refused");
+        journal::complete(root.path(), &record, &audit).unwrap();
+        for (method, suffix) in [("GET", ""), ("GET", "/audit"), ("POST", "/cancel")] {
+            let response = http(
+                &state,
+                method,
+                &format!("/v1/executions/{}{suffix}", request.id),
+                b"",
+                &state.token,
+            );
+            assert!(response.starts_with("HTTP/1.1 200"), "{response}");
+            let value: serde_json::Value =
+                serde_json::from_str(response.split_once("\r\n\r\n").unwrap().1).unwrap();
+            let expected = if suffix == "/audit" {
+                serde_json::to_value(&audit).unwrap()
+            } else {
+                serde_json::to_value(&record).unwrap()
+            };
+            assert_eq!(value, expected);
+        }
+        assert!(
+            http(&state, "POST", "/v1/executions", &body, &state.token).starts_with("HTTP/1.1 200")
+        );
+        assert!(state.executions.lock().unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminal_persistence_failure_is_not_reported_as_completion_or_evicted() {
+        let root = tempfile::tempdir().unwrap();
+        let request = request_with_egress(&[]);
+        let mut entry = Entry::new(empty_record(&request.id));
+        entry.journal_root = Some(root.path().into());
+        entry.audit = Some(audit::Audit::new(&request, "test"));
+        // Missing claim simulates unavailable/corrupt admission state.
+        entry.value.phase = "Failed".into();
+        entry.at = Instant::now() - RECORD_TTL - Duration::from_secs(1);
+        assert!(persist_terminal(&entry).is_err());
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (mut server, _) = listener.accept().unwrap();
+        reply_entry(&mut server, &entry, false).unwrap();
+        drop(server);
+        let mut response = String::new();
+        client.read_to_string(&mut response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 503"));
+        let mut registry = HashMap::from([(request.id.clone(), entry)]);
+        evict_expired(&mut registry);
+        assert!(registry.contains_key(&request.id));
     }
 
     #[test]
@@ -1364,6 +1569,7 @@ mod tests {
                 control: None,
                 reservation: None,
                 audit: None,
+                journal_root: None,
             },
         );
         registry.insert("fresh".into(), Entry::new(empty_record("fresh")));
@@ -1375,6 +1581,7 @@ mod tests {
                 control: None,
                 reservation: None,
                 audit: None,
+                journal_root: None,
             },
         );
 

--- a/crates/celln-cli/src/dispatch_journal.rs
+++ b/crates/celln-cli/src/dispatch_journal.rs
@@ -1,0 +1,207 @@
+//! Durable admission tombstones and terminal records. An interrupted claim is
+//! NOT evidence of teardown and never authorizes automatic execution replay.
+use super::{execution_is_active, ExecutionRecord};
+use anyhow::{bail, Context, Result};
+use celln_manifest::Hash;
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+const CAPACITY: usize = 100_000;
+const MAX_BYTES: u64 = 16 * 1024 * 1024;
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Snapshot {
+    version: u8,
+    pub request_hash: String,
+    pub record: ExecutionRecord,
+    pub audit: serde_json::Value,
+}
+
+fn directory(root: &Path) -> PathBuf {
+    root.join("execution-journal")
+}
+fn path(root: &Path, id: &str) -> PathBuf {
+    directory(root).join(format!(
+        "{}.json",
+        Hash::of(id.as_bytes()).0.trim_start_matches("blake3:")
+    ))
+}
+
+pub(super) fn prepare(root: &Path) -> Result<()> {
+    fs::create_dir_all(directory(root))?;
+    for ancestor in fs::canonicalize(directory(root))?.ancestors() {
+        fs::File::open(ancestor)?
+            .sync_all()
+            .context("Unsupported: dispatcher journal requires directory fsync")?;
+    }
+    Ok(())
+}
+
+pub(super) fn read(root: &Path, id: &str) -> Result<Option<Snapshot>> {
+    let file = match fs::File::open(path(root, id)) {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    let mut bytes = Vec::new();
+    file.take(MAX_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_BYTES {
+        bail!("dispatcher journal record too large");
+    }
+    let snapshot: Snapshot = serde_json::from_slice(&bytes)?;
+    if snapshot.version != 1 || snapshot.record.request_id != id {
+        bail!("invalid dispatcher journal identity/version");
+    }
+    if let Some(receipt) = &snapshot.record.receipt {
+        if receipt.request_id != id || format!("{:?}", receipt.phase) != snapshot.record.phase {
+            bail!("invalid dispatcher journal receipt");
+        }
+    }
+    // Also finish a directory sync that may have failed after publication in
+    // the same process. Never acknowledge terminal durability on equality alone.
+    fs::File::open(directory(root))?.sync_all()?;
+    Ok(Some(snapshot))
+}
+
+fn publish(root: &Path, snapshot: &Snapshot, new: bool) -> Result<()> {
+    let bytes = serde_json::to_vec(snapshot)?;
+    if bytes.len() as u64 > MAX_BYTES {
+        bail!("dispatcher journal record too large");
+    }
+    let mut file = tempfile::NamedTempFile::new_in(directory(root))?;
+    file.write_all(&bytes)?;
+    file.as_file().sync_all()?;
+    let destination = path(root, &snapshot.record.request_id);
+    if new {
+        file.persist_noclobber(destination)?;
+    } else {
+        file.persist(destination)?;
+    }
+    fs::File::open(directory(root))?.sync_all()?;
+    Ok(())
+}
+
+// Caller holds the execution registry lock; serve also owns dispatcher.lock.
+pub(super) fn claim(
+    root: &Path,
+    body: &[u8],
+    record: &ExecutionRecord,
+    audit: &super::audit::Audit,
+) -> Result<()> {
+    claim_with_capacity(root, body, record, audit, CAPACITY)
+}
+
+fn claim_with_capacity(
+    root: &Path,
+    body: &[u8],
+    record: &ExecutionRecord,
+    audit: &super::audit::Audit,
+    capacity: usize,
+) -> Result<()> {
+    prepare(root)?;
+    if fs::read_dir(directory(root))?
+        .filter(|e| {
+            e.as_ref()
+                .map_or(true, |e| e.path().extension().is_some_and(|s| s == "json"))
+        })
+        .take(capacity)
+        .count()
+        >= capacity
+    {
+        bail!("dispatcher journal capacity exhausted; operator reconciliation required");
+    }
+    publish(
+        root,
+        &Snapshot {
+            version: 1,
+            request_hash: Hash::of(body).0,
+            record: record.clone(),
+            audit: serde_json::to_value(audit)?,
+        },
+        true,
+    )
+}
+
+pub(super) fn complete(
+    root: &Path,
+    record: &ExecutionRecord,
+    audit: &super::audit::Audit,
+) -> Result<()> {
+    if execution_is_active(record) {
+        bail!("cannot archive active execution as terminal");
+    }
+    let previous = read(root, &record.request_id)?.context("missing durable admission claim")?;
+    let snapshot = Snapshot {
+        version: 1,
+        request_hash: previous.request_hash.clone(),
+        record: record.clone(),
+        audit: serde_json::to_value(audit)?,
+    };
+    if !execution_is_active(&previous.record) {
+        if serde_json::to_vec(&previous)? != serde_json::to_vec(&snapshot)? {
+            bail!("terminal journal record is immutable");
+        }
+        // Retry the sync too: a previous publication may have succeeded while
+        // its directory fsync failed. Equality alone does not prove durability.
+        fs::File::open(directory(root))?.sync_all()?;
+        return Ok(());
+    }
+    publish(root, &snapshot, false)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    #[test]
+    fn claims_survive_restart_and_terminal_records_are_immutable() {
+        let root = tempfile::tempdir().unwrap();
+        let mut record = ExecutionRecord {
+            request_id: "../safe-hashed-id".into(),
+            phase: "Admitting".into(),
+            reason: None,
+            output: None,
+            receipt: None,
+        };
+        let request: celln_spec::ExecutionRequest = serde_json::from_value(serde_json::json!({
+            "apiVersion":"celln.dev/v1alpha1", "id":record.request_id,
+            "workload":{"id":"test","caller":"test"},
+            "capabilities":{"workspace":"none","timeoutMs":1000,"memoryBytes":1,"outputBytes":1},
+            "execution":{"lane":"tool","requireHardwareIsolation":true}
+        }))
+        .unwrap();
+        let audit = super::super::audit::Audit::new(&request, "test");
+        claim(root.path(), b"body", &record, &audit).unwrap();
+        let mut another = record.clone();
+        another.request_id = "second".into();
+        assert!(claim_with_capacity(root.path(), b"second", &another, &audit, 1).is_err());
+        assert!(read(root.path(), "second").unwrap().is_none());
+        assert!(execution_is_active(
+            &read(root.path(), &record.request_id)
+                .unwrap()
+                .unwrap()
+                .record
+        ));
+        assert!(claim(root.path(), b"body", &record, &audit).is_err());
+        record.phase = "Refused".into();
+        record.reason = Some("test refusal".into());
+        complete(root.path(), &record, &audit).unwrap();
+        complete(root.path(), &record, &audit).unwrap();
+        assert_eq!(
+            read(root.path(), &record.request_id)
+                .unwrap()
+                .unwrap()
+                .record
+                .reason,
+            record.reason
+        );
+        record.reason = Some("changed".into());
+        assert!(complete(root.path(), &record, &audit).is_err());
+        fs::write(path(root.path(), &record.request_id), b"corrupt").unwrap();
+        assert!(read(root.path(), &record.request_id).is_err());
+    }
+}

--- a/docs/DISPATCHER_JOURNAL.md
+++ b/docs/DISPATCHER_JOURNAL.md
@@ -1,0 +1,77 @@
+# Dispatcher durability and interrupted execution
+
+Part of Sympozium epic #426. The router's shared owner ledger and the
+dispatcher's journal serve different purposes: the router records **where** an
+ID belongs; each dispatcher records that it admitted that ID and its eventual
+result/audit. Keep both on persistent operator-controlled storage.
+
+## Behavior
+
+The dispatcher owns its state root exclusively using the existing process
+lock. Before starting a worker or returning acceptance it publishes a durable
+claim under `ROOT/execution-journal/`. The filename hashes the request ID; the
+claim binds the exact submitted request bytes by hash. It contains no bearer
+credential or request task/argument payload. Terminal snapshots also contain
+the bounded output and audit and therefore may contain sensitive workload data;
+files are private mode-0600 temporary files published atomically.
+
+Terminal records are written and synced before serving them as completion.
+Their receipt shape is unchanged. Terminal output/audit retrieval and idempotent
+cancellation work after memory-cache expiry or dispatcher restart. A completed
+ID never starts another execution. Changed request bytes return 409.
+
+| State after restart | Response |
+|---|---|
+| Durable terminal snapshot | Return original result, receipt/audit; never execute again |
+| Admission claim without durable terminal snapshot | 503: interrupted execution requires reconciliation; never replay |
+| Corrupt/unreadable journal | 503; never treat it as a missing execution |
+| No journal record | 404 on lookup; a new POST still requires normal admission |
+
+An interrupted claim is **not** evidence that a cell or provider transaction
+finished or was cleaned up. Cancellation of that claim does not fabricate a
+cancelled receipt or let a controller falsely finalize teardown. A crash
+between claim persistence and worker start can consequently leave work that
+never ran requiring reconciliation. Automatic in-flight crash recovery and
+operator acknowledgement/fencing are not implemented by this increment.
+
+## Bounds and failure handling
+
+- At most 100,000 admission/terminal records per root. New admission refuses
+  when full; existing records remain readable. No automatic tombstone deletion.
+- At most 16 MiB per serialized journal record. A terminal snapshot exceeding
+  this bound or failing storage I/O is not advertised as durably completed;
+  reads/cancellation return 503 until persistence succeeds. The memory entry
+  is retained past the one-hour cache TTL while persistence is unproven.
+- Output storage failure, interruption and successful execution are distinct
+  facts. Journal failure never authorizes replay of possible side effects.
+- Publication uses private files, file fsync, atomic no-clobber creation for
+  claims, atomic replacement for terminal snapshots, and directory fsync.
+  Existing identical snapshots still require directory sync before a durable
+  acknowledgement. Directory-fsync failure is unsupported, not success.
+- Terminal snapshots are immutable. Cleanup/compaction requires an explicit
+  request-ID retirement protocol and coordinated router retention; not simple
+  age-based deletion. Storage capacity planning remains operator work.
+
+The journal is process-local to the owning dispatcher state root. It does not
+turn multiple independent dispatchers behind a load balancer into one owner,
+certify a distributed filesystem, or promise exactly-once provider effects.
+
+## Upgrade limits
+
+The old dispatcher kept records/audits only in memory and expired them after
+an hour. This version cannot recover those records retroactively. Quiesce old
+submissions and export/reconcile outstanding results before upgrading; preserve
+the router ledger and do not replay its old IDs to recreate missing results.
+Do not roll back to a dispatcher that ignores the journal while IDs can still
+be retried. An old execution with no new journal record is not protected by a
+new claim invented after the fact.
+
+## Verification scope
+
+Tests exercise durable claim/terminal publication, immutability, capacity,
+corruption refusal, unavailable-persistence refusal and cache retention. Real
+TCP HTTP handler tests use an empty registry to check authenticated poll,
+audit, cancellation and POST retry: terminal state survives, interrupted claims
+refuse, changed bytes conflict, and no worker is registered. These do not by
+themselves prove deployed KVM node-loss recovery. The deployed image still needs
+updating and testing with fresh executions before that gate is claimed.

--- a/docs/DISPATCHER_JOURNAL.md
+++ b/docs/DISPATCHER_JOURNAL.md
@@ -73,5 +73,7 @@ corruption refusal, unavailable-persistence refusal and cache retention. Real
 TCP HTTP handler tests use an empty registry to check authenticated poll,
 audit, cancellation and POST retry: terminal state survives, interrupted claims
 refuse, changed bytes conflict, and no worker is registered. These do not by
-themselves prove deployed KVM node-loss recovery. The deployed image still needs
-updating and testing with fresh executions before that gate is claimed.
+themselves prove deployed KVM node-loss recovery. A subsequent actual terminal
+execution/owner-restart test is recorded in
+`docs/evidence/dispatcher-journal-restart-2026-09-07.md`; it verifies terminal
+retrieval and non-replay, not automatic recovery of interrupted work.

--- a/docs/evidence/dispatcher-journal-restart-2026-09-07.json
+++ b/docs/evidence/dispatcher-journal-restart-2026-09-07.json
@@ -1,0 +1,301 @@
+{
+  "scope": "completed real KVM execution retrieved after dispatcher owner node-container restart",
+  "source": "463356c",
+  "status": {
+    "cellnActionId": "journal-terminal-proof-647487df-40a5-49c8-8683-a2b82baf07b5",
+    "cellnReceipt": "{\"apiVersion\":\"celln.dev/v1alpha1\",\"requestId\":\"journal-terminal-proof-647487df-40a5-49c8-8683-a2b82baf07b5\",\"phase\":\"failed\",\"node\":\"celln-deployed-worker2\",\"startedAt\":\"2026-09-07T11:19:40Z\",\"completedAt\":\"2026-09-07T11:20:00Z\",\"cellId\":\"3643ebb82e76\",\"resolved\":{\"mote\":\"blake3:4d95a591956302f46253fa0cd5b67e7421ebcb1bcd948ab3c6121a3643968665\",\"tools\":[\"blake3:aba26600c0f9abf3f1f1daf249bb2107ede0afe9aadec6defc31fb4a4d0d3a29\"],\"inputs\":[]},\"output\":{\"hash\":\"blake3:caf81f9ef224a3ee75e748da3374a132b9fdc6e365aff3ea9f810cb03f780c83\",\"mediaType\":\"application/octet-stream\",\"bytes\":24}}",
+    "cellnRequest": "{\"apiVersion\":\"celln.dev/v1alpha1\",\"id\":\"journal-terminal-proof-647487df-40a5-49c8-8683-a2b82baf07b5\",\"workload\":{\"id\":\"reference\",\"caller\":\"sympozium:sympozium-system/journal-terminal-proof\"},\"mote\":{\"hash\":\"blake3:4d95a591956302f46253fa0cd5b67e7421ebcb1bcd948ab3c6121a3643968665\"},\"tools\":[{\"alias\":\"/harness\",\"hash\":\"blake3:aba26600c0f9abf3f1f1daf249bb2107ede0afe9aadec6defc31fb4a4d0d3a29\",\"closure\":{\"hash\":\"blake3:e821ab9f24b37f5fd63053bb26b1f1dbeb58d344359e3d67ac8f30e1eebaa326\"}}],\"invocation\":{\"alias\":\"/harness\"},\"capabilities\":{\"workspace\":\"none\",\"timeoutMs\":20000,\"memoryBytes\":268435456,\"outputBytes\":65536},\"execution\":{\"lane\":\"tool\",\"requireHardwareIsolation\":true}}",
+    "completedAt": "2026-09-07T11:20:05Z",
+    "error": "Celln execution Failed: execution deadline exceeded",
+    "phase": "Failed",
+    "startedAt": "2026-09-07T11:19:40Z"
+  },
+  "auditBefore": {
+    "apiVersion": "celln.dev/audit-v1alpha1",
+    "requestId": "journal-terminal-proof-647487df-40a5-49c8-8683-a2b82baf07b5",
+    "caller": "sympozium:sympozium-system/journal-terminal-proof",
+    "workload": "reference",
+    "node": "celln-deployed-worker2",
+    "events": [
+      {
+        "sequence": 0,
+        "at": "2026-09-07T11:19:40Z",
+        "phase": "Admitting"
+      },
+      {
+        "sequence": 1,
+        "at": "2026-09-07T11:19:40Z",
+        "phase": "Resolving"
+      },
+      {
+        "sequence": 2,
+        "at": "2026-09-07T11:19:48Z",
+        "phase": "CellRunning"
+      },
+      {
+        "sequence": 3,
+        "at": "2026-09-07T11:20:00Z",
+        "phase": "Dissolved"
+      },
+      {
+        "sequence": 4,
+        "at": "2026-09-07T11:20:00Z",
+        "phase": "Failed"
+      }
+    ],
+    "execution": {
+      "cellId": "3643ebb82e76",
+      "substrate": {
+        "closure": {
+          "hash": "blake3:e821ab9f24b37f5fd63053bb26b1f1dbeb58d344359e3d67ac8f30e1eebaa326",
+          "publisher": "6fb173b3ea040b8a03b9406f0b75c6082e7e0bd927a1e36142551f0654c11bb8",
+          "toolfs": "blake3:e8efa4fe127f01256564a7f04608faa44cdafd86113ac4788707a55b45681b0b",
+          "members": {
+            "/add": {
+              "hash": "blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020",
+              "dependencies": []
+            },
+            "/harness": {
+              "hash": "blake3:aba26600c0f9abf3f1f1daf249bb2107ede0afe9aadec6defc31fb4a4d0d3a29",
+              "dependencies": [
+                "/add",
+                "/multiply",
+                "/pilot-fetch"
+              ]
+            },
+            "/multiply": {
+              "hash": "blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1",
+              "dependencies": []
+            },
+            "/pilot-fetch": {
+              "hash": "blake3:9afcf605962e29d25fd95fcd3d3a719210f644cd1ee0893ff3d5578eeb86888e",
+              "dependencies": []
+            }
+          }
+        },
+        "kernel": "blake3:e8e05482b24c4d9019ff7298f42f6f2730fcf656cbcb429ec44150ceac0e4ca8",
+        "initrd": "blake3:f9c1ac97c1ab330b6128620778d283a22dbb96043f200be6bd99c2a1dc375f3a",
+        "toolfs": "blake3:e8efa4fe127f01256564a7f04608faa44cdafd86113ac4788707a55b45681b0b",
+        "invocation": "blake3:8b35bf04cf365b3a68d957a1761017f0aff2b3ec00a6abde6ff4fae07dc31fa4"
+      },
+      "pilot": {
+        "tool": "blake3:aba26600c0f9abf3f1f1daf249bb2107ede0afe9aadec6defc31fb4a4d0d3a29",
+        "lane": "tool",
+        "workspace": "none",
+        "fetch": false
+      },
+      "granted": {
+        "workspace": "none",
+        "egress": [],
+        "timeoutMs": 20000,
+        "memoryBytes": 268435456,
+        "outputBytes": 65536
+      },
+      "inputs": [],
+      "broker": {
+        "requests": 0,
+        "denied": 0,
+        "responseBytes": 0
+      },
+      "exitCode": null,
+      "signal": null,
+      "watchdogStopped": true
+    },
+    "receipt": {
+      "apiVersion": "celln.dev/v1alpha1",
+      "requestId": "journal-terminal-proof-647487df-40a5-49c8-8683-a2b82baf07b5",
+      "phase": "failed",
+      "node": "celln-deployed-worker2",
+      "cellId": "3643ebb82e76",
+      "resolved": {
+        "mote": "blake3:4d95a591956302f46253fa0cd5b67e7421ebcb1bcd948ab3c6121a3643968665",
+        "tools": [
+          "blake3:aba26600c0f9abf3f1f1daf249bb2107ede0afe9aadec6defc31fb4a4d0d3a29"
+        ],
+        "inputs": []
+      },
+      "output": {
+        "hash": "blake3:caf81f9ef224a3ee75e748da3374a132b9fdc6e365aff3ea9f810cb03f780c83",
+        "mediaType": "application/octet-stream",
+        "bytes": 24
+      },
+      "startedAt": "2026-09-07T11:19:40Z",
+      "completedAt": "2026-09-07T11:20:00Z"
+    }
+  },
+  "auditAfter": {
+    "apiVersion": "celln.dev/audit-v1alpha1",
+    "caller": "sympozium:sympozium-system/journal-terminal-proof",
+    "events": [
+      {
+        "at": "2026-09-07T11:19:40Z",
+        "phase": "Admitting",
+        "sequence": 0
+      },
+      {
+        "at": "2026-09-07T11:19:40Z",
+        "phase": "Resolving",
+        "sequence": 1
+      },
+      {
+        "at": "2026-09-07T11:19:48Z",
+        "phase": "CellRunning",
+        "sequence": 2
+      },
+      {
+        "at": "2026-09-07T11:20:00Z",
+        "phase": "Dissolved",
+        "sequence": 3
+      },
+      {
+        "at": "2026-09-07T11:20:00Z",
+        "phase": "Failed",
+        "sequence": 4
+      }
+    ],
+    "execution": {
+      "broker": {
+        "denied": 0,
+        "requests": 0,
+        "responseBytes": 0
+      },
+      "cellId": "3643ebb82e76",
+      "exitCode": null,
+      "granted": {
+        "egress": [],
+        "memoryBytes": 268435456,
+        "outputBytes": 65536,
+        "timeoutMs": 20000,
+        "workspace": "none"
+      },
+      "inputs": [],
+      "pilot": {
+        "fetch": false,
+        "lane": "tool",
+        "tool": "blake3:aba26600c0f9abf3f1f1daf249bb2107ede0afe9aadec6defc31fb4a4d0d3a29",
+        "workspace": "none"
+      },
+      "signal": null,
+      "substrate": {
+        "closure": {
+          "hash": "blake3:e821ab9f24b37f5fd63053bb26b1f1dbeb58d344359e3d67ac8f30e1eebaa326",
+          "members": {
+            "/add": {
+              "dependencies": [],
+              "hash": "blake3:d25dee37d4c633b1a46ab2b824b00010f24ec10cb4ac78c9d1b5ecded854f020"
+            },
+            "/harness": {
+              "dependencies": [
+                "/add",
+                "/multiply",
+                "/pilot-fetch"
+              ],
+              "hash": "blake3:aba26600c0f9abf3f1f1daf249bb2107ede0afe9aadec6defc31fb4a4d0d3a29"
+            },
+            "/multiply": {
+              "dependencies": [],
+              "hash": "blake3:de79be33d977d7b31a2c787476b5849949f9017d309fe76ef0b02dd9c47890c1"
+            },
+            "/pilot-fetch": {
+              "dependencies": [],
+              "hash": "blake3:9afcf605962e29d25fd95fcd3d3a719210f644cd1ee0893ff3d5578eeb86888e"
+            }
+          },
+          "publisher": "6fb173b3ea040b8a03b9406f0b75c6082e7e0bd927a1e36142551f0654c11bb8",
+          "toolfs": "blake3:e8efa4fe127f01256564a7f04608faa44cdafd86113ac4788707a55b45681b0b"
+        },
+        "initrd": "blake3:f9c1ac97c1ab330b6128620778d283a22dbb96043f200be6bd99c2a1dc375f3a",
+        "invocation": "blake3:8b35bf04cf365b3a68d957a1761017f0aff2b3ec00a6abde6ff4fae07dc31fa4",
+        "kernel": "blake3:e8e05482b24c4d9019ff7298f42f6f2730fcf656cbcb429ec44150ceac0e4ca8",
+        "toolfs": "blake3:e8efa4fe127f01256564a7f04608faa44cdafd86113ac4788707a55b45681b0b"
+      },
+      "watchdogStopped": true
+    },
+    "node": "celln-deployed-worker2",
+    "receipt": {
+      "apiVersion": "celln.dev/v1alpha1",
+      "cellId": "3643ebb82e76",
+      "completedAt": "2026-09-07T11:20:00Z",
+      "node": "celln-deployed-worker2",
+      "output": {
+        "bytes": 24,
+        "hash": "blake3:caf81f9ef224a3ee75e748da3374a132b9fdc6e365aff3ea9f810cb03f780c83",
+        "mediaType": "application/octet-stream"
+      },
+      "phase": "failed",
+      "requestId": "journal-terminal-proof-647487df-40a5-49c8-8683-a2b82baf07b5",
+      "resolved": {
+        "inputs": [],
+        "mote": "blake3:4d95a591956302f46253fa0cd5b67e7421ebcb1bcd948ab3c6121a3643968665",
+        "tools": [
+          "blake3:aba26600c0f9abf3f1f1daf249bb2107ede0afe9aadec6defc31fb4a4d0d3a29"
+        ]
+      },
+      "startedAt": "2026-09-07T11:19:40Z"
+    },
+    "requestId": "journal-terminal-proof-647487df-40a5-49c8-8683-a2b82baf07b5",
+    "workload": "reference"
+  },
+  "exactRequestRetry": {
+    "requestId": "journal-terminal-proof-647487df-40a5-49c8-8683-a2b82baf07b5",
+    "phase": "Failed",
+    "reason": "execution deadline exceeded",
+    "output": "CELLN_LIFECYCLE_STARTED\n",
+    "receipt": {
+      "apiVersion": "celln.dev/v1alpha1",
+      "requestId": "journal-terminal-proof-647487df-40a5-49c8-8683-a2b82baf07b5",
+      "phase": "failed",
+      "node": "celln-deployed-worker2",
+      "cellId": "3643ebb82e76",
+      "resolved": {
+        "mote": "blake3:4d95a591956302f46253fa0cd5b67e7421ebcb1bcd948ab3c6121a3643968665",
+        "tools": [
+          "blake3:aba26600c0f9abf3f1f1daf249bb2107ede0afe9aadec6defc31fb4a4d0d3a29"
+        ],
+        "inputs": []
+      },
+      "output": {
+        "hash": "blake3:caf81f9ef224a3ee75e748da3374a132b9fdc6e365aff3ea9f810cb03f780c83",
+        "mediaType": "application/octet-stream",
+        "bytes": 24
+      },
+      "startedAt": "2026-09-07T11:19:40Z",
+      "completedAt": "2026-09-07T11:20:00Z"
+    }
+  },
+  "cancelAfterRestart": {
+    "requestId": "journal-terminal-proof-647487df-40a5-49c8-8683-a2b82baf07b5",
+    "phase": "Failed",
+    "reason": "execution deadline exceeded",
+    "output": "CELLN_LIFECYCLE_STARTED\n",
+    "receipt": {
+      "apiVersion": "celln.dev/v1alpha1",
+      "requestId": "journal-terminal-proof-647487df-40a5-49c8-8683-a2b82baf07b5",
+      "phase": "failed",
+      "node": "celln-deployed-worker2",
+      "cellId": "3643ebb82e76",
+      "resolved": {
+        "mote": "blake3:4d95a591956302f46253fa0cd5b67e7421ebcb1bcd948ab3c6121a3643968665",
+        "tools": [
+          "blake3:aba26600c0f9abf3f1f1daf249bb2107ede0afe9aadec6defc31fb4a4d0d3a29"
+        ],
+        "inputs": []
+      },
+      "output": {
+        "hash": "blake3:caf81f9ef224a3ee75e748da3374a132b9fdc6e365aff3ea9f810cb03f780c83",
+        "mediaType": "application/octet-stream",
+        "bytes": 24
+      },
+      "startedAt": "2026-09-07T11:19:40Z",
+      "completedAt": "2026-09-07T11:20:00Z"
+    }
+  },
+  "checks": {
+    "auditEqual": true,
+    "retryReceiptEqual": true,
+    "cancelEqual": true,
+    "dispatcherRestartCount": 1,
+    "liveCells": 0,
+    "warmTemplates": 0
+  }
+}

--- a/docs/evidence/dispatcher-journal-restart-2026-09-07.md
+++ b/docs/evidence/dispatcher-journal-restart-2026-09-07.md
@@ -1,0 +1,51 @@
+# Deployed terminal journal survives owner-node restart
+
+Tested Celln `463356c` (PR #78) in the existing isolated `celln-deployed` Kind
+cluster. Both dispatchers had zero live cells before their image upgrade. No
+model credential was present or used. Pre-upgrade memory-only history was not
+invented or imported; previous evidence remains committed separately.
+
+New dispatcher image: `localhost/celln-dispatcher-journal:463356c`.
+Image config digest:
+`sha256:9357a4d57647a9bd794fff7bca337bd1112852e8e1aad8da998edcc72327b6df`.
+Static CLI SHA-256:
+`679ffe172a0329bfb78403e0ccb828b553b5cb36ee234c69f201b111b3bcb305`.
+The controller/router versions and transport restrictions are unchanged from
+the prior deployed proof. Rollout exceeded the 45-second observation timeout
+but completed normally; no state was recreated because of that timeout.
+
+## Actual sequence
+
+1. Submit `journal-terminal-proof` through the actual in-cluster controller and
+   router Service using the non-networked lifecycle tool and a 20-second limit.
+2. Observe AgentRun Failed with `execution deadline exceeded`, cell
+   `3643ebb82e76` on `celln-deployed-worker2`, 11:19:40–11:20:00 UTC. The result
+   contains `CELLN_LIFECYCLE_STARTED`, showing the guest tool actually ran.
+3. Fetch its full audit through the Service and verify the failed receipt and
+   Dissolved event before touching the owning node.
+4. SIGKILL the disposable Kind worker container `celln-deployed-worker2`, then
+   restart that same container. Existing persistent state and journal remain.
+5. Confirm dispatcher-0 is ready with container restart count 1. Fetch the audit
+   through the Service again and compare the complete JSON equal to the original.
+6. Repost the controller's **exact frozen request bytes** directly to the
+   authenticated dispatcher. Compare the returned receipt with the original;
+   it is identical. This deliberately exercises dispatcher replay protection,
+   not merely the router's independent retry-as-GET behavior.
+7. POST cancellation through the router Service. The terminal response equals
+   the retry response; a failed receipt is not relabelled cancelled.
+8. The restarted dispatcher reports zero live cells and an empty warm cache,
+   consistent with no new execution launched by retrieval/retry/cancellation.
+
+The companion JSON contains the original AgentRun status/receipt, before/after
+audits, retry and cancellation responses. Raw artifacts are also retained under
+`target/deployed-kind.JcI9Gg/evidence/journal-*`.
+
+## Limits and continuation
+
+This proves retrieval of a **durably completed** real KVM execution after its
+owner's process/node-container restart. It does not prove power-loss durability
+on separate physical hosts, automatic recovery of an interrupted execution,
+provider side-effect reconciliation or production TLS/storage qualification.
+An unfinished admission claim still conservatively returns 503 and needs
+operator reconciliation; that separate state must not be labelled cancelled
+or replayed. The larger Harness/BYO-tool/UX epic remains open.


### PR DESCRIPTION
Part of sympozium-ai/sympozium#426; stacked on #76.

Node-loss inspection found that dispatcher results/audits were memory-only and expired after one hour even though routers retain ownership indefinitely. Add a bounded durable per-root journal: publish an exact-request-hash admission tombstone before starting work, persist immutable terminal record/receipt/audit before advertising completion, and retrieve archived state after restart/cache expiry. Changed bytes conflict; ambiguous interrupted claims and corrupt/unavailable storage return 503 and cannot replay work. The existing dispatcher root lock remains the single-owner boundary.

Tests: full make ci passes; actual TCP handler tests with fresh empty registry cover authenticated result/audit/cancel/retry, interrupted-claim refusal, changed-body conflict and no worker creation; filesystem tests cover publication, immutability, corruption/capacity and terminal-persistence failure/cache retention.

Draft gate: deployed image/node-restart proof still pending. This does not synthesize teardown for interrupted work, recover pre-upgrade memory-only history, implement operator reconciliation or complete M0. See docs/DISPATCHER_JOURNAL.md for bounds, failure behavior and upgrade/rollback constraints.