### PR TITLE
feat(schema): bounded immutable tool schema and data verification

### DIFF
--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -16,6 +16,7 @@ mod node;
 mod out;
 mod router;
 mod run;
+mod schema_cli;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -67,6 +68,9 @@ enum Cmd {
     /// Authenticate and admit precomposed dependency closures.
     #[command(subcommand)]
     Closure(ClosureCmd),
+    /// Verify immutable tool-schema bytes and optionally bounded JSON data.
+    #[command(subcommand)]
+    Schema(SchemaCmd),
     /// Report what this machine can run.
     Doctor,
 
@@ -356,6 +360,19 @@ enum ClosureCmd {
     },
 }
 
+#[derive(Subcommand)]
+enum SchemaCmd {
+    Verify {
+        schema: PathBuf,
+        #[arg(long)]
+        expected_hash: String,
+        #[arg(long, requires = "max_value_bytes")]
+        value: Option<PathBuf>,
+        #[arg(long, requires = "value")]
+        max_value_bytes: Option<usize>,
+    },
+}
+
 #[derive(clap::Args, Clone)]
 struct NodeProbeArgs {
     #[arg(long, env = "CELLN_NODE_NAME", default_value = "local")]
@@ -407,6 +424,12 @@ fn resolve_root(explicit: &Option<PathBuf>) -> PathBuf {
 fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
     let root = resolve_root(&cli.root);
     match &cli.cmd {
+        Cmd::Schema(SchemaCmd::Verify {
+            schema,
+            expected_hash,
+            value,
+            max_value_bytes,
+        }) => schema_cli::verify(schema, expected_hash, value.as_deref(), *max_value_bytes),
         Cmd::Closure(ClosureCmd::Sign {
             descriptor,
             key_file,

--- a/crates/celln-cli/src/schema_cli.rs
+++ b/crates/celln-cli/src/schema_cli.rs
@@ -1,0 +1,46 @@
+//! Offline, bounded schema/data checks. No store writes or execution authority.
+use anyhow::Result;
+use celln_manifest::{
+    tool_schema::{ToolSchema, MAX_SCHEMA_BYTES, MAX_VALUE_BYTES, PROFILE},
+    Hash,
+};
+use std::{io::Read, path::Path};
+
+fn read(path: &Path, limit: usize) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)?
+        .take((limit + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    anyhow::ensure!(bytes.len() <= limit, "schema or value exceeds byte ceiling");
+    Ok(bytes)
+}
+
+pub fn verify(
+    path: &Path,
+    expected: &str,
+    value: Option<&Path>,
+    max_value_bytes: Option<usize>,
+) -> Result<u8> {
+    let schema = ToolSchema::parse(&read(path, MAX_SCHEMA_BYTES)?, &Hash(expected.into()))
+        .map_err(anyhow::Error::msg)?;
+    match (value, max_value_bytes) {
+        (Some(path), Some(limit)) if (1..=MAX_VALUE_BYTES).contains(&limit) => {
+            schema
+                .validate(&read(path, limit)?, limit)
+                .map_err(anyhow::Error::msg)?;
+        }
+        (None, None) => {}
+        _ => anyhow::bail!("value validation requires an explicit 1..65536 byte ceiling"),
+    }
+    println!(
+        "{}",
+        serde_json::json!({
+            "apiVersion":"celln.dev/tool-schema-verification-v1",
+            "profile":PROFILE,
+            "schema":schema.identity().0,
+            "valueValidated":value.is_some(),
+            "scope":"schema-and-data-only"
+        })
+    );
+    Ok(0)
+}

--- a/crates/celln-cli/tests/schema_verify.rs
+++ b/crates/celln-cli/tests/schema_verify.rs
@@ -1,0 +1,46 @@
+use celln_manifest::Hash;
+use std::process::Command;
+
+#[test]
+fn cli_binds_schema_and_requires_explicit_value_budget() {
+    let dir = tempfile::tempdir().unwrap();
+    let schema = dir.path().join("schema.json");
+    let value = dir.path().join("value.json");
+    let bytes = br#"{"type":"integer","minimum":0,"maximum":42}"#;
+    std::fs::write(&schema, bytes).unwrap();
+    std::fs::write(&value, b"42").unwrap();
+    let run = |hash: &str, budget: Option<&str>| {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_celln"));
+        command
+            .args(["schema", "verify"])
+            .arg(&schema)
+            .args(["--expected-hash", hash, "--value"])
+            .arg(&value);
+        if let Some(budget) = budget {
+            command.args(["--max-value-bytes", budget]);
+        }
+        command.output().unwrap()
+    };
+    let hash = Hash::of(bytes).0;
+    let success = run(&hash, Some("2"));
+    assert!(
+        success.status.success(),
+        "{}",
+        String::from_utf8_lossy(&success.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&success.stdout).unwrap();
+    assert_eq!(report["schema"], hash);
+    assert_eq!(report["valueValidated"], true);
+    assert_eq!(report["scope"], "schema-and-data-only");
+    for budget in [None, Some("0"), Some("1"), Some("65537")] {
+        let refused = run(&hash, budget);
+        assert!(!refused.status.success());
+        assert!(refused.stdout.is_empty());
+    }
+    assert!(!run(&Hash::of(b"wrong").0, Some("2")).status.success());
+    std::fs::write(&value, b"43").unwrap();
+    let refused = run(&hash, Some("2"));
+    assert!(!refused.status.success());
+    assert!(refused.stdout.is_empty());
+    assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 2);
+}

--- a/crates/celln-manifest/src/lib.rs
+++ b/crates/celln-manifest/src/lib.rs
@@ -374,3 +374,4 @@ mod tests {
     }
 }
 pub mod closure;
+pub mod tool_schema;

--- a/crates/celln-manifest/src/tool_schema.rs
+++ b/crates/celln-manifest/src/tool_schema.rs
@@ -1,0 +1,380 @@
+//! Bounded, closed JSON-schema subset for immutable tool argument/result data.
+//! No I/O, reference resolution, executable authority or remote schema fetching.
+use crate::Hash;
+use serde::{
+    de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor},
+    Deserialize,
+};
+use serde_json::Value;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
+
+pub const PROFILE: &str = "celln.tool-schema/v1";
+pub const MAX_SCHEMA_BYTES: usize = 32768;
+pub const MAX_VALUE_BYTES: usize = 65536;
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase", deny_unknown_fields)]
+enum Node {
+    Object {
+        properties: BTreeMap<String, Node>,
+        required: Vec<String>,
+        #[serde(rename = "additionalProperties")]
+        additional_properties: bool,
+    },
+    Array {
+        items: Box<Node>,
+        #[serde(rename = "minItems")]
+        min_items: usize,
+        #[serde(rename = "maxItems")]
+        max_items: usize,
+    },
+    String {
+        #[serde(rename = "minLength")]
+        min_length: usize,
+        #[serde(rename = "maxLength")]
+        max_length: usize,
+    },
+    Integer {
+        minimum: i64,
+        maximum: i64,
+    },
+    Boolean {},
+}
+
+pub struct ToolSchema {
+    identity: Hash,
+    node: Node,
+}
+
+impl ToolSchema {
+    /// Expected identity is the hash of exact schema bytes, not normalized JSON.
+    pub fn parse(bytes: &[u8], expected: &Hash) -> Result<Self, String> {
+        if bytes.len() > MAX_SCHEMA_BYTES {
+            return Err("schema exceeds 32 KiB".into());
+        }
+        let identity = Hash::of(bytes);
+        if &identity != expected {
+            return Err("schema artifact identity mismatch".into());
+        }
+        let value = parse_json(bytes)?;
+        let node: Node =
+            serde_json::from_value(value).map_err(|_| "unsupported or malformed tool schema")?;
+        node.check(0, &mut 0)?;
+        Ok(Self { identity, node })
+    }
+
+    pub fn identity(&self) -> &Hash {
+        &self.identity
+    }
+
+    /// Caller supplies the effective argument/result byte ceiling. Validation
+    /// cannot raise it. Integer values must use signed-64-bit integer encoding;
+    /// float/exponent spellings are explicitly unsupported in this profile.
+    pub fn validate(&self, bytes: &[u8], max_bytes: usize) -> Result<(), String> {
+        if max_bytes == 0 || max_bytes > MAX_VALUE_BYTES || bytes.len() > max_bytes {
+            return Err("tool value exceeds permitted byte ceiling".into());
+        }
+        let value = parse_json(bytes)?;
+        self.node.matches(&value)
+    }
+}
+
+impl Node {
+    fn check(&self, depth: usize, nodes: &mut usize) -> Result<(), String> {
+        *nodes += 1;
+        if depth > 4 || *nodes > 128 {
+            return Err("schema nesting or node limit exceeded".into());
+        }
+        match self {
+            Self::Object {
+                properties,
+                required,
+                additional_properties,
+            } => {
+                if *additional_properties
+                    || properties.len() > 32
+                    || required.len() > properties.len()
+                    || required.iter().collect::<BTreeSet<_>>().len() != required.len()
+                    || required.iter().any(|k| !properties.contains_key(k))
+                    || properties.keys().any(|k| {
+                        k.is_empty()
+                            || k.len() > 64
+                            || !k
+                                .bytes()
+                                .all(|b| b.is_ascii_alphanumeric() || b"_-".contains(&b))
+                    })
+                {
+                    return Err(
+                        "object schema must be closed with unique declared properties".into(),
+                    );
+                }
+                for node in properties.values() {
+                    node.check(depth + 1, nodes)?;
+                }
+            }
+            Self::Array {
+                items,
+                min_items,
+                max_items,
+            } => {
+                if min_items > max_items || *max_items > 64 {
+                    return Err("invalid array bounds".into());
+                }
+                items.check(depth + 1, nodes)?;
+            }
+            Self::String {
+                min_length,
+                max_length,
+            } => {
+                if min_length > max_length || *max_length > 4096 {
+                    return Err("invalid string bounds".into());
+                }
+            }
+            Self::Integer { minimum, maximum } if minimum > maximum => {
+                return Err("invalid integer bounds".into())
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn matches(&self, value: &Value) -> Result<(), String> {
+        match (self, value) {
+            (
+                Self::Object {
+                    properties,
+                    required,
+                    ..
+                },
+                Value::Object(values),
+            ) => {
+                if required.iter().any(|k| !values.contains_key(k)) {
+                    return Err("required tool field missing".into());
+                }
+                for (key, value) in values {
+                    properties
+                        .get(key)
+                        .ok_or("undeclared tool field")?
+                        .matches(value)?;
+                }
+            }
+            (
+                Self::Array {
+                    items,
+                    min_items,
+                    max_items,
+                },
+                Value::Array(values),
+            ) => {
+                if values.len() < *min_items || values.len() > *max_items {
+                    return Err("tool array outside bounds".into());
+                }
+                for value in values {
+                    items.matches(value)?;
+                }
+            }
+            (
+                Self::String {
+                    min_length,
+                    max_length,
+                },
+                Value::String(value),
+            ) => {
+                let length = value.chars().count();
+                if length < *min_length || length > *max_length {
+                    return Err("tool string outside bounds".into());
+                }
+            }
+            (Self::Integer { minimum, maximum }, Value::Number(value)) => {
+                let value = value
+                    .as_i64()
+                    .ok_or("unsupported non-i64 integer encoding")?;
+                if value < *minimum || value > *maximum {
+                    return Err("tool integer outside bounds".into());
+                }
+            }
+            (Self::Boolean {}, Value::Bool(_)) => {}
+            _ => return Err("tool value type mismatch".into()),
+        }
+        Ok(())
+    }
+}
+
+// Reject duplicate keys before serde's normal object decoding can overwrite
+// them. Byte, depth and node bounds also apply to malformed input documents.
+struct Bounded<'a> {
+    depth: usize,
+    nodes: &'a mut usize,
+}
+impl<'de> DeserializeSeed<'de> for Bounded<'_> {
+    type Value = Value;
+    fn deserialize<D: de::Deserializer<'de>>(self, d: D) -> Result<Value, D::Error> {
+        *self.nodes += 1;
+        if self.depth > 16 || *self.nodes > 4096 {
+            return Err(de::Error::custom("JSON complexity exceeded"));
+        }
+        d.deserialize_any(self)
+    }
+}
+impl<'de> Visitor<'de> for Bounded<'_> {
+    type Value = Value;
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("bounded JSON")
+    }
+    fn visit_bool<E: de::Error>(self, v: bool) -> Result<Value, E> {
+        Ok(v.into())
+    }
+    fn visit_i64<E: de::Error>(self, v: i64) -> Result<Value, E> {
+        Ok(v.into())
+    }
+    fn visit_u64<E: de::Error>(self, v: u64) -> Result<Value, E> {
+        Ok(v.into())
+    }
+    fn visit_f64<E: de::Error>(self, v: f64) -> Result<Value, E> {
+        serde_json::Number::from_f64(v)
+            .map(Value::Number)
+            .ok_or_else(|| E::custom("non-finite number"))
+    }
+    fn visit_str<E: de::Error>(self, v: &str) -> Result<Value, E> {
+        Ok(v.into())
+    }
+    fn visit_string<E: de::Error>(self, v: String) -> Result<Value, E> {
+        Ok(v.into())
+    }
+    fn visit_unit<E: de::Error>(self) -> Result<Value, E> {
+        Ok(Value::Null)
+    }
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Value, A::Error> {
+        let mut values = Vec::new();
+        while let Some(value) = seq.next_element_seed(Bounded {
+            depth: self.depth + 1,
+            nodes: self.nodes,
+        })? {
+            values.push(value);
+        }
+        Ok(Value::Array(values))
+    }
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Value, A::Error> {
+        let mut values = serde_json::Map::new();
+        while let Some(key) = map.next_key::<String>()? {
+            if values.contains_key(&key) {
+                return Err(de::Error::custom("duplicate JSON key"));
+            }
+            let value = map.next_value_seed(Bounded {
+                depth: self.depth + 1,
+                nodes: self.nodes,
+            })?;
+            values.insert(key, value);
+        }
+        Ok(Value::Object(values))
+    }
+}
+fn parse_json(bytes: &[u8]) -> Result<Value, String> {
+    let mut d = serde_json::Deserializer::from_slice(bytes);
+    let value = Bounded {
+        depth: 0,
+        nodes: &mut 0,
+    }
+    .deserialize(&mut d)
+    .map_err(|_| "malformed, duplicate-key or over-complex JSON")?;
+    d.end().map_err(|_| "trailing JSON data")?;
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn schema(value: &str) -> Result<ToolSchema, String> {
+        ToolSchema::parse(value.as_bytes(), &Hash::of(value.as_bytes()))
+    }
+    const OBJECT: &str = r#"{"type":"object","properties":{"count":{"type":"integer","minimum":-2,"maximum":42},"label":{"type":"string","minLength":1,"maxLength":2},"ok":{"type":"boolean"}},"required":["count"],"additionalProperties":false}"#;
+
+    #[test]
+    fn closed_object_and_scalar_bounds() {
+        let s = schema(OBJECT).unwrap();
+        for v in [
+            r#"{"count":42}"#,
+            r#"{"count":-2,"label":"é🦀","ok":false}"#,
+        ] {
+            assert!(s.validate(v.as_bytes(), 1024).is_ok(), "{v}");
+        }
+        for v in [
+            r#"{}"#,
+            r#"{"count":43}"#,
+            r#"{"count":-3}"#,
+            r#"{"count":1.0}"#,
+            r#"{"count":1e0}"#,
+            r#"{"count":"1"}"#,
+            r#"{"count":1,"extra":true}"#,
+            r#"{"count":1,"label":"abc"}"#,
+            r#"{"count":1,"ok":null}"#,
+            r#"{"count":1,"count":2}"#,
+            r#"{"count":1} {}"#,
+        ] {
+            assert!(s.validate(v.as_bytes(), 1024).is_err(), "{v}");
+        }
+        assert!(s.validate(br#"{"count":1}"#, 1).is_err());
+        assert!(s.validate(br#"{"count":1}"#, 0).is_err());
+        assert!(s.validate(br#"{"count":1}"#, 65537).is_err());
+    }
+
+    #[test]
+    fn array_and_integer_encoding_limits() {
+        let s = schema(r#"{"type":"array","items":{"type":"integer","minimum":-9223372036854775808,"maximum":9223372036854775807},"minItems":1,"maxItems":2}"#).unwrap();
+        for v in ["[-9223372036854775808]", "[9223372036854775807,0]"] {
+            assert!(s.validate(v.as_bytes(), 1024).is_ok());
+        }
+        for v in [
+            "[]",
+            "[1,2,3]",
+            "[9223372036854775808]",
+            "[-9223372036854775809]",
+            "[1.5]",
+            "[true]",
+        ] {
+            assert!(s.validate(v.as_bytes(), 1024).is_err(), "{v}");
+        }
+    }
+
+    #[test]
+    fn unsupported_features_and_malformed_schemas_refuse() {
+        for doc in [
+            r#"{"type":"boolean","default":true}"#,
+            r#"{"type":"boolean","$ref":"https://example.com/schema"}"#,
+            r#"{"type":"boolean","enum":[true]}"#,
+            r#"{"type":"boolean","type":"string"}"#,
+            r#"{"type":"number"}"#,
+            r#"{"type":"string","minLength":0,"maxLength":4097}"#,
+            r#"{"type":"string","minLength":2,"maxLength":1}"#,
+            r#"{"type":"string","maxLength":2}"#,
+            r#"{"type":"integer","minimum":3,"maximum":2}"#,
+            r#"{"type":"array","items":{"type":"boolean"},"minItems":0,"maxItems":65}"#,
+            r#"{"type":"object","properties":{},"required":[],"additionalProperties":true}"#,
+            r#"{"type":"object","properties":{},"required":["missing"],"additionalProperties":false}"#,
+            r#"{"type":"object","properties":{"a":{"type":"boolean"}},"required":["a","a"],"additionalProperties":false}"#,
+            r#"{"type":"object","properties":{"a":{"type":"boolean"},"a":{"type":"boolean"}},"required":[],"additionalProperties":false}"#,
+        ] {
+            assert!(schema(doc).is_err(), "{doc}");
+        }
+        assert!(ToolSchema::parse(OBJECT.as_bytes(), &Hash::of(b"wrong")).is_err());
+        assert!(schema(&" ".repeat(MAX_SCHEMA_BYTES + 1)).is_err());
+        let mut nested = r#"{"type":"boolean"}"#.to_owned();
+        for _ in 0..5 {
+            nested = format!(r#"{{"type":"array","minItems":0,"maxItems":1,"items":{nested}}}"#);
+        }
+        assert!(schema(&nested).is_err());
+    }
+
+    #[test]
+    fn parser_limits_malformed_data_before_validation() {
+        let s = schema(r#"{"type":"boolean"}"#).unwrap();
+        let nested = format!("{}true{}", "[".repeat(20), "]".repeat(20));
+        assert!(s.validate(nested.as_bytes(), 1024).is_err());
+        let many = format!("[{}]", vec!["true"; 4097].join(","));
+        assert!(s.validate(many.as_bytes(), 65536).is_err());
+        assert!(s.validate(&[0xff], 1024).is_err());
+    }
+}

--- a/docs/TOOL_SCHEMAS.md
+++ b/docs/TOOL_SCHEMAS.md
@@ -1,0 +1,74 @@
+# Immutable bounded tool schemas
+
+`celln.tool-schema/v1` is the initial, deliberately restricted structured-data
+validation profile for catalogue arguments and results. `celln-manifest` exposes
+`ToolSchema::parse(bytes, expected_hash)` and `validate(bytes, effective_limit)`;
+both are pure, with no filesystem, network or code execution.
+
+The expected BLAKE3 hash covers exact schema bytes. Parsing does not approve a
+publisher or tool: trusted catalogue approval must bind this schema hash to the
+executable revision. Both arguments and results need independently bound schemas.
+
+## Supported grammar
+
+Every schema node requires `type`. The following keys are the **only** supported
+keys, and every listed key is required. Unknown keywords (including `$ref`,
+`$schema`, `enum`, `format`, `pattern`, `default`, `description` and composition)
+refuse rather than silently lose validation. This is not general JSON Schema
+conformance; callers must explicitly select the profile.
+
+| Type | Required fields and limits |
+| --- | --- |
+| `object` | `properties` (up to 32), `required` (unique declared names), `additionalProperties: false` |
+| `array` | `items` (one schema), `minItems`, `maxItems` (0–64, ordered) |
+| `string` | `minLength`, `maxLength` (0–4096 Unicode scalar values, ordered) |
+| `integer` | `minimum`, `maximum` (signed 64-bit integers, ordered) |
+| `boolean` | No additional fields |
+
+Property names use 1–64 ASCII letters, digits, underscores or hyphens. Missing
+required properties, undeclared properties, wrong types and out-of-bound values
+refuse. Integer data must use integer JSON encoding: `1.0` and `1e0` are
+explicitly unsupported, even though general JSON Schema considers them integers.
+Null, floating-point numbers, tuple schemas and implicit coercion are unsupported.
+
+The schema ceiling is 32 KiB, four nested levels below the root and 128 schema
+nodes. Value validation requires an explicit 1–65536 byte ceiling, supplied from
+the resolved argument/result grant; it cannot raise that grant. Raw JSON parsing
+also caps nesting at 16 and nodes at 4096. Duplicate keys, invalid UTF-8, trailing
+documents and non-finite/out-of-range numeric encoding are rejected. The parser
+rejects duplicates before a map could overwrite them.
+
+## Offline verification
+
+```sh
+celln schema verify arguments.schema.json \
+  --expected-hash blake3:<exact-schema-hash>
+celln schema verify arguments.schema.json \
+  --expected-hash blake3:<exact-schema-hash> \
+  --value arguments.json --max-value-bytes 4096
+```
+
+Success emits `celln.dev/tool-schema-verification-v1` JSON with the schema hash,
+profile, `valueValidated` flag and `scope=schema-and-data-only`. Failure is
+nonzero without a success report. Reads are bounded before parsing; the command
+creates no store or approval object and uses no credentials. Reports are not
+signed and must not be trusted when supplied by a tenant.
+
+This component is **not yet connected** to catalogue admission or dispatcher
+invocation. In particular, it does not change the reference Harness's two
+integer-string function protocol, translate JSON to argv, or claim arbitrary
+tools can run. Admission still needs trusted schema/artifact retrieval, publisher
+and behavior approval, ABI compatibility and distribution/prewarming. Invocation
+must validate against the frozen schema and effective byte ceiling before
+executing; results need validation before returning to the model. A schema is
+data validation, never executable authority.
+
+Tests cover boundaries, malformed/duplicate JSON, exact identity, unknown
+keywords, closed properties, scalar/array bounds, explicit integer encoding and
+real CLI exit/stdout/no-write behavior. No KVM or provider access is required.
+
+On 2026-09-07, `CARGO_TARGET_DIR=target/deployed make ci` passed, including
+format checks, all-target/all-feature Clippy with warnings denied, full workspace
+build/tests and the real schema CLI integration test. No deployed cluster was
+changed and no model calls were made. This evidence covers schema/data checks,
+not an integrated approval or tool-invocation workflow.


### PR DESCRIPTION
## Scope
M1 dependency for sympozium-ai/sympozium#426 and #335, stacked on #81. Adds a pure no-I/O ToolSchema validator and read-only schema verify CLI. Exact BLAKE3 schema identity, closed objects, bounded arrays/strings/i64 integers/booleans, explicit effective value-byte ceilings, duplicate-key detection and parser complexity limits.

Unsupported keywords and representations refuse; this is explicitly celln.tool-schema/v1, not arbitrary JSON Schema. No external references, defaults, coercion or executable authority. No changes to the reference Harness two-function ABI.

## Verification
- Full CARGO_TARGET_DIR=target/deployed make ci passed (fmt, strict all-target/all-feature Clippy, build, workspace tests)
- Unit cases for exact identity, unknown features, malformed/duplicate/trailing JSON, nesting/node/byte limits, field/type and numeric/string/array bounds
- Real CLI integration checks explicit budgets, out-of-range data, output/exit semantics and no store writes

See docs/TOOL_SCHEMAS.md for full grammar and limits. Still requires trusted catalogue schema/artifact retrieval, approval, distribution and invocation integration. No cluster or provider-key changes; this does not close the epic.