### PR TITLE
fix(dispatcher): reload credentials safely without restart

### DIFF
--- a/crates/celln-cli/src/dispatch_harness_tests.rs
+++ b/crates/celln-cli/src/dispatch_harness_tests.rs
@@ -143,6 +143,7 @@ fn harness_model_over_authenticated_dispatch() {
     let request: ExecutionRequest = serde_json::from_value(json!({"apiVersion":"celln.dev/v1alpha2","id":"harness-dispatch-proof","workload":{"id":"test-run","caller":caller},"mote":{"hash":mote.0},"tools":[{"alias":"/harness","hash":runtime.0,"closure":{"hash":closure.0}}],"invocation":{"alias":"/harness"},"harness":{"model":"deepseek-chat","contractVersion":"celln.reference-functions/v1","modelGrant":{"hash":grant_hash.0},"task":"Use add with args [\"37\",\"5\"], wait for its result, then multiply that result by \"2\". Reply with exactly the final integer.","borrowedTools":borrowed},"capabilities":{"workspace":"none","egress":["https://api.deepseek.com"],"timeoutMs":180000,"memoryBytes":268435456,"outputBytes":65536},"execution":{"lane":"agent","requireHardwareIsolation":true}})).unwrap();
     assert!(request.problems().is_empty(), "{:?}", request.problems());
     let state = State {
+        token_file: PathBuf::new(),
         token: "test-token-at-least-24-bytes".into(),
         egress_policy: EgressPolicy::new(&["api.deepseek.com".into()]).unwrap(),
         root: root.into(),

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -205,11 +205,37 @@ fn current_node(
 }
 
 struct State {
+    token_file: PathBuf,
+    #[cfg(test)]
     token: String,
     egress_policy: EgressPolicy,
     root: PathBuf,
     probe: NodeProbeArgs,
     executions: Executions,
+}
+
+/// Reopen the path each time: projected Secrets replace symlinks during rotation.
+/// Bound the read and never include credential bytes in diagnostics.
+pub(crate) fn read_bearer_token(path: &Path) -> Result<String> {
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)?
+        .take(4097)
+        .read_to_end(&mut bytes)?;
+    let token = std::str::from_utf8(&bytes)?.trim();
+    if bytes.len() > 4096 || token.len() < 24 || !token.bytes().all(|b| b.is_ascii_graphic()) {
+        bail!("invalid bearer credential");
+    }
+    Ok(token.to_owned())
+}
+
+impl State {
+    fn credential(&self) -> Result<String> {
+        #[cfg(test)]
+        if self.token_file.as_os_str().is_empty() {
+            return Ok(self.token.clone());
+        }
+        read_bearer_token(&self.token_file)
+    }
 }
 
 #[derive(Debug)]
@@ -295,13 +321,7 @@ pub fn serve(
 ) -> Result<u8> {
     let (listen_address, non_loopback) = validate_listen(listen, unsafe_non_loopback)?;
     let egress_policy = EgressPolicy::new(allow_egress_hosts)?;
-    let token = std::fs::read_to_string(token_file)
-        .with_context(|| format!("reading dispatcher token {}", token_file.display()))?
-        .trim()
-        .to_owned();
-    if token.len() < 24 {
-        bail!("dispatcher token must contain at least 24 non-whitespace bytes");
-    }
+    read_bearer_token(token_file).context("reading dispatcher credential")?;
     // Reservations are process-local. Two dispatchers must not independently
     // advertise the same state root's capacity while neither has a cell yet.
     let _ownership = own_dispatch_root(&root)?;
@@ -309,7 +329,9 @@ pub fn serve(
     let listener = TcpListener::bind(listen_address)
         .with_context(|| format!("binding dispatcher {listen_address}"))?;
     let state = Arc::new(State {
-        token,
+        token_file: token_file.to_owned(),
+        #[cfg(test)]
+        token: String::new(),
         egress_policy,
         root,
         probe: probe.clone(),
@@ -377,15 +399,27 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
         .to_owned();
     let method = method.to_owned();
     let (length, authorization) = read_headers(&mut reader)?;
-    let authorized = authorization
-        .is_some_and(|value| constant_time_eq(value.as_bytes(), state.token.as_bytes()));
     let is_public_health_check = method == "GET" && path == "/v1/health";
-    if !authorized && !is_public_health_check {
-        return reply(
-            &mut stream,
-            401,
-            &serde_json::json!({"error":"unauthorized"}),
-        );
+    if !is_public_health_check {
+        let token = match state.credential() {
+            Ok(token) => token,
+            Err(_) => {
+                return reply(
+                    &mut stream,
+                    503,
+                    &serde_json::json!({"error":"dispatcher credential unavailable"}),
+                );
+            }
+        };
+        let authorized =
+            authorization.is_some_and(|value| constant_time_eq(value.as_bytes(), token.as_bytes()));
+        if !authorized {
+            return reply(
+                &mut stream,
+                401,
+                &serde_json::json!({"error":"unauthorized"}),
+            );
+        }
     }
     match (method.as_str(), path.as_str()) {
         ("GET", "/v1/node") => {
@@ -944,6 +978,7 @@ mod tests {
 
     fn lifecycle_state(root: &Path) -> State {
         State {
+            token_file: PathBuf::new(),
             token: "test-token-at-least-24-bytes".into(),
             egress_policy: EgressPolicy::new(&[]).unwrap(),
             root: root.into(),
@@ -957,6 +992,42 @@ mod tests {
             },
             executions: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    #[test]
+    fn credentials_rotate_and_fail_closed_without_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = lifecycle_state(dir.path());
+        state.token_file = dir.path().join("credential");
+        let old = "old-public-test-token-at-least-24";
+        let new = "new-public-test-token-at-least-24";
+        std::fs::write(&state.token_file, old).unwrap();
+        // An authenticated request reaches lookup (404); rejected requests do not.
+        assert!(cancel_http(&state, "absent", old).starts_with("HTTP/1.1 404"));
+        assert!(cancel_http(&state, "absent", "").starts_with("HTTP/1.1 401"));
+        let replacement = dir.path().join("replacement");
+        std::fs::write(&replacement, format!("{new}\n")).unwrap();
+        std::fs::rename(&replacement, &state.token_file).unwrap();
+        assert!(cancel_http(&state, "absent", old).starts_with("HTTP/1.1 401"));
+        assert!(cancel_http(&state, "absent", new).starts_with("HTTP/1.1 404"));
+        for invalid in [
+            Vec::new(),
+            b"short".to_vec(),
+            format!("{new} injected").into_bytes(),
+            format!("{new}\r\nInjected: header").into_bytes(),
+            vec![b'x'; 4097],
+            vec![0xff; 24],
+        ] {
+            std::fs::write(&state.token_file, invalid).unwrap();
+            let response = cancel_http(&state, "absent", new);
+            assert!(response.starts_with("HTTP/1.1 503"));
+            assert!(!response.contains(new));
+        }
+        std::fs::remove_file(&state.token_file).unwrap();
+        assert!(cancel_http(&state, "absent", old).starts_with("HTTP/1.1 503"));
+        std::fs::write(&state.token_file, new).unwrap();
+        assert!(cancel_http(&state, "absent", new).starts_with("HTTP/1.1 404"));
+        assert!(state.executions.lock().unwrap().is_empty());
     }
 
     #[cfg(unix)]
@@ -1375,6 +1446,7 @@ mod tests {
         let work = tempfile::tempdir().unwrap();
         let root = work.path().join("unused");
         let state = State {
+            token_file: PathBuf::new(),
             token: "test-token-at-least-24-bytes".into(),
             egress_policy: EgressPolicy::new(&[]).unwrap(),
             root: root.clone(),

--- a/crates/celln-cli/src/router.rs
+++ b/crates/celln-cli/src/router.rs
@@ -20,25 +20,13 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-const ROUTER_TOKEN_BYTES: usize = 24;
 #[path = "router_ownership.rs"]
 mod ownership;
 
 // Credentials are bounded and never echoed in errors. Reload on each request
 // to support atomic file/Secret rotation; an unreadable file fails closed.
 fn read_token(path: &Path) -> Result<String> {
-    let mut bytes = Vec::new();
-    std::fs::File::open(path)?
-        .take(4097)
-        .read_to_end(&mut bytes)?;
-    let token = std::str::from_utf8(&bytes)?.trim();
-    if bytes.len() > 4096
-        || token.len() < ROUTER_TOKEN_BYTES
-        || !token.bytes().all(|b| b.is_ascii_graphic())
-    {
-        bail!("invalid router credential");
-    }
-    Ok(token.to_owned())
+    crate::dispatch_http::read_bearer_token(path)
 }
 
 fn credentials(state: &RouterState) -> Result<(String, String)> {

--- a/docs/DISPATCHER_SECURITY.md
+++ b/docs/DISPATCHER_SECURITY.md
@@ -20,6 +20,24 @@ celln dispatcher \
   --token-file /etc/celln/dispatcher-token/token
 ```
 
+## Credential rotation
+
+The credential file must contain at least 24 printable ASCII non-whitespace
+bytes, with at most 4096 file bytes; surrounding whitespace is trimmed. Startup
+validates the file, and every protected request reopens it. Rotate with atomic
+file replacement or a projected Kubernetes Secret directory, not a `subPath`
+mount. Old credentials return 401 once the replacement is visible. Invalid or
+unreadable files return 503 without falling back to a cached credential; fixing
+the file restores authentication without a restart. Credential contents are
+never included in these errors. Already authorized requests may finish.
+
+`GET /v1/health` remains public and does not certify authentication readiness.
+Verify rotation using a protected endpoint. Router and dispatcher Secret
+projections update independently: expect temporary authentication failures until
+both see the same backend token. This is single-token rotation, not a zero-downtime
+overlapping-key protocol. Do not replay an execution under a new ID to bypass an
+authentication failure; retain its original owner and request identity.
+
 ## Host-owned egress policy
 
 An execution request cannot grant itself network authority. The dispatcher

--- a/docs/ROUTER_SECURITY.md
+++ b/docs/ROUTER_SECURITY.md
@@ -21,8 +21,10 @@ Both files are reread per request. Rotate through atomic file replacement (or
 a projected Secret directory, not a Kubernetes `subPath` mount). New requests
 use the new values; already authorized in-flight requests may finish. An invalid,
 missing or equal pair refuses startup or returns 503 after rotation. Old client
-tokens return 401. Dispatcher credential rotation must also be coordinated with
-the dispatcher, which currently loads its credential at startup.
+tokens return 401. Dispatchers also reread their credential per protected request.
+Backend rotation must be coordinated across both services: independent Secret
+projections can temporarily disagree. There is no overlapping-key guarantee; see
+[Dispatcher security](DISPATCHER_SECURITY.md#credential-rotation).
 
 This is an intentional fail-closed CLI compatibility change. Old commands with
 only `--token-file` must be updated before rollout. Do not install this binary

--- a/docs/evidence/dispatcher-secret-rotation-2026-09-07.md
+++ b/docs/evidence/dispatcher-secret-rotation-2026-09-07.md
@@ -1,0 +1,77 @@
+# Deployed dispatcher Secret rotation — 2026-09-07
+
+Scope: backend authentication through the isolated `kind-celln-deployed`
+cluster, with two dispatcher Pods and two router replicas. Framework is not
+involved. This proof uses public dummy tokens and makes no provider requests.
+
+## Revision and setup
+
+- Dispatcher source: `a0a4938`, image
+  `localhost/celln-dispatcher-rotation:a0a4938`.
+- Image configuration SHA256:
+  `80b54a84b6940ceec64ea3e3868d7bc678e63d94a70dee2ef03c425b4640d2f1`.
+- Static dispatcher binary SHA256:
+  `0c5158d5d3c09fa64c30f79730378521941b0b66581d1de62f456a5b78bb6775`.
+- Router: `bb1e718`, the previously deployed chart topology, with separate
+  projected client and backend credentials.
+- Both dispatchers reported zero live cells before image rollout. Rotation
+  begins only after both upgraded Pods are Ready.
+- The protected target is the already completed execution
+  `journal-terminal-proof-647487df-40a5-49c8-8683-a2b82baf07b5`.
+  Its owner is dispatcher-0; dispatcher-1 has no record for that ID.
+
+## Procedure
+
+1. Read the terminal record directly on its owner (200), confirm authenticated
+   non-owner lookup (404), and retrieve the audit through the router Service
+   from the allowed controller-labelled client Pod (200).
+2. Replace `celln-system/celln-dispatcher-backend` with a different valid dummy
+   token. Wait for Secret projection; require the new token to reach each
+   dispatcher's protected lookup and the old token to receive 401 on both.
+   Require the router Service audit request to recover to 200.
+3. Replace that Secret with the invalid value `short`. Require protected
+   requests to both dispatchers and the router Service to return 503.
+4. Restore the original dummy token. Require owner 200, non-owner 404,
+   rotated-token 401 on both dispatchers, and router Service audit 200.
+5. Compare all four service Pod UIDs and restart counts before/after the
+   rotation sequence; changes fail the proof.
+
+The local script has an EXIT trap restoring the original dummy Secret even
+on failure. Each projection wait has a 180-second deadline. Persistent raw
+output is under `target/deployed-kind.JcI9Gg/evidence/rotation-proof.log`.
+
+## Result: passed
+
+All times UTC on 2026-09-07:
+
+| Observation | Time | Result |
+| --- | --- | --- |
+| Baseline owner / non-owner / router Service | 11:33:56–57 | 200 / 404 / 200 |
+| New token accepted on both dispatchers | 11:34:47 | 200 / 404 |
+| Old token rejected on both dispatchers | 11:34:47 | 401 / 401 |
+| Router Service with rotated backend token | 11:34:50 | 200 |
+| Invalid Secret on both dispatchers and router | 11:35:59 | 503 / 503 / 503 |
+| Original token restored on both dispatchers | 11:37:04–20 | 200 / 404 |
+| Rotated token rejected after restoration | 11:37:20 | 401 / 401 |
+| Router Service recovered | 11:37:20 | 200 |
+
+All four Pod UIDs and restart counts were unchanged during rotation:
+
+| Pod | UID | Restarts before and after |
+| --- | --- | --- |
+| celln-router-7766b9c46b-72nv9 | caf3f0b9-5049-4527-af7c-2ee8c5a10214 | 0 |
+| celln-router-7766b9c46b-fshxf | ce5c96da-b3b9-41a7-a418-b54a419acea6 | 1 |
+| dispatcher-0 | cb1ca244-5846-4dca-bc50-0d93af4272e6 | 0 |
+| dispatcher-1 | 5b904fcb-e45c-49e5-a883-ccec46f5df85 | 0 |
+
+The router's existing restart count of one predates this test (the prior
+owner-node restart proof). No provider Secret was present. The original dummy
+backend credential was restored and verified through protected requests.
+
+## Limits
+
+This does not prove simultaneous or zero-downtime rotation: independent
+projected volumes can disagree temporarily. It does not revoke an already
+authorized in-flight request, rotate provider credentials, test TLS, or certify
+production installation/upgrade. No new execution or model call is submitted.
+The authenticated non-owner 404 is expected, not a missing-owner recovery test.


### PR DESCRIPTION
Advances M0 credential rotation in sympozium-ai/sympozium#426. Stacked on #78.

Dispatcher protected requests reopen the credential path instead of retaining the startup token. Router and dispatcher share bounded validation. Invalid or missing files fail closed with 503; replaced old tokens receive 401. Public health semantics are unchanged.

Validation: real TCP unit tests cover atomic replacement, malformed/oversized/missing files and recovery without restart. CARGO_TARGET_DIR=target/deployed make ci passes.

Deployed proof PASSED on isolated kind-celln-deployed: two dispatchers and two router replicas, shared projected backend Secret rotated, old credentials rejected, invalid Secret fails closed across dispatchers and router Service, original restored, all four Pod UIDs/restart counts unchanged. Evidence: docs/evidence/dispatcher-secret-rotation-2026-09-07.md (3ad684a). No model credentials or Framework changes.

Independent Secret projection delays were observed; this is not zero-downtime overlapping-key rotation. Full epic and production release qualification remain open.