### PR TITLE
feat(closure): bound read-only verification and shared policy checks

### DIFF
--- a/crates/celln-cli/src/capabilities.rs
+++ b/crates/celln-cli/src/capabilities.rs
@@ -1,0 +1,43 @@
+//! Versioned preflight, never proof of execution or authority for a named bundle.
+use crate::node::NodeEligibility;
+use serde::{Deserialize, Serialize};
+
+pub(crate) const VERSION: &str = "celln.dev/capabilities-v1alpha1";
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DispatcherCapabilities {
+    pub api_version: String,
+    pub binary_version: String,
+    pub preflight_only: bool,
+    pub node: NodeEligibility,
+    pub request_versions: Vec<String>,
+    pub harness_contracts: Vec<String>,
+    pub persistent_sessions: bool,
+    pub artifact_readiness: String,
+}
+
+impl DispatcherCapabilities {
+    pub fn new(node: NodeEligibility) -> Self {
+        Self {
+            api_version: VERSION.into(),
+            binary_version: env!("CARGO_PKG_VERSION").into(),
+            preflight_only: true,
+            node,
+            request_versions: vec!["celln.dev/v1alpha1".into(), "celln.dev/v1alpha2".into()],
+            harness_contracts: vec!["celln.reference-functions/v1".into()],
+            persistent_sessions: false,
+            artifact_readiness: "not_checked".into(),
+        }
+    }
+
+    pub fn compatible(&self) -> bool {
+        self.api_version == VERSION
+            && self.preflight_only
+            && self
+                .request_versions
+                .iter()
+                .any(|v| v == "celln.dev/v1alpha1")
+            && self.artifact_readiness == "not_checked"
+    }
+}

--- a/crates/celln-cli/src/closure_cli.rs
+++ b/crates/celln-cli/src/closure_cli.rs
@@ -1,7 +1,11 @@
 //! Offline publisher tooling. Private keys never enter a dispatcher request.
 use anyhow::{Context, Result};
