### PR TITLE
feat(router): authenticated read-only capability discovery

### DIFF
--- a/crates/celln-cli/src/capabilities.rs
+++ b/crates/celln-cli/src/capabilities.rs
@@ -1,0 +1,43 @@
+//! Versioned preflight, never proof of execution or authority for a named bundle.
+use crate::node::NodeEligibility;
+use serde::{Deserialize, Serialize};
+
+pub(crate) const VERSION: &str = "celln.dev/capabilities-v1alpha1";
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DispatcherCapabilities {
+    pub api_version: String,
+    pub binary_version: String,
+    pub preflight_only: bool,
+    pub node: NodeEligibility,
+    pub request_versions: Vec<String>,
+    pub harness_contracts: Vec<String>,
+    pub persistent_sessions: bool,
+    pub artifact_readiness: String,
+}
+
+impl DispatcherCapabilities {
+    pub fn new(node: NodeEligibility) -> Self {
+        Self {
+            api_version: VERSION.into(),
+            binary_version: env!("CARGO_PKG_VERSION").into(),
+            preflight_only: true,
+            node,
+            request_versions: vec!["celln.dev/v1alpha1".into(), "celln.dev/v1alpha2".into()],
+            harness_contracts: vec!["celln.reference-functions/v1".into()],
+            persistent_sessions: false,
+            artifact_readiness: "not_checked".into(),
+        }
+    }
+
+    pub fn compatible(&self) -> bool {
+        self.api_version == VERSION
+            && self.preflight_only
+            && self
+                .request_versions
+                .iter()
+                .any(|v| v == "celln.dev/v1alpha1")
+            && self.artifact_readiness == "not_checked"
+    }
+}

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -422,6 +422,15 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
         }
     }
     match (method.as_str(), path.as_str()) {
+        ("GET", "/v1/capabilities") => {
+            let registry = state
+                .executions
+                .lock()
+                .expect("dispatcher registry not poisoned");
+            let report =
+                crate::capabilities::DispatcherCapabilities::new(current_node(state, &registry));
+            reply(&mut stream, 200, &serde_json::to_value(report)?)
+        }
         ("GET", "/v1/node") => {
             let registry = state
                 .executions
@@ -1235,7 +1244,11 @@ mod tests {
         let work = tempfile::tempdir().unwrap();
         let state = lifecycle_state(work.path());
         std::fs::create_dir(&state.probe.mote_store).unwrap();
-        for (path, expected) in [("/v1/health", "HTTP/1.1 200"), ("/v1/node", "HTTP/1.1 401")] {
+        for (path, expected) in [
+            ("/v1/health", "HTTP/1.1 200"),
+            ("/v1/node", "HTTP/1.1 401"),
+            ("/v1/capabilities", "HTTP/1.1 401"),
+        ] {
             let listener = TcpListener::bind("127.0.0.1:0").unwrap();
             let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
             let (server, _) = listener.accept().unwrap();
@@ -1254,6 +1267,34 @@ mod tests {
                 assert!(body.get("warm").is_none());
             }
         }
+    }
+
+    #[test]
+    fn capability_report_is_versioned_preflight_and_does_not_advertise_artifact_readiness() {
+        let work = tempfile::tempdir().unwrap();
+        let state = lifecycle_state(work.path());
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (server, _) = listener.accept().unwrap();
+        write!(
+            client,
+            "GET /v1/capabilities HTTP/1.1\r\nAuthorization: Bearer {}\r\n\r\n",
+            state.token
+        )
+        .unwrap();
+        handle(server, &state).unwrap();
+        let mut response = String::new();
+        client.read_to_string(&mut response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 200"));
+        let report: crate::capabilities::DispatcherCapabilities =
+            serde_json::from_str(response.split_once("\r\n\r\n").unwrap().1).unwrap();
+        assert!(report.compatible());
+        assert!(!report.node.eligible()); // Configured stores are absent.
+        assert!(!report.persistent_sessions);
+        assert_eq!(report.harness_contracts, ["celln.reference-functions/v1"]);
+        assert_eq!(report.artifact_readiness, "not_checked");
+        assert!(state.executions.lock().unwrap().is_empty());
+        assert!(!work.path().join("execution-journal").exists());
     }
 
     fn cancel_http(state: &State, id: &str, token: &str) -> String {

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -1,6 +1,7 @@
 //! `celln` command-line interface.
 
 mod agent;
+mod capabilities;
 mod cells;
 mod closure_cli;
 mod config;
@@ -124,6 +125,9 @@ enum Cmd {
         /// Both files are reread per request so rotation does not need a restart.
         #[arg(long)]
         client_token_file: PathBuf,
+        /// Optional read-only bearer credential for GET /v1/capabilities only.
+        #[arg(long)]
+        capability_token_file: Option<PathBuf>,
         /// Durable owner ledger shared by all router replicas (coherent POSIX locks required).
         #[arg(long)]
         ownership_dir: PathBuf,
@@ -416,6 +420,7 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             mode,
             token_file,
             client_token_file,
+            capability_token_file,
             ownership_dir,
         } => router::serve(
             listen,
@@ -424,6 +429,7 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             *mode,
             token_file,
             client_token_file,
+            capability_token_file.as_deref(),
             ownership_dir,
         ),
         Cmd::Node(NodeCmd::Probe { probe }) => node::probe(probe, &root),

--- a/crates/celln-cli/src/node.rs
+++ b/crates/celln-cli/src/node.rs
@@ -9,10 +9,10 @@ use crate::host::Host;
 use crate::NodeProbeArgs;
 use anyhow::{Context, Result};
 use celln_spec::{ExecutionProblem, ExecutionRequest};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeEligibility {
     pub node_name: String,
     pub kvm: bool,

--- a/crates/celln-cli/src/router.rs
+++ b/crates/celln-cli/src/router.rs
@@ -16,7 +16,7 @@ use serde::Deserialize;
 use std::io::{BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -29,13 +29,33 @@ fn read_token(path: &Path) -> Result<String> {
     crate::dispatch_http::read_bearer_token(path)
 }
 
-fn credentials(state: &RouterState) -> Result<(String, String)> {
+fn credentials(state: &RouterState) -> Result<(String, String, Option<String>)> {
     let client = read_token(&state.client_token_file)?;
     let backend = read_token(&state.token_file)?;
     if constant_time_eq(client.as_bytes(), backend.as_bytes()) {
         bail!("client and dispatcher credentials must be distinct");
     }
-    Ok((client, backend))
+    let capability = capability_credential(state, &client, &backend)?;
+    Ok((client, backend, capability))
+}
+
+fn capability_credential(
+    state: &RouterState,
+    client: &str,
+    backend: &str,
+) -> Result<Option<String>> {
+    let token = state
+        .capability_token_file
+        .as_deref()
+        .map(read_token)
+        .transpose()?;
+    if token.as_ref().is_some_and(|token| {
+        constant_time_eq(token.as_bytes(), client.as_bytes())
+            || constant_time_eq(token.as_bytes(), backend.as_bytes())
+    }) {
+        bail!("capability credential must be distinct");
+    }
+    Ok(token)
 }
 
 /// How the router selects a dispatcher backend for each action.
@@ -67,6 +87,7 @@ struct Health {
     kvm: bool,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn serve(
     listen: &str,
     backends: Vec<String>,
@@ -74,6 +95,7 @@ pub fn serve(
     mode: RoutingMode,
     token_file: &Path,
     client_token_file: &Path,
+    capability_token_file: Option<&Path>,
     ownership_dir: &Path,
 ) -> Result<u8> {
     let mut urls: Vec<String> = backends
@@ -115,6 +137,8 @@ pub fn serve(
         executions: ownership::Ledger::open(ownership_dir, 100_000)?,
         token_file: token_file.to_owned(),
         client_token_file: client_token_file.to_owned(),
+        capability_token_file: capability_token_file.map(Path::to_owned),
+        capability_probe_active: AtomicBool::new(false),
     });
     credentials(&state).context("router credentials are missing, invalid or not distinct")?;
     let listener = TcpListener::bind(listen).with_context(|| format!("binding router {listen}"))?;
@@ -146,6 +170,8 @@ struct RouterState {
     executions: ownership::Ledger,
     token_file: PathBuf,
     client_token_file: PathBuf,
+    capability_token_file: Option<PathBuf>,
+    capability_probe_active: AtomicBool,
 }
 
 fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
@@ -226,20 +252,25 @@ fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
         }
     }
 
-    let Ok((client_token, backend_token)) = credentials(state) else {
+    let Ok((client_token, backend_token, read_token)) = credentials(state) else {
         return reply(
             &mut stream,
             503,
             &serde_json::json!({"error":"router credentials unavailable"}),
         );
     };
-    let authorized = authorization
-        .as_deref()
-        .and_then(|value| {
-            let (scheme, token) = value.split_once(' ')?;
-            scheme.eq_ignore_ascii_case("bearer").then_some(token)
-        })
-        .is_some_and(|token| constant_time_eq(token.as_bytes(), client_token.as_bytes()));
+    let presented = authorization.as_deref().and_then(|value| {
+        let (scheme, token) = value.split_once(' ')?;
+        scheme.eq_ignore_ascii_case("bearer").then_some(token)
+    });
+    let is_capability_read = method == "GET" && path == "/v1/capabilities";
+    let authorized = presented.is_some_and(|token| {
+        constant_time_eq(token.as_bytes(), client_token.as_bytes())
+            || (is_capability_read
+                && read_token
+                    .as_ref()
+                    .is_some_and(|read| constant_time_eq(token.as_bytes(), read.as_bytes())))
+    });
     if !authorized {
         return reply(
             &mut stream,
@@ -249,6 +280,7 @@ fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
     }
     let backend_token = Some(backend_token);
     match (method.as_str(), path.as_str()) {
+        ("GET", "/v1/capabilities") => capability_report(state, &mut stream, &backend_token)?,
         ("POST", "/v1/executions") => forward_submission(
             state,
             &mut stream,
@@ -275,6 +307,73 @@ fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn capability_report(
+    state: &RouterState,
+    stream: &mut TcpStream,
+    token: &Option<String>,
+) -> Result<()> {
+    // Bound fanout and permit only one probe at a time per router. No request or
+    // owner ledger is mutated by discovery; failures never trigger execution.
+    if state.backends.len() > 32 || state.capability_probe_active.swap(true, Ordering::AcqRel) {
+        return reply(
+            stream,
+            503,
+            &serde_json::json!({"error":"capability probe unavailable"}),
+        );
+    }
+    struct ProbeGuard<'a>(&'a AtomicBool);
+    impl Drop for ProbeGuard<'_> {
+        fn drop(&mut self) {
+            self.0.store(false, Ordering::Release);
+        }
+    }
+    let _guard = ProbeGuard(&state.capability_probe_active);
+    let nodes = std::thread::scope(|scope| {
+        let probes: Vec<_> = state.backends.iter().enumerate().map(|(index, backend)| {
+            scope.spawn(move || {
+                let report = (|| -> Result<crate::capabilities::DispatcherCapabilities> {
+                    let addr = backend_to_addr(backend)?;
+                    let mut conn = connect(&addr)?;
+                    let credential = token.as_deref().context("backend credential missing")?;
+                    write!(conn, "GET /v1/capabilities HTTP/1.1\r\nHost: dispatcher\r\nAuthorization: Bearer {credential}\r\nConnection: close\r\n\r\n")?;
+                    let response = read_capability_response(&mut conn)?;
+                    if parse_status(&response) != 200 { bail!("backend capability request failed"); }
+                    let report: crate::capabilities::DispatcherCapabilities = serde_json::from_str(extract_body(&response))?;
+                    if !report.compatible() { bail!("incompatible backend capabilities"); }
+                    Ok(report)
+                })();
+                match report {
+                    Ok(report) => serde_json::json!({"index":index,"preflightEligible":report.node.eligible(),"report":report}),
+                    Err(_) => serde_json::json!({"index":index,"preflightEligible":false,"reason":"unreachable_unauthorized_or_incompatible"}),
+                }
+            })
+        }).collect();
+        probes
+            .into_iter()
+            .map(|probe| {
+                probe.join().unwrap_or_else(
+                    |_| serde_json::json!({"preflightEligible":false,"reason":"probe_failed"}),
+                )
+            })
+            .collect::<Vec<_>>()
+    });
+    let eligible = nodes
+        .iter()
+        .filter(|node| node["preflightEligible"] == true)
+        .count();
+    reply(
+        stream,
+        200,
+        &serde_json::json!({
+            "apiVersion":crate::capabilities::VERSION,
+            "preflightOnly":true,
+            "eligibleNodes":eligible,
+            "artifactReadiness":"not_checked",
+            "nodes":nodes,
+        }),
+    )
 }
 
 /// `POST <endpoint>`: pick a healthy backend deterministically by the
@@ -548,10 +647,37 @@ fn connect(addr: &str) -> Result<TcpStream> {
 fn read_response(stream: &mut TcpStream) -> Result<String> {
     // Dispatchers close each response. Bound the entire wire message, including
     // headers; a truncated header must not cause an infinite EOF loop.
-    const MAX_RESPONSE: u64 = 16 * 1024 * 1024;
+    read_response_limit(stream, 16 * 1024 * 1024)
+}
+
+fn read_capability_response(stream: &mut TcpStream) -> Result<String> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
     let mut bytes = Vec::new();
-    stream.take(MAX_RESPONSE + 1).read_to_end(&mut bytes)?;
-    if bytes.len() as u64 > MAX_RESPONSE || !bytes.windows(4).any(|w| w == b"\r\n\r\n") {
+    let mut buf = [0u8; 4096];
+    loop {
+        let remaining = deadline
+            .checked_duration_since(std::time::Instant::now())
+            .context("capability response deadline exceeded")?;
+        stream.set_read_timeout(Some(remaining))?;
+        let n = stream.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buf[..n]);
+        if bytes.len() > 65536 {
+            bail!("oversized capability response");
+        }
+    }
+    if !bytes.windows(4).any(|w| w == b"\r\n\r\n") {
+        bail!("invalid capability response");
+    }
+    String::from_utf8(bytes).context("invalid capability encoding")
+}
+
+fn read_response_limit(stream: &mut TcpStream, max_response: u64) -> Result<String> {
+    let mut bytes = Vec::new();
+    stream.take(max_response + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > max_response || !bytes.windows(4).any(|w| w == b"\r\n\r\n") {
         bail!("invalid or oversized dispatcher response");
     }
     String::from_utf8(bytes).context("dispatcher response is not UTF-8")
@@ -661,6 +787,182 @@ mod tests {
     const BACKEND_TOKEN: &str = "backend-test-credential-at-least-24";
 
     #[test]
+    fn capability_token_is_read_only_distinct_and_rotatable() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = state(dir.path());
+        let path = dir.path().join("capability");
+        let first = "readonly-test-credential-at-least-24";
+        let second = "rotated-readonly-credential-at-least-24";
+        std::fs::write(&path, first).unwrap();
+        state.capability_token_file = Some(path.clone());
+        let headers = |token| format!("Authorization: Bearer {token}\r\n");
+        for token in [first, CLIENT_TOKEN] {
+            let response = request(&state, "GET", "/v1/capabilities", &headers(token), "");
+            assert_eq!(parse_status(&response), 200);
+            let report: serde_json::Value = serde_json::from_str(extract_body(&response)).unwrap();
+            assert_eq!(report["eligibleNodes"], 0);
+            assert_eq!(report["preflightOnly"], true);
+        }
+        for (method, path) in [
+            ("POST", "/v1/executions"),
+            ("GET", "/v1/executions/x"),
+            ("GET", "/v1/executions/x/audit"),
+            ("POST", "/v1/executions/x/cancel"),
+            ("POST", "/v1/capabilities"),
+            ("GET", "/v1/node"),
+        ] {
+            assert_eq!(
+                parse_status(&request(&state, method, path, &headers(first), "")),
+                401
+            );
+        }
+        for token in ["", BACKEND_TOKEN, "wrong"] {
+            assert_eq!(
+                parse_status(&request(
+                    &state,
+                    "GET",
+                    "/v1/capabilities",
+                    &headers(token),
+                    ""
+                )),
+                401
+            );
+        }
+        std::fs::write(&path, second).unwrap();
+        assert_eq!(
+            parse_status(&request(
+                &state,
+                "GET",
+                "/v1/capabilities",
+                &headers(first),
+                ""
+            )),
+            401
+        );
+        assert_eq!(
+            parse_status(&request(
+                &state,
+                "GET",
+                "/v1/capabilities",
+                &headers(second),
+                ""
+            )),
+            200
+        );
+        for invalid in [CLIENT_TOKEN, BACKEND_TOKEN, "short"] {
+            std::fs::write(&path, invalid).unwrap();
+            assert!(credentials(&state).is_err());
+            assert_eq!(
+                parse_status(&request(
+                    &state,
+                    "GET",
+                    "/v1/capabilities",
+                    &headers(second),
+                    ""
+                )),
+                503
+            );
+        }
+        std::fs::remove_file(path).unwrap();
+        assert_eq!(
+            parse_status(&request(
+                &state,
+                "GET",
+                "/v1/capabilities",
+                &headers(second),
+                ""
+            )),
+            503
+        );
+    }
+
+    #[test]
+    fn capability_fanout_requires_authenticated_compatible_eligible_reports() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = state(dir.path());
+        let base = crate::capabilities::DispatcherCapabilities::new(crate::node::NodeEligibility {
+            node_name: "fixture".into(),
+            kvm: true,
+            cpu_virtualization: true,
+            guest_kernel: true,
+            mote_store: true,
+            tool_store: true,
+            live_cells: 0,
+            max_cells: 1,
+            memory_bytes: 268435456,
+            egress_slots: 1,
+        });
+        let good = serde_json::to_value(base).unwrap();
+        let mut missing_kvm = good.clone();
+        missing_kvm["node"]["kvm"] = false.into();
+        let mut full = good.clone();
+        full["node"]["live_cells"] = 1.into();
+        let mut incompatible = good.clone();
+        incompatible["apiVersion"] = "future/unknown".into();
+        let fixtures = [
+            (200, good),
+            (200, missing_kvm),
+            (200, full),
+            (200, incompatible),
+            (401, serde_json::json!({})),
+            (200, serde_json::json!({"ok":true,"kvm":true})),
+        ];
+        std::thread::scope(|scope| {
+            for (status, body) in fixtures {
+                let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+                state
+                    .backends
+                    .push(format!("http://{}", listener.local_addr().unwrap()));
+                scope.spawn(move || {
+                    let (mut stream, _) = listener.accept().unwrap();
+                    let mut reader = BufReader::new(stream.try_clone().unwrap());
+                    let line = read_bounded_line(&mut reader, MAX_REQUEST_LINE).unwrap();
+                    assert_eq!(line, "GET /v1/capabilities HTTP/1.1\r\n");
+                    let mut seen_backend = false;
+                    loop {
+                        let line = read_bounded_line(&mut reader, MAX_HEADER_LINE).unwrap();
+                        if line.trim().is_empty() {
+                            break;
+                        }
+                        if line.starts_with("Authorization:") {
+                            assert_eq!(line, format!("Authorization: Bearer {BACKEND_TOKEN}\r\n"));
+                            seen_backend = true;
+                        }
+                    }
+                    assert!(seen_backend);
+                    reply(&mut stream, status, &body).unwrap();
+                });
+            }
+            let response = request(
+                &state,
+                "GET",
+                "/v1/capabilities",
+                &format!("Authorization: Bearer {CLIENT_TOKEN}\r\n"),
+                "",
+            );
+            assert_eq!(parse_status(&response), 200);
+            let report: serde_json::Value = serde_json::from_str(extract_body(&response)).unwrap();
+            assert_eq!(report["eligibleNodes"], 1);
+            assert_eq!(report["nodes"].as_array().unwrap().len(), 6);
+            assert_eq!(report["artifactReadiness"], "not_checked");
+            assert_eq!(report["nodes"][0]["report"]["persistentSessions"], false);
+            assert!(!response.contains(BACKEND_TOKEN));
+        });
+        assert!(!state.capability_probe_active.load(Ordering::Acquire));
+        state.capability_probe_active.store(true, Ordering::Release);
+        assert_eq!(
+            parse_status(&request(
+                &state,
+                "GET",
+                "/v1/capabilities",
+                &format!("Authorization: Bearer {CLIENT_TOKEN}\r\n"),
+                ""
+            )),
+            503
+        );
+    }
+
+    #[test]
     fn lost_acceptance_is_not_replayed_and_fresh_replica_recovers_owner() {
         let dir = tempfile::tempdir().unwrap();
         let mut first = state(dir.path());
@@ -767,6 +1069,8 @@ mod tests {
             executions: ownership::Ledger::open(&dir.join("ownership"), 100).unwrap(),
             token_file,
             client_token_file,
+            capability_token_file: None,
+            capability_probe_active: AtomicBool::new(false),
         }
     }
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -1,0 +1,79 @@
+# Authenticated execution-plane capabilities
+
+`GET /v1/capabilities` is a read-only, separately versioned preflight endpoint
+on both dispatcher and router. It neither creates a cell nor claims an execution
+owner. A reachable TCP port, HTTP 200, or a positive eligible-node count is not
+proof that a particular Harness/task can execute.
+
+## Authentication and deployment
+
+The dispatcher requires its backend bearer credential. The router accepts its
+existing execution-client credential, or an optional **distinct read-only**
+credential configured with `--capability-token-file PATH`. This latter token is
+accepted only for `GET /v1/capabilities`: it cannot submit, poll, audit or cancel
+executions. Do not give the UI/API server the execution-client or backend token
+just to discover readiness.
+
+All configured credentials reload per request, use bounded validation, and must
+be pairwise distinct. Missing/invalid configured credentials return 503; wrong
+or absent caller credentials return 401. If no capability token is configured,
+only the existing execution-client credential can read router capabilities.
+This optional flag preserves existing router startup commands. Use projected
+Secret directories, not `subPath` mounts, and retain authenticated/encrypted
+transport. This endpoint does not add TLS to Celln.
+
+Sympozium still needs coordinated API-server credential mounting, narrowly
+scoped NetworkPolicy ingress, and a version-aware consumer before this replaces
+its TCP-only check. That integration is not delivered merely by adding this
+endpoint. Never relax ingress to all namespace Pods for capability discovery.
+
+## Wire contract
+
+Both envelopes use `apiVersion: celln.dev/capabilities-v1alpha1` and
+`preflightOnly: true`. Dispatcher fields:
+
+- `binaryVersion`: build package version, not an image digest or attestation.
+- `node`: the existing NodeEligibility fields (snake_case), measured using the
+  dispatcher's configured stores, host preflight and current reservations.
+- `requestVersions`: `celln.dev/v1alpha1` and `celln.dev/v1alpha2`. Support is
+  subject to their existing combination/authority guards; not every valid
+  request is supported.
+- `harnessContracts`: only `celln.reference-functions/v1`. This is the bounded
+  reference adapter, not arbitrary OCI/Pi/Hermes Harness support.
+- `persistentSessions: false`.
+- `artifactReadiness: not_checked`. Readable stores are not proof of approved
+  artifacts, signatures, publisher admission, model grants or a warm template.
+
+Router fields:
+
+- `eligibleNodes`: count of compatible authenticated reports whose node passes
+  the existing eligibility predicate, including available cell/memory capacity.
+- `nodes`: one entry per configured backend, with its configuration `index`,
+  `preflightEligible`, and parsed `report`. A failed probe instead includes a
+  generic reason; backend errors, credentials and URLs are not echoed.
+- `artifactReadiness: not_checked`.
+
+Older dispatcher 404s, auth failures, malformed or incompatible reports never
+become eligible through fallback to public health/TCP. Per-node features are
+not unioned: one node supporting a feature and another having capacity does not
+establish an eligible placement for that feature. Zero eligible nodes can still
+return HTTP 200: consumers must validate the version and report, not the status
+code alone. The report does not reserve capacity; execution rechecks authority
+and eligibility.
+
+## Bounds and remaining qualification
+
+One capability fanout runs at a time per router; concurrent probes receive 503.
+Fanout is capped at 32 configured backends (larger configurations return 503
+for discovery without changing execution routing). Responses are capped at
+64 KiB per backend and two seconds of response reading, including slow-drip
+traffic. Existing connection/DNS handling applies: a three-second connect
+timeout does not bound the system resolver. No fleet-scale or latency claim is
+made. Consumers need their own end-to-end deadline and must handle busy probes.
+
+TCP tests cover read-only scope, rotation, distinct credentials, authenticated
+fanout and incompatible/unavailable/capacity reports. Dispatcher tests check
+version/authentication and no execution side effects. These are protocol tests,
+not guest isolation or a deployed discovery proof. Named-artifact validation,
+prewarming, catalogue selection and the Sympozium consumer remain follow-on work
+within epic sympozium-ai/sympozium#426.

--- a/docs/NODE_CAPACITY.md
+++ b/docs/NODE_CAPACITY.md
@@ -33,6 +33,10 @@ starting independently of this service. Run one managed dispatcher per node.
 
 ## Reports
 
+For versioned discovery through the router, see
+[authenticated capabilities](CAPABILITIES.md). Its preflight result deliberately
+does not advertise readiness for an unchecked runtime/tool bundle.
+
 `GET /v1/health` remains public and returns HTTP 200 for a reachable service;
 `ok` describes admission preflight, not merely `/dev/kvm` pathname presence.
 It uses configured mote/tool-store directories, the loader's kernel-format


### PR DESCRIPTION
Advances M0 of sympozium-ai/sympozium#426. Stacked on #79.

Adds versioned GET /v1/capabilities to dispatcher and router. The router authenticates backend probes and reports compatible node preflight eligibility, current capacity and narrowly supported request/Harness contracts. Artifact readiness remains explicitly not_checked and persistent sessions false; no public-health/TCP fallback.

An optional distinct --capability-token-file grants only this GET, never submission, polling, audit or cancellation. Credentials reload per request. Fanout is bounded to 32 backends and one active probe per router, with bounded response bytes/time.

Tests cover read-only authority, rotation/distinctness, actual TCP backend auth, incompatible/auth-failed/missing-KVM/full nodes, dispatcher version/auth and no execution side effects. CARGO_TARGET_DIR=target/deployed make ci passes.

Contract and limits: docs/CAPABILITIES.md. Sympozium consumer, scoped chart credentials/ingress, deployed discovery proof and named-artifact readiness are still required. This PR alone does not replace the UI availability check or complete the epic.