-use celln_manifest::closure::{Closure, SignedClosure};
-use std::{collections::BTreeSet, io::Read, path::Path};
+use celln_manifest::closure::Closure;
+use std::{io::Read, path::Path};
+
+fn read(path: &Path) -> Result<Vec<u8>> {
+    crate::closure_policy::read_bounded(path).map_err(anyhow::Error::msg)
+}
 
 pub fn sign(descriptor: &Path, key: &Path) -> Result<u8> {
     let closure: Closure = serde_json::from_slice(&read(descriptor)?)?;
@@ -20,48 +24,211 @@ pub fn sign(descriptor: &Path, key: &Path) -> Result<u8> {
     Ok(0)
 }
 
-fn read(path: &Path) -> Result<Vec<u8>> {
-    let mut bytes = Vec::new();
-    std::fs::File::open(path)?
-        .take(262145)
-        .read_to_end(&mut bytes)?;
-    anyhow::ensure!(bytes.len() <= 262144, "closure descriptor too large");
-    Ok(bytes)
-}
-
 pub fn admit(descriptor: &Path, root: &Path) -> Result<u8> {
-    #[derive(serde::Deserialize)]
-    #[serde(rename_all = "camelCase", deny_unknown_fields)]
-    struct Policy {
-        api_version: String,
-        publishers: BTreeSet<String>,
-        revoked: BTreeSet<String>,
-    }
     let bytes = read(descriptor)?;
-    let signed: SignedClosure = serde_json::from_slice(&bytes)?;
-    let policy: Policy = serde_json::from_slice(&read(&root.join("trusted-closures.json"))?)?;
-    anyhow::ensure!(
-        policy.api_version == "celln.dev/closure-policy-v1",
-        "unsupported closure policy"
-    );
-    signed
-        .verify(&policy.publishers)
-        .map_err(anyhow::Error::msg)?;
-    let identity = celln_manifest::Hash::of(&bytes);
-    anyhow::ensure!(
-        !policy.revoked.contains(&identity.0)
-            && !policy.revoked.contains(&signed.closure.toolfs)
-            && signed
-                .closure
-                .members
-                .values()
-                .all(|m| !policy.revoked.contains(&m.hash)),
-        "closure revoked"
-    );
+    let verified = crate::closure_policy::verify(&bytes, root).map_err(anyhow::Error::msg)?;
     let hash = celln_store::Store::open(root.join("closures"))?.put(&bytes)?;
     println!(
         "{}",
-        serde_json::json!({"closure": hash.0,"publisher": signed.publisher})
+        serde_json::json!({"closure": hash.0,"publisher": verified.signed.publisher})
     );
     Ok(0)
+}
+
+pub fn verify(
+    descriptor: &Path,
+    root: &Path,
+    expected_hash: &str,
+    publisher: &str,
+    entry_point: &str,
+    executable: &str,
+) -> Result<u8> {
+    let report = verification_report(
+        &read(descriptor)?,
+        root,
+        expected_hash,
+        publisher,
+        entry_point,
+        executable,
+    )?;
+    println!("{}", serde_json::to_string(&report)?);
+    Ok(0)
+}
+
+fn verification_report(
+    bytes: &[u8],
+    root: &Path,
+    expected_hash: &str,
+    publisher: &str,
+    entry_point: &str,
+    executable: &str,
+) -> Result<serde_json::Value> {
+    let verified = crate::closure_policy::verify(bytes, root).map_err(anyhow::Error::msg)?;
+    anyhow::ensure!(
+        verified.identity.0 == expected_hash,
+        "closure identity mismatch"
+    );
+    anyhow::ensure!(
+        verified.signed.publisher == publisher,
+        "catalogue publisher mismatch"
+    );
+    let closure = &verified.signed.closure;
+    anyhow::ensure!(
+        closure
+            .members
+            .get(entry_point)
+            .is_some_and(|member| member.hash == executable),
+        "catalogue executable member mismatch"
+    );
+    Ok(serde_json::json!({
+        "apiVersion": "celln.dev/closure-verification-v1",
+        "scope": "descriptor-authenticity-only",
+        "closure": verified.identity.0,
+        "policyHash": verified.policy_hash.0,
+        "publisher": verified.signed.publisher,
+        "entryPoint": entry_point,
+        "executable": executable,
+        "toolfs": closure.toolfs,
+        "closureEntryPoint": closure.entrypoint,
+        "interpreter": closure.interpreter,
+        "members": closure.members,
+        "artifactReadiness": "not_checked",
+        "conformance": "not_checked"
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use celln_manifest::{closure::Member, Hash};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn fixture() -> (tempfile::TempDir, Vec<u8>, String, String) {
+        let root = tempfile::tempdir().unwrap();
+        let executable = Hash::of(b"fixture executable").0;
+        let signed = Closure {
+            api_version: "celln.dev/closure-v1".into(),
+            toolfs: Hash::of(b"fixture filesystem").0,
+            entrypoint: "/tools/example".into(),
+            interpreter: false,
+            members: BTreeMap::from([(
+                "/tools/example".into(),
+                Member {
+                    hash: executable.clone(),
+                    dependencies: BTreeSet::new(),
+                },
+            )]),
+        }
+        .sign(&[42; 32])
+        .unwrap();
+        let publisher = signed.publisher.clone();
+        std::fs::write(root.path().join("trusted-closures.json"), serde_json::to_vec(&serde_json::json!({"apiVersion":"celln.dev/closure-policy-v1","publishers":[publisher],"revoked":[]})).unwrap()).unwrap();
+        (
+            root,
+            serde_json::to_vec_pretty(&signed).unwrap(),
+            publisher,
+            executable,
+        )
+    }
+
+    #[test]
+    fn report_binds_exact_bytes_and_does_not_admit_or_claim_readiness() {
+        let (root, bytes, publisher, executable) = fixture();
+        let expected = Hash::of(&bytes).0;
+        let report = verification_report(
+            &bytes,
+            root.path(),
+            &expected,
+            &publisher,
+            "/tools/example",
+            &executable,
+        )
+        .unwrap();
+        assert_eq!(report["closure"], expected);
+        assert_eq!(report["artifactReadiness"], "not_checked");
+        assert_eq!(report["conformance"], "not_checked");
+        assert_eq!(report["scope"], "descriptor-authenticity-only");
+        assert_eq!(
+            report["policyHash"],
+            Hash::of(&std::fs::read(root.path().join("trusted-closures.json")).unwrap()).0
+        );
+        assert!(!root.path().join("closures").exists());
+        for (hash, key, path, program) in [
+            (
+                "wrong",
+                publisher.as_str(),
+                "/tools/example",
+                executable.as_str(),
+            ),
+            (
+                expected.as_str(),
+                "wrong",
+                "/tools/example",
+                executable.as_str(),
+            ),
+            (
+                expected.as_str(),
+                publisher.as_str(),
+                "/tools/unlisted",
+                executable.as_str(),
+            ),
+            (
+                expected.as_str(),
+                publisher.as_str(),
+                "/tools/example",
+                "wrong",
+            ),
+        ] {
+            assert!(verification_report(&bytes, root.path(), hash, key, path, program).is_err());
+        }
+        let mut reformatted = bytes.clone();
+        reformatted.push(b'\n');
+        assert!(verification_report(
+            &reformatted,
+            root.path(),
+            &expected,
+            &publisher,
+            "/tools/example",
+            &executable
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn shared_verifier_rechecks_policy_and_all_revocation_targets() {
+        let (root, bytes, publisher, executable) = fixture();
+        let signed: celln_manifest::closure::SignedClosure =
+            serde_json::from_slice(&bytes).unwrap();
+        for revoked in [Hash::of(&bytes).0, signed.closure.toolfs, executable] {
+            std::fs::write(root.path().join("trusted-closures.json"),serde_json::to_vec(&serde_json::json!({"apiVersion":"celln.dev/closure-policy-v1","publishers":[publisher],"revoked":[revoked]})).unwrap()).unwrap();
+            assert!(crate::closure_policy::verify(&bytes, root.path())
+                .err()
+                .unwrap()
+                .contains("revoked"));
+        }
+    }
+
+    #[test]
+    fn shared_verifier_refuses_tampering_missing_trust_and_oversize() {
+        let (root, bytes, _, _) = fixture();
+        let mut tampered: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        tampered["closure"]["interpreter"] = true.into();
+        assert!(crate::closure_policy::verify(
+            &serde_json::to_vec(&tampered).unwrap(),
+            root.path()
+        )
+        .is_err());
+        assert!(crate::closure_policy::verify(&vec![b' '; 262145], root.path()).is_err());
+        for policy in [
+            serde_json::json!({"apiVersion":"unknown","publishers":[],"revoked":[]}).to_string(),
+            serde_json::json!({"apiVersion":"celln.dev/closure-policy-v1","publishers":[],"revoked":[]}).to_string(),
+            " ".repeat(262145),
+            "invalid".into(),
+        ] {
+            std::fs::write(root.path().join("trusted-closures.json"),policy).unwrap();
+            assert!(crate::closure_policy::verify(&bytes,root.path()).is_err());
+        }
+        let absent = tempfile::tempdir().unwrap();
+        assert!(crate::closure_policy::verify(&bytes, absent.path()).is_err());
+    }
 }

--- a/crates/celln-cli/src/closure_policy.rs
+++ b/crates/celln-cli/src/closure_policy.rs
@@ -1,0 +1,64 @@
+//! Shared, bounded host-policy verification. No admission-store writes.
+use celln_manifest::{closure::SignedClosure, Hash};
+use serde::Deserialize;
+use std::{collections::BTreeSet, io::Read, path::Path};
+
+pub const MAX_DESCRIPTOR_BYTES: usize = 262144;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Policy {
+    api_version: String,
+    publishers: BTreeSet<String>,
+    revoked: BTreeSet<String>,
+}
+
+pub struct Verified {
+    pub signed: SignedClosure,
+    pub identity: Hash,
+    pub policy_hash: Hash,
+}
+
+pub fn read_bounded(path: &Path) -> Result<Vec<u8>, String> {
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)
+        .map_err(|_| "closure descriptor or policy unavailable")?
+        .take((MAX_DESCRIPTOR_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|_| "closure descriptor or policy unreadable")?;
+    if bytes.len() > MAX_DESCRIPTOR_BYTES {
+        return Err("closure descriptor or policy exceeds 256 KiB".into());
+    }
+    Ok(bytes)
+}
+
+pub fn verify(bytes: &[u8], root: &Path) -> Result<Verified, String> {
+    if bytes.len() > MAX_DESCRIPTOR_BYTES {
+        return Err("closure descriptor exceeds 256 KiB".into());
+    }
+    let policy_bytes = read_bounded(&root.join("trusted-closures.json"))?;
+    let policy: Policy =
+        serde_json::from_slice(&policy_bytes).map_err(|_| "invalid closure trust policy")?;
+    if policy.api_version != "celln.dev/closure-policy-v1" {
+        return Err("unsupported closure policy".into());
+    }
+    let signed: SignedClosure =
+        serde_json::from_slice(bytes).map_err(|_| "invalid signed closure")?;
+    signed.verify(&policy.publishers)?;
+    let identity = Hash::of(bytes);
+    if policy.revoked.contains(&identity.0)
+        || policy.revoked.contains(&signed.closure.toolfs)
+        || signed
+            .closure
+            .members
+            .values()
+            .any(|m| policy.revoked.contains(&m.hash))
+    {
+        return Err("closure or dependency revoked".into());
+    }
+    Ok(Verified {
+        signed,
+        identity,
+        policy_hash: Hash::of(&policy_bytes),
+    })
+}

--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -974,7 +974,9 @@ mod tests {
     pub(super) fn test_runtime_root(work: &Path) -> Option<std::path::PathBuf> {
         let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."); // crates/celln-cli -> repo root
         let repo_root = repo_root.canonicalize().expect("repo root resolves");
-        let pilot_dir = repo_root.join("target/x86_64-unknown-linux-musl/release");
+        let pilot_dir = std::env::var_os("CELLN_PILOT_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| repo_root.join("target/x86_64-unknown-linux-musl/release"));
         if !pilot_dir.join("celln-pilot").exists() || !pilot_dir.join("pilot-fetch").exists() {
             eprintln!(
                 "skipping: guest pilot binaries not built — run \

--- a/crates/celln-cli/src/dispatch_closure.rs
+++ b/crates/celln-cli/src/dispatch_closure.rs
@@ -1,20 +1,12 @@
 //! Resolve authenticated, precomposed closures without consulting host runtimes.
 use celln_manifest::{closure::SignedClosure, Hash};
 use celln_spec::ExecutionRequest;
-use serde::{Deserialize, Serialize};
-use std::{collections::BTreeSet, path::Path};
+use serde::Serialize;
+use std::path::Path;
 
 #[cfg(all(test, target_os = "linux"))]
 #[path = "dispatch_closure_tests.rs"]
 mod tests;
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct Policy {
-    api_version: String,
-    publishers: BTreeSet<String>,
-    revoked: BTreeSet<String>,
-}
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -46,16 +38,6 @@ pub fn resolve(
             "unsupported authority: closure requires celln.warm-closure-v1 substrate".into(),
         );
     }
-    let policy: Policy = serde_json::from_slice(
-        &std::fs::read(root.join("trusted-closures.json"))
-            .map_err(|_| "closure trust policy unavailable")?,
-    )
-    .map_err(|_| "invalid closure trust policy")?;
-    if policy.api_version != "celln.dev/closure-policy-v1"
-        || policy.revoked.contains(&reference.hash)
-    {
-        return Err("closure policy version unsupported or closure revoked".into());
-    }
     let store = celln_store::Store::open(root.join("closures")).map_err(|e| e.to_string())?;
     let bytes = store
         .get_bounded(&Hash(reference.hash.clone()), 262144)
@@ -63,9 +45,8 @@ pub fn resolve(
     if bytes.len() > 262144 {
         return Err("closure descriptor exceeds limit".into());
     }
-    let signed: SignedClosure =
-        serde_json::from_slice(&bytes).map_err(|_| "invalid signed closure")?;
-    signed.verify(&policy.publishers)?;
+    let verified = crate::closure_policy::verify(&bytes, root)?;
+    let signed = verified.signed;
     let closure = &signed.closure;
     if bundle.toolfs_bytes.len() as u64 > crate::image::MAX_IMAGE_BYTES {
         return Err("unsupported closure filesystem exceeds 512 MiB".into());
@@ -74,14 +55,6 @@ pub fn resolve(
         || closure.members[&closure.entrypoint].hash != bundle.program_hash
     {
         return Err("closure does not bind selected filesystem and executable".into());
-    }
-    if closure
-        .members
-        .values()
-        .any(|m| policy.revoked.contains(&m.hash))
-        || policy.revoked.contains(&closure.toolfs)
-    {
-        return Err("closure dependency revoked".into());
     }
     let provenance = Provenance {
         hash: reference.hash.clone(),

--- a/crates/celln-cli/src/dispatch_conformance.rs
+++ b/crates/celln-cli/src/dispatch_conformance.rs
@@ -18,7 +18,9 @@ pub(crate) fn prove_closure(
     root: &Path,
     evidence: &Path,
 ) {
-    let binary = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/celln");
+    let binary = std::env::var_os("CELLN_TEST_BINARY")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/celln"));
     let address = TcpListener::bind("127.0.0.1:0")
         .unwrap()
         .local_addr()

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -422,6 +422,15 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
         }
     }
     match (method.as_str(), path.as_str()) {
+        ("GET", "/v1/capabilities") => {
+            let registry = state
+                .executions
+                .lock()
+                .expect("dispatcher registry not poisoned");
+            let report =
+                crate::capabilities::DispatcherCapabilities::new(current_node(state, &registry));
+            reply(&mut stream, 200, &serde_json::to_value(report)?)
+        }
         ("GET", "/v1/node") => {
             let registry = state
                 .executions
@@ -1235,7 +1244,11 @@ mod tests {
         let work = tempfile::tempdir().unwrap();
         let state = lifecycle_state(work.path());
         std::fs::create_dir(&state.probe.mote_store).unwrap();
-        for (path, expected) in [("/v1/health", "HTTP/1.1 200"), ("/v1/node", "HTTP/1.1 401")] {
+        for (path, expected) in [
+            ("/v1/health", "HTTP/1.1 200"),
+            ("/v1/node", "HTTP/1.1 401"),
+            ("/v1/capabilities", "HTTP/1.1 401"),
+        ] {
             let listener = TcpListener::bind("127.0.0.1:0").unwrap();
             let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
             let (server, _) = listener.accept().unwrap();
@@ -1254,6 +1267,34 @@ mod tests {
                 assert!(body.get("warm").is_none());
             }
         }
+    }
+
+    #[test]
+    fn capability_report_is_versioned_preflight_and_does_not_advertise_artifact_readiness() {
+        let work = tempfile::tempdir().unwrap();
+        let state = lifecycle_state(work.path());
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (server, _) = listener.accept().unwrap();
+        write!(
+            client,
+            "GET /v1/capabilities HTTP/1.1\r\nAuthorization: Bearer {}\r\n\r\n",
+            state.token
+        )
+        .unwrap();
+        handle(server, &state).unwrap();
+        let mut response = String::new();
+        client.read_to_string(&mut response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 200"));
+        let report: crate::capabilities::DispatcherCapabilities =
+            serde_json::from_str(response.split_once("\r\n\r\n").unwrap().1).unwrap();
+        assert!(report.compatible());
+        assert!(!report.node.eligible()); // Configured stores are absent.
+        assert!(!report.persistent_sessions);
+        assert_eq!(report.harness_contracts, ["celln.reference-functions/v1"]);
+        assert_eq!(report.artifact_readiness, "not_checked");
+        assert!(state.executions.lock().unwrap().is_empty());
+        assert!(!work.path().join("execution-journal").exists());
     }
 
     fn cancel_http(state: &State, id: &str, token: &str) -> String {

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -1,6 +1,7 @@
 //! `celln` command-line interface.
 
 mod agent;
+mod capabilities;
 mod cells;
 mod closure_cli;
 mod config;
@@ -124,6 +125,9 @@ enum Cmd {
         /// Both files are reread per request so rotation does not need a restart.
         #[arg(long)]
         client_token_file: PathBuf,
+        /// Optional read-only bearer credential for GET /v1/capabilities only.
+        #[arg(long)]
+        capability_token_file: Option<PathBuf>,
         /// Durable owner ledger shared by all router replicas (coherent POSIX locks required).
         #[arg(long)]
         ownership_dir: PathBuf,
@@ -416,6 +420,7 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             mode,
             token_file,
             client_token_file,
+            capability_token_file,
             ownership_dir,
         } => router::serve(
             listen,
@@ -424,6 +429,7 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             *mode,
             token_file,
             client_token_file,
+            capability_token_file.as_deref(),
             ownership_dir,
         ),
         Cmd::Node(NodeCmd::Probe { probe }) => node::probe(probe, &root),

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -4,6 +4,7 @@ mod agent;
 mod capabilities;
 mod cells;
 mod closure_cli;
+mod closure_policy;
 mod config;
 mod dispatch;
 #[cfg(all(test, target_os = "linux"))]
@@ -340,6 +341,19 @@ enum ClosureCmd {
     },
     /// Verify against host policy and store a signed descriptor by content hash.
     Admit { descriptor: PathBuf },
+    /// Read-only signature/policy check bound to exact catalogue identities.
+    /// Does not certify artifact distribution, conformance or execution readiness.
+    Verify {
+        descriptor: PathBuf,
+        #[arg(long)]
+        expected_hash: String,
+        #[arg(long)]
+        publisher: String,
+        #[arg(long)]
+        entry_point: String,
+        #[arg(long)]
+        executable: String,
+    },
 }
 
 #[derive(clap::Args, Clone)]
@@ -398,6 +412,20 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             key_file,
         }) => closure_cli::sign(descriptor, key_file),
         Cmd::Closure(ClosureCmd::Admit { descriptor }) => closure_cli::admit(descriptor, &root),
+        Cmd::Closure(ClosureCmd::Verify {
+            descriptor,
+            expected_hash,
+            publisher,
+            entry_point,
+            executable,
+        }) => closure_cli::verify(
+            descriptor,
+            &root,
+            expected_hash,
+            publisher,
+            entry_point,
+            executable,
+        ),
         Cmd::Doctor => Ok(doctor(o)),
         Cmd::Dispatcher {
             listen,

--- a/crates/celln-cli/src/node.rs
+++ b/crates/celln-cli/src/node.rs
@@ -9,10 +9,10 @@ use crate::host::Host;
 use crate::NodeProbeArgs;
 use anyhow::{Context, Result};
 use celln_spec::{ExecutionProblem, ExecutionRequest};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeEligibility {
     pub node_name: String,
     pub kvm: bool,

--- a/crates/celln-cli/src/router.rs
+++ b/crates/celln-cli/src/router.rs
@@ -16,7 +16,7 @@ use serde::Deserialize;
 use std::io::{BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -29,13 +29,33 @@ fn read_token(path: &Path) -> Result<String> {
     crate::dispatch_http::read_bearer_token(path)
 }
 
-fn credentials(state: &RouterState) -> Result<(String, String)> {
+fn credentials(state: &RouterState) -> Result<(String, String, Option<String>)> {
     let client = read_token(&state.client_token_file)?;
     let backend = read_token(&state.token_file)?;
     if constant_time_eq(client.as_bytes(), backend.as_bytes()) {
         bail!("client and dispatcher credentials must be distinct");
     }
-    Ok((client, backend))
+    let capability = capability_credential(state, &client, &backend)?;
+    Ok((client, backend, capability))
+}
+
+fn capability_credential(
+    state: &RouterState,
+    client: &str,
+    backend: &str,
+) -> Result<Option<String>> {
+    let token = state
+        .capability_token_file
+        .as_deref()
+        .map(read_token)
+        .transpose()?;
+    if token.as_ref().is_some_and(|token| {
+        constant_time_eq(token.as_bytes(), client.as_bytes())
+            || constant_time_eq(token.as_bytes(), backend.as_bytes())
+    }) {
+        bail!("capability credential must be distinct");
+    }
+    Ok(token)
 }
 
 /// How the router selects a dispatcher backend for each action.
@@ -67,6 +87,7 @@ struct Health {
     kvm: bool,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn serve(
     listen: &str,
     backends: Vec<String>,
@@ -74,6 +95,7 @@ pub fn serve(
     mode: RoutingMode,
     token_file: &Path,
     client_token_file: &Path,
+    capability_token_file: Option<&Path>,
     ownership_dir: &Path,
 ) -> Result<u8> {
     let mut urls: Vec<String> = backends
@@ -115,6 +137,8 @@ pub fn serve(
         executions: ownership::Ledger::open(ownership_dir, 100_000)?,
         token_file: token_file.to_owned(),
         client_token_file: client_token_file.to_owned(),
+        capability_token_file: capability_token_file.map(Path::to_owned),
+        capability_probe_active: AtomicBool::new(false),
     });
     credentials(&state).context("router credentials are missing, invalid or not distinct")?;
     let listener = TcpListener::bind(listen).with_context(|| format!("binding router {listen}"))?;
@@ -146,6 +170,8 @@ struct RouterState {
     executions: ownership::Ledger,
     token_file: PathBuf,
     client_token_file: PathBuf,
+    capability_token_file: Option<PathBuf>,
+    capability_probe_active: AtomicBool,
 }
 
 fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
@@ -226,20 +252,25 @@ fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
         }
     }
 
-    let Ok((client_token, backend_token)) = credentials(state) else {
+    let Ok((client_token, backend_token, read_token)) = credentials(state) else {
         return reply(
             &mut stream,
             503,
             &serde_json::json!({"error":"router credentials unavailable"}),
         );
     };
-    let authorized = authorization
-        .as_deref()
-        .and_then(|value| {
-            let (scheme, token) = value.split_once(' ')?;
-            scheme.eq_ignore_ascii_case("bearer").then_some(token)
-        })
-        .is_some_and(|token| constant_time_eq(token.as_bytes(), client_token.as_bytes()));
+    let presented = authorization.as_deref().and_then(|value| {
+        let (scheme, token) = value.split_once(' ')?;
+        scheme.eq_ignore_ascii_case("bearer").then_some(token)
+    });
+    let is_capability_read = method == "GET" && path == "/v1/capabilities";
+    let authorized = presented.is_some_and(|token| {
+        constant_time_eq(token.as_bytes(), client_token.as_bytes())
+            || (is_capability_read
+                && read_token
+                    .as_ref()
+                    .is_some_and(|read| constant_time_eq(token.as_bytes(), read.as_bytes())))
+    });
     if !authorized {
         return reply(
             &mut stream,
@@ -249,6 +280,7 @@ fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
     }
     let backend_token = Some(backend_token);
     match (method.as_str(), path.as_str()) {
+        ("GET", "/v1/capabilities") => capability_report(state, &mut stream, &backend_token)?,
         ("POST", "/v1/executions") => forward_submission(
             state,
             &mut stream,
@@ -275,6 +307,73 @@ fn handle(mut stream: TcpStream, state: &RouterState) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn capability_report(
+    state: &RouterState,
+    stream: &mut TcpStream,
+    token: &Option<String>,
+) -> Result<()> {
+    // Bound fanout and permit only one probe at a time per router. No request or
+    // owner ledger is mutated by discovery; failures never trigger execution.
+    if state.backends.len() > 32 || state.capability_probe_active.swap(true, Ordering::AcqRel) {
+        return reply(
+            stream,
+            503,
+            &serde_json::json!({"error":"capability probe unavailable"}),
+        );
+    }
+    struct ProbeGuard<'a>(&'a AtomicBool);
+    impl Drop for ProbeGuard<'_> {
+        fn drop(&mut self) {
+            self.0.store(false, Ordering::Release);
+        }
+    }
+    let _guard = ProbeGuard(&state.capability_probe_active);
+    let nodes = std::thread::scope(|scope| {
+        let probes: Vec<_> = state.backends.iter().enumerate().map(|(index, backend)| {
+            scope.spawn(move || {
+                let report = (|| -> Result<crate::capabilities::DispatcherCapabilities> {
+                    let addr = backend_to_addr(backend)?;
+                    let mut conn = connect(&addr)?;
+                    let credential = token.as_deref().context("backend credential missing")?;
+                    write!(conn, "GET /v1/capabilities HTTP/1.1\r\nHost: dispatcher\r\nAuthorization: Bearer {credential}\r\nConnection: close\r\n\r\n")?;
+                    let response = read_capability_response(&mut conn)?;
+                    if parse_status(&response) != 200 { bail!("backend capability request failed"); }
+                    let report: crate::capabilities::DispatcherCapabilities = serde_json::from_str(extract_body(&response))?;
+                    if !report.compatible() { bail!("incompatible backend capabilities"); }
+                    Ok(report)
+                })();
+                match report {
+                    Ok(report) => serde_json::json!({"index":index,"preflightEligible":report.node.eligible(),"report":report}),
+                    Err(_) => serde_json::json!({"index":index,"preflightEligible":false,"reason":"unreachable_unauthorized_or_incompatible"}),
+                }
+            })
+        }).collect();
+        probes
+            .into_iter()
+            .map(|probe| {
+                probe.join().unwrap_or_else(
+                    |_| serde_json::json!({"preflightEligible":false,"reason":"probe_failed"}),
+                )
+            })
+            .collect::<Vec<_>>()
+    });
+    let eligible = nodes
+        .iter()
+        .filter(|node| node["preflightEligible"] == true)
+        .count();
+    reply(
+        stream,
+        200,
+        &serde_json::json!({
+            "apiVersion":crate::capabilities::VERSION,
+            "preflightOnly":true,
+            "eligibleNodes":eligible,
+            "artifactReadiness":"not_checked",
+            "nodes":nodes,
+        }),
+    )
 }
 
 /// `POST <endpoint>`: pick a healthy backend deterministically by the
@@ -548,10 +647,37 @@ fn connect(addr: &str) -> Result<TcpStream> {
 fn read_response(stream: &mut TcpStream) -> Result<String> {
     // Dispatchers close each response. Bound the entire wire message, including
     // headers; a truncated header must not cause an infinite EOF loop.
-    const MAX_RESPONSE: u64 = 16 * 1024 * 1024;
+    read_response_limit(stream, 16 * 1024 * 1024)
+}
+
+fn read_capability_response(stream: &mut TcpStream) -> Result<String> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
     let mut bytes = Vec::new();
-    stream.take(MAX_RESPONSE + 1).read_to_end(&mut bytes)?;
-    if bytes.len() as u64 > MAX_RESPONSE || !bytes.windows(4).any(|w| w == b"\r\n\r\n") {
+    let mut buf = [0u8; 4096];
+    loop {
+        let remaining = deadline
+            .checked_duration_since(std::time::Instant::now())
+            .context("capability response deadline exceeded")?;
+        stream.set_read_timeout(Some(remaining))?;
+        let n = stream.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buf[..n]);
+        if bytes.len() > 65536 {
+            bail!("oversized capability response");
+        }
+    }
+    if !bytes.windows(4).any(|w| w == b"\r\n\r\n") {
+        bail!("invalid capability response");
+    }
+    String::from_utf8(bytes).context("invalid capability encoding")
+}
+
+fn read_response_limit(stream: &mut TcpStream, max_response: u64) -> Result<String> {
+    let mut bytes = Vec::new();
+    stream.take(max_response + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > max_response || !bytes.windows(4).any(|w| w == b"\r\n\r\n") {
         bail!("invalid or oversized dispatcher response");
     }
     String::from_utf8(bytes).context("dispatcher response is not UTF-8")
@@ -661,6 +787,182 @@ mod tests {
     const BACKEND_TOKEN: &str = "backend-test-credential-at-least-24";
 
     #[test]
+    fn capability_token_is_read_only_distinct_and_rotatable() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = state(dir.path());
+        let path = dir.path().join("capability");
+        let first = "readonly-test-credential-at-least-24";
+        let second = "rotated-readonly-credential-at-least-24";
+        std::fs::write(&path, first).unwrap();
+        state.capability_token_file = Some(path.clone());
+        let headers = |token| format!("Authorization: Bearer {token}\r\n");
+        for token in [first, CLIENT_TOKEN] {
+            let response = request(&state, "GET", "/v1/capabilities", &headers(token), "");
+            assert_eq!(parse_status(&response), 200);
+            let report: serde_json::Value = serde_json::from_str(extract_body(&response)).unwrap();
+            assert_eq!(report["eligibleNodes"], 0);
+            assert_eq!(report["preflightOnly"], true);
+        }
+        for (method, path) in [
+            ("POST", "/v1/executions"),
+            ("GET", "/v1/executions/x"),
+            ("GET", "/v1/executions/x/audit"),
+            ("POST", "/v1/executions/x/cancel"),
+            ("POST", "/v1/capabilities"),
+            ("GET", "/v1/node"),
+        ] {
+            assert_eq!(
+                parse_status(&request(&state, method, path, &headers(first), "")),
+                401
+            );
+        }
+        for token in ["", BACKEND_TOKEN, "wrong"] {
+            assert_eq!(
+                parse_status(&request(
+                    &state,
+                    "GET",
+                    "/v1/capabilities",
+                    &headers(token),
+                    ""
+                )),
+                401
+            );
+        }
+        std::fs::write(&path, second).unwrap();
+        assert_eq!(
+            parse_status(&request(
+                &state,
+                "GET",
+                "/v1/capabilities",
+                &headers(first),
+                ""
+            )),
+            401
+        );
+        assert_eq!(
+            parse_status(&request(
+                &state,
+                "GET",
+                "/v1/capabilities",
+                &headers(second),
+                ""
+            )),
+            200
+        );
+        for invalid in [CLIENT_TOKEN, BACKEND_TOKEN, "short"] {
+            std::fs::write(&path, invalid).unwrap();
+            assert!(credentials(&state).is_err());
+            assert_eq!(
+                parse_status(&request(
+                    &state,
+                    "GET",
+                    "/v1/capabilities",
+                    &headers(second),
+                    ""
+                )),
+                503
+            );
+        }
+        std::fs::remove_file(path).unwrap();
+        assert_eq!(
+            parse_status(&request(
+                &state,
+                "GET",
+                "/v1/capabilities",
+                &headers(second),
+                ""
+            )),
+            503
+        );
+    }
+
+    #[test]
+    fn capability_fanout_requires_authenticated_compatible_eligible_reports() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = state(dir.path());
+        let base = crate::capabilities::DispatcherCapabilities::new(crate::node::NodeEligibility {
+            node_name: "fixture".into(),
+            kvm: true,
+            cpu_virtualization: true,
+            guest_kernel: true,
+            mote_store: true,
+            tool_store: true,
+            live_cells: 0,
+            max_cells: 1,
+            memory_bytes: 268435456,
+            egress_slots: 1,
+        });
+        let good = serde_json::to_value(base).unwrap();
+        let mut missing_kvm = good.clone();
+        missing_kvm["node"]["kvm"] = false.into();
+        let mut full = good.clone();
+        full["node"]["live_cells"] = 1.into();
+        let mut incompatible = good.clone();
+        incompatible["apiVersion"] = "future/unknown".into();
+        let fixtures = [
+            (200, good),
+            (200, missing_kvm),
+            (200, full),
+            (200, incompatible),
+            (401, serde_json::json!({})),
+            (200, serde_json::json!({"ok":true,"kvm":true})),
+        ];
+        std::thread::scope(|scope| {
+            for (status, body) in fixtures {
+                let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+                state
+                    .backends
+                    .push(format!("http://{}", listener.local_addr().unwrap()));
+                scope.spawn(move || {
+                    let (mut stream, _) = listener.accept().unwrap();
+                    let mut reader = BufReader::new(stream.try_clone().unwrap());
+                    let line = read_bounded_line(&mut reader, MAX_REQUEST_LINE).unwrap();
+                    assert_eq!(line, "GET /v1/capabilities HTTP/1.1\r\n");
+                    let mut seen_backend = false;
+                    loop {
+                        let line = read_bounded_line(&mut reader, MAX_HEADER_LINE).unwrap();
+                        if line.trim().is_empty() {
+                            break;
+                        }
+                        if line.starts_with("Authorization:") {
+                            assert_eq!(line, format!("Authorization: Bearer {BACKEND_TOKEN}\r\n"));
+                            seen_backend = true;
+                        }
+                    }
+                    assert!(seen_backend);
+                    reply(&mut stream, status, &body).unwrap();
+                });
+            }
+            let response = request(
+                &state,
+                "GET",
+                "/v1/capabilities",
+                &format!("Authorization: Bearer {CLIENT_TOKEN}\r\n"),
+                "",
+            );
+            assert_eq!(parse_status(&response), 200);
+            let report: serde_json::Value = serde_json::from_str(extract_body(&response)).unwrap();
+            assert_eq!(report["eligibleNodes"], 1);
+            assert_eq!(report["nodes"].as_array().unwrap().len(), 6);
+            assert_eq!(report["artifactReadiness"], "not_checked");
+            assert_eq!(report["nodes"][0]["report"]["persistentSessions"], false);
+            assert!(!response.contains(BACKEND_TOKEN));
+        });
+        assert!(!state.capability_probe_active.load(Ordering::Acquire));
+        state.capability_probe_active.store(true, Ordering::Release);
+        assert_eq!(
+            parse_status(&request(
+                &state,
+                "GET",
+                "/v1/capabilities",
+                &format!("Authorization: Bearer {CLIENT_TOKEN}\r\n"),
+                ""
+            )),
+            503
+        );
+    }
+
+    #[test]
     fn lost_acceptance_is_not_replayed_and_fresh_replica_recovers_owner() {
         let dir = tempfile::tempdir().unwrap();
         let mut first = state(dir.path());
@@ -767,6 +1069,8 @@ mod tests {
             executions: ownership::Ledger::open(&dir.join("ownership"), 100).unwrap(),
             token_file,
             client_token_file,
+            capability_token_file: None,
+            capability_probe_active: AtomicBool::new(false),
         }
     }
 

--- a/crates/celln-cli/tests/closure_verify.rs
+++ b/crates/celln-cli/tests/closure_verify.rs
@@ -1,0 +1,74 @@
+//! Real CLI proof using a public deterministic test signing seed, no KVM/model.
+use celln_manifest::{
+    closure::{Closure, Member},
+    Hash,
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    process::Command,
+};
+
+#[test]
+fn cli_verification_is_bound_read_only_and_rechecks_policy() {
+    let root = tempfile::tempdir().unwrap();
+    let executable = Hash::of(b"test executable").0;
+    let signed = Closure {
+        api_version: "celln.dev/closure-v1".into(),
+        toolfs: Hash::of(b"test toolfs").0,
+        entrypoint: "/tools/test".into(),
+        interpreter: false,
+        members: BTreeMap::from([(
+            "/tools/test".into(),
+            Member {
+                hash: executable.clone(),
+                dependencies: BTreeSet::new(),
+            },
+        )]),
+    }
+    .sign(&[42; 32])
+    .unwrap();
+    let bytes = serde_json::to_vec_pretty(&signed).unwrap();
+    let descriptor = root.path().join("signed.json");
+    std::fs::write(&descriptor, &bytes).unwrap();
+    let policy = root.path().join("trusted-closures.json");
+    std::fs::write(&policy, serde_json::json!({"apiVersion":"celln.dev/closure-policy-v1","publishers":[signed.publisher],"revoked":[]}).to_string()).unwrap();
+    let run = |expected: &str| {
+        Command::new(env!("CARGO_BIN_EXE_celln"))
+            .arg("--root")
+            .arg(root.path())
+            .args(["closure", "verify"])
+            .arg(&descriptor)
+            .args([
+                "--expected-hash",
+                expected,
+                "--publisher",
+                &signed.publisher,
+                "--entry-point",
+                "/tools/test",
+                "--executable",
+                &executable,
+            ])
+            .output()
+            .unwrap()
+    };
+    let identity = Hash::of(&bytes).0;
+    let accepted = run(&identity);
+    assert!(
+        accepted.status.success(),
+        "{}",
+        String::from_utf8_lossy(&accepted.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&accepted.stdout).unwrap();
+    assert_eq!(report["apiVersion"], "celln.dev/closure-verification-v1");
+    assert_eq!(report["closure"], identity);
+    assert_eq!(report["artifactReadiness"], "not_checked");
+    assert!(!root.path().join("closures").exists());
+    let mismatch = run(&Hash::of(b"wrong").0);
+    assert!(!mismatch.status.success());
+    assert!(mismatch.stdout.is_empty());
+    std::fs::write(&policy, serde_json::json!({"apiVersion":"celln.dev/closure-policy-v1","publishers":[signed.publisher],"revoked":[identity]}).to_string()).unwrap();
+    let revoked = run(&identity);
+    assert!(!revoked.status.success());
+    assert!(revoked.stdout.is_empty());
+    assert!(!root.path().join("closures").exists());
+}

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -1,0 +1,79 @@
+# Authenticated execution-plane capabilities
+
+`GET /v1/capabilities` is a read-only, separately versioned preflight endpoint
+on both dispatcher and router. It neither creates a cell nor claims an execution
+owner. A reachable TCP port, HTTP 200, or a positive eligible-node count is not
+proof that a particular Harness/task can execute.
+
+## Authentication and deployment
+
+The dispatcher requires its backend bearer credential. The router accepts its
+existing execution-client credential, or an optional **distinct read-only**
+credential configured with `--capability-token-file PATH`. This latter token is
+accepted only for `GET /v1/capabilities`: it cannot submit, poll, audit or cancel
+executions. Do not give the UI/API server the execution-client or backend token
+just to discover readiness.
+
+All configured credentials reload per request, use bounded validation, and must
+be pairwise distinct. Missing/invalid configured credentials return 503; wrong
+or absent caller credentials return 401. If no capability token is configured,
+only the existing execution-client credential can read router capabilities.
+This optional flag preserves existing router startup commands. Use projected
+Secret directories, not `subPath` mounts, and retain authenticated/encrypted
+transport. This endpoint does not add TLS to Celln.
+
+Sympozium still needs coordinated API-server credential mounting, narrowly
+scoped NetworkPolicy ingress, and a version-aware consumer before this replaces
+its TCP-only check. That integration is not delivered merely by adding this
+endpoint. Never relax ingress to all namespace Pods for capability discovery.
+
+## Wire contract
+
+Both envelopes use `apiVersion: celln.dev/capabilities-v1alpha1` and
+`preflightOnly: true`. Dispatcher fields:
+
+- `binaryVersion`: build package version, not an image digest or attestation.
+- `node`: the existing NodeEligibility fields (snake_case), measured using the
+  dispatcher's configured stores, host preflight and current reservations.
+- `requestVersions`: `celln.dev/v1alpha1` and `celln.dev/v1alpha2`. Support is
+  subject to their existing combination/authority guards; not every valid
+  request is supported.
+- `harnessContracts`: only `celln.reference-functions/v1`. This is the bounded
+  reference adapter, not arbitrary OCI/Pi/Hermes Harness support.
+- `persistentSessions: false`.
+- `artifactReadiness: not_checked`. Readable stores are not proof of approved
+  artifacts, signatures, publisher admission, model grants or a warm template.
+
+Router fields:
+
+- `eligibleNodes`: count of compatible authenticated reports whose node passes
+  the existing eligibility predicate, including available cell/memory capacity.
+- `nodes`: one entry per configured backend, with its configuration `index`,
+  `preflightEligible`, and parsed `report`. A failed probe instead includes a
+  generic reason; backend errors, credentials and URLs are not echoed.
+- `artifactReadiness: not_checked`.
+
+Older dispatcher 404s, auth failures, malformed or incompatible reports never
+become eligible through fallback to public health/TCP. Per-node features are
+not unioned: one node supporting a feature and another having capacity does not
+establish an eligible placement for that feature. Zero eligible nodes can still
+return HTTP 200: consumers must validate the version and report, not the status
+code alone. The report does not reserve capacity; execution rechecks authority
+and eligibility.
+
+## Bounds and remaining qualification
+
+One capability fanout runs at a time per router; concurrent probes receive 503.
+Fanout is capped at 32 configured backends (larger configurations return 503
+for discovery without changing execution routing). Responses are capped at
+64 KiB per backend and two seconds of response reading, including slow-drip
+traffic. Existing connection/DNS handling applies: a three-second connect
+timeout does not bound the system resolver. No fleet-scale or latency claim is
+made. Consumers need their own end-to-end deadline and must handle busy probes.
+
+TCP tests cover read-only scope, rotation, distinct credentials, authenticated
+fanout and incompatible/unavailable/capacity reports. Dispatcher tests check
+version/authentication and no execution side effects. These are protocol tests,
+not guest isolation or a deployed discovery proof. Named-artifact validation,
+prewarming, catalogue selection and the Sympozium consumer remain follow-on work
+within epic sympozium-ai/sympozium#426.

--- a/docs/CLOSURE_VERIFICATION.md
+++ b/docs/CLOSURE_VERIFICATION.md
@@ -1,0 +1,95 @@
+# Read-only closure authenticity reports
+
+For Sympozium's approved-tool catalogue integration (epic
+[sympozium#426](https://github.com/sympozium-ai/sympozium/issues/426)), an operator
+can verify a signed descriptor against the current local publisher/revocation
+policy without admitting it to a store:
+
+```sh
+celln --root /var/lib/celln closure verify signed-closure.json \
+  --expected-hash blake3:<exact-descriptor-hash> \
+  --publisher <expected-lowercase-ed25519-public-key> \
+  --entry-point /tools/example \
+  --executable blake3:<expected-executable-hash>
+```
+
+Replace placeholders with exact catalogue identities. The root must already
+contain operator-controlled `trusted-closures.json` in the existing
+`celln.dev/closure-policy-v1` format. A tenant submission must never supply that
+policy or add itself to the publisher list. No private signing key is needed.
+
+Success emits one `celln.dev/closure-verification-v1` JSON report on stdout.
+Failure returns nonzero without a success report. The report binds the exact
+descriptor bytes, expected publisher, selected member path/hash and current
+policy bytes' BLAKE3 hash. It also reports the signed filesystem hash, closure
+entry point, interpreter flag and dependency graph. A selected member need not
+be the closure's primary entry point: membership is not permission to invoke it.
+Reformatting a signed JSON descriptor preserves signature semantics but changes
+its content identity; the expected descriptor hash must still match exact bytes.
+
+The same verification function now serves offline admission and dispatcher
+resolution. All three re-read the current policy and reject revoked descriptor,
+filesystem or member hashes. Policy and descriptor reads are bounded at 256 KiB;
+an oversized policy fails closed rather than being partially loaded. An existing
+larger dispatcher policy must be reduced within that documented bound before
+upgrading. No wire-format or signature-domain change is introduced.
+
+## Deliberately limited evidence
+
+`scope=descriptor-authenticity-only`, `artifactReadiness=not_checked` and
+`conformance=not_checked` are explicit. The command does not fetch or inspect
+filesystem/member bytes, verify schema documents, approve behavior or lending
+limits, distribute/prewarm artifacts, run a guest, grant invocation authority,
+or write an admission store. The policy hash is a snapshot identifier, not a
+lease or exemption from later revocation checks. A report is not signed and
+must be obtained directly by a trusted verifier, not accepted from a tenant.
+
+Catalogue readiness still requires independently trusted approval, exact
+artifact and schema verification, adapter conformance, node eligibility and
+prewarming. Guest isolation must still be proven by guest attempts. Existing
+dispatch performs its own current-policy and filesystem/executable binding
+checks; a successful offline report never bypasses them.
+
+Tests use real Ed25519 signatures from a public deterministic test seed. They
+cover tampering, identity/publisher/member mismatch, exact-byte identity,
+revocation of every target type, missing/invalid/oversized policy, oversized
+descriptor, read-only behavior and the real CLI exit/stdout contract. They do
+not constitute KVM or full Harness/BYO-tool E2E evidence.
+
+## Regression evidence — 2026-09-07
+
+`CARGO_TARGET_DIR=target/deployed make ci` passed (format, all-target/all-feature
+Clippy with warnings denied, build and workspace tests), including the actual
+CLI verification test. The separate ignored `signed_closure_on_real_kvm` suite
+then passed in 7.14 seconds with explicit build paths:
+
+```sh
+CARGO_TARGET_DIR=target/deployed cargo build --release \
+  --target x86_64-unknown-linux-musl -p celln-pilot \
+  --bin celln-pilot --bin pilot-fetch
+CARGO_TARGET_DIR=target/deployed cargo build -p celln-cli
+CELLN_TEST_BINARY="$PWD/target/deployed/debug/celln" \
+CELLN_PILOT_DIR="$PWD/target/deployed/x86_64-unknown-linux-musl/release" \
+CARGO_TARGET_DIR=target/deployed cargo test -p celln-cli \
+  signed_closure_on_real_kvm -- --ignored --nocapture
+```
+
+The test helpers now accept those explicit paths instead of requiring the
+default target directory. Initial attempts skipped on the hard-coded guest path
+and then failed on the hard-coded dispatcher path; neither was counted as a
+pass. The final run exercised the dynamic guest, replacement attempts, signed
+member mismatch, publisher withdrawal, dependency revocation, live DAX
+withdrawal, executable-scratch refusal, warm reuse and backing reclamation,
+including production dispatcher HTTP receipt/audit checks. Local raw evidence:
+`target/closure-proof/240005.json` and `target/closure-proof/240005/`.
+
+Measured fixture executions: 2,779,841 µs initial preparation/execution,
+133,335 and 141,610 µs warm executions. Eight simultaneous forks shared
+33,554,432 sealed-tool bytes with zero additional tool allocations. These are
+single-host fixture measurements, not full-Harness latency or fleet guarantees.
+
+Tested dispatcher binary SHA256:
+`e24a0cc3fd2efbcbb77149728de16d887b4338653ec90d2a0d1b6a5b97346cf9`.
+The deployed Kubernetes cluster was not changed and no model credentials or
+model calls were used. This rerun checks existing signed-closure behavior, not
+the still-unimplemented catalogue approval/distribution user journey.

--- a/docs/NODE_CAPACITY.md
+++ b/docs/NODE_CAPACITY.md
@@ -33,6 +33,10 @@ starting independently of this service. Run one managed dispatcher per node.
 
 ## Reports
 
+For versioned discovery through the router, see
+[authenticated capabilities](CAPABILITIES.md). Its preflight result deliberately
+does not advertise readiness for an unchecked runtime/tool bundle.
+
 `GET /v1/health` remains public and returns HTTP 200 for a reachable service;
 `ok` describes admission preflight, not merely `/dev/kvm` pathname presence.
 It uses configured mote/tool-store directories, the loader's kernel-format


### PR DESCRIPTION
## Scope
Dependency for sympozium-ai/sympozium#426 and #335. Adds closure verify with exact descriptor hash, publisher and selected executable member binding. Emits versioned authenticity-only JSON; does not admit, inspect artifact bytes or claim readiness/conformance.

Shares bounded current-policy/signature/revocation checks between CLI admission, verification and dispatcher resolution. Dispatcher policy reads now fail closed above 256 KiB, matching the existing offline bound. No signature-domain or request wire change.

## Evidence
- CARGO_TARGET_DIR=target/deployed make ci passed, including strict Clippy and real CLI test
- Signature/tampering, exact-byte identity, mismatch, all revocation targets, missing/malformed/oversized policy and descriptor tests
- Separate real KVM signed-dynamic-closure regression passed in 7.14 seconds, including production HTTP dispatcher receipt/audit, guest replacement attacks, dependency/publisher withdrawal, live DAX withdrawal, warm reuse and reclamation
- Test helpers accept explicit pilot and dispatcher build paths; initial skipped/missing-path attempts are documented, not counted as passes

See docs/CLOSURE_VERIFICATION.md for command, scope, compatibility bound and measured evidence. No Kubernetes deployment or model calls. Trusted catalogue approval, artifact/schema verification and distribution remain required; this report is not execution authority.