### PR TITLE
feat(closure): verify local artifact bytes for catalogue review

### DIFF
--- a/crates/celln-cli/examples/prepare_review_fixture.rs
+++ b/crates/celln-cli/examples/prepare_review_fixture.rs
@@ -1,0 +1,70 @@
+//! Public deterministic metadata-review fixture, NOT executable/conformance evidence.
+use anyhow::{ensure, Result};
+use celln_manifest::{
+    closure::{Closure, Member},
+    Hash,
+};
+use serde_json::json;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::PathBuf,
+};
+
+fn main() -> Result<()> {
+    let args: Vec<_> = std::env::args().collect();
+    ensure!(
+        args.len() == 2,
+        "usage: prepare_review_fixture NEW_DIRECTORY"
+    );
+    let root = PathBuf::from(&args[1]);
+    fs::create_dir(&root)?;
+    let filesystem = b"non-executable review fixture; never mark Ready";
+    let executable = Hash::of(b"declared example member").0;
+    let signed = Closure {
+        api_version: "celln.dev/closure-v1".into(),
+        toolfs: Hash::of(filesystem).0,
+        entrypoint: "/example".into(),
+        interpreter: false,
+        members: BTreeMap::from([(
+            "/example".into(),
+            Member {
+                hash: executable.clone(),
+                dependencies: BTreeSet::new(),
+            },
+        )]),
+    }
+    .sign(&[42; 32])
+    .map_err(anyhow::Error::msg)?;
+    let descriptor = serde_json::to_vec_pretty(&signed)?;
+    let arguments = br#"{"type":"array","items":{"type":"string","minLength":0,"maxLength":64},"minItems":0,"maxItems":2}"#;
+    let result = br#"{"type":"string","minLength":0,"maxLength":64}"#;
+    for schema in [arguments.as_slice(), result.as_slice()] {
+        celln_manifest::tool_schema::ToolSchema::parse(schema, &Hash::of(schema))
+            .map_err(anyhow::Error::msg)?;
+    }
+    fs::write(root.join("closure.json"), &descriptor)?;
+    fs::write(root.join("toolfs.ext2"), filesystem)?;
+    fs::write(root.join("arguments.schema.json"), arguments)?;
+    fs::write(root.join("result.schema.json"), result)?;
+    fs::write(
+        root.join("trusted-closures.json"),
+        serde_json::to_vec(&json!({
+            "apiVersion":"celln.dev/closure-policy-v1", "publishers":[signed.publisher], "revoked":[]
+        }))?,
+    )?;
+    fs::write(
+        root.join("submission.json"),
+        serde_json::to_vec_pretty(&json!({
+            "apiVersion":"sympozium.ai/v1alpha1", "kind":"CellnToolSubmission", "metadata":{"name":"review-fixture"},
+            "spec": {"revision":"v1", "description":"Public non-executable review test; not conformance", "supportOwner":"test",
+                "publisherKey":signed.publisher, "executable":{"hash":executable}, "closure":{"hash":Hash::of(&descriptor).0},
+                "entryPoint":"/example", "invocationABI":"celln.argv/v1", "argumentsSchema":{"hash":Hash::of(arguments).0},
+                "resultSchema":{"hash":Hash::of(result).0}, "platform":"linux/amd64", "lane":"tool",
+                "limits":{"timeoutMillis":1000,"memoryBytes":33554432,"argumentBytes":1024,"outputBytes":1024,"workspace":"none","effects":"none"}
+            }
+        }))?,
+    )?;
+    println!("{}", root.display());
+    Ok(())
+}

--- a/crates/celln-cli/src/closure_cli.rs
+++ b/crates/celln-cli/src/closure_cli.rs
@@ -42,17 +42,74 @@ pub fn verify(
     publisher: &str,
     entry_point: &str,
     executable: &str,
+    toolfs: Option<&Path>,
 ) -> Result<u8> {
-    let report = verification_report(
-        &read(descriptor)?,
+    let bytes = read(descriptor)?;
+    let mut report = verification_report(
+        &bytes,
         root,
         expected_hash,
         publisher,
         entry_point,
         executable,
     )?;
+    if let Some(path) = toolfs {
+        let size = verify_toolfs(path, report["toolfs"].as_str().unwrap())?;
+        // A large artifact read must not hide a policy change during review.
+        let current = verification_report(
+            &bytes,
+            root,
+            expected_hash,
+            publisher,
+            entry_point,
+            executable,
+        )?;
+        anyhow::ensure!(
+            current["policyHash"] == report["policyHash"],
+            "policy changed during verification"
+        );
+        report["scope"] = "descriptor-and-local-toolfs-bytes".into();
+        report["localToolfsBytes"] = size.into();
+        report["localToolfsVerified"] = true.into();
+        // Distribution, member semantics and guest conformance remain separate gates.
+    }
     println!("{}", serde_json::to_string(&report)?);
     Ok(0)
+}
+
+fn verify_toolfs(path: &Path, expected: &str) -> Result<u64> {
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // Refuse symlinks and avoid hanging on a FIFO supplied as an artifact.
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let file = options
+        .open(path)
+        .context("opening local closure filesystem")?;
+    let metadata = file.metadata()?;
+    anyhow::ensure!(
+        metadata.is_file(),
+        "closure filesystem must be a regular file"
+    );
+    anyhow::ensure!(
+        metadata.len() > 0 && metadata.len() <= crate::image::MAX_IMAGE_BYTES,
+        "closure filesystem must contain 1..512 MiB"
+    );
+    let mut bytes = Vec::new();
+    file.take(crate::image::MAX_IMAGE_BYTES + 1)
+        .read_to_end(&mut bytes)?;
+    anyhow::ensure!(
+        !bytes.is_empty() && bytes.len() as u64 <= crate::image::MAX_IMAGE_BYTES,
+        "closure filesystem exceeds byte ceiling or is empty"
+    );
+    anyhow::ensure!(
+        celln_manifest::Hash::of(&bytes).0 == expected,
+        "closure filesystem identity mismatch"
+    );
+    Ok(bytes.len() as u64)
 }
 
 fn verification_report(
@@ -102,6 +159,30 @@ mod tests {
     use super::*;
     use celln_manifest::{closure::Member, Hash};
     use std::collections::{BTreeMap, BTreeSet};
+
+    #[test]
+    fn local_artifact_refuses_missing_empty_oversized_and_nonregular_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("toolfs");
+        let expected = Hash::of(b"test").0;
+        assert!(verify_toolfs(&path, &expected).is_err());
+        assert!(verify_toolfs(dir.path(), &expected).is_err());
+        std::fs::write(&path, b"").unwrap();
+        assert!(verify_toolfs(&path, &expected).is_err());
+        std::fs::File::create(&path)
+            .unwrap()
+            .set_len(crate::image::MAX_IMAGE_BYTES + 1)
+            .unwrap();
+        assert!(verify_toolfs(&path, &expected).is_err());
+        std::fs::write(&path, b"test").unwrap();
+        assert_eq!(verify_toolfs(&path, &expected).unwrap(), 4);
+        #[cfg(unix)]
+        {
+            let alias = dir.path().join("alias");
+            std::os::unix::fs::symlink(&path, &alias).unwrap();
+            assert!(verify_toolfs(&alias, &expected).is_err());
+        }
+    }
 
     fn fixture() -> (tempfile::TempDir, Vec<u8>, String, String) {
         let root = tempfile::tempdir().unwrap();

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -357,6 +357,9 @@ enum ClosureCmd {
         entry_point: String,
         #[arg(long)]
         executable: String,
+        /// Also hash the exact local filesystem bytes (not member conformance or readiness).
+        #[arg(long)]
+        toolfs: Option<PathBuf>,
     },
 }
 
@@ -441,6 +444,7 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             publisher,
             entry_point,
             executable,
+            toolfs,
         }) => closure_cli::verify(
             descriptor,
             &root,
@@ -448,6 +452,7 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             publisher,
             entry_point,
             executable,
+            toolfs.as_deref(),
         ),
         Cmd::Doctor => Ok(doctor(o)),
         Cmd::Dispatcher {

--- a/crates/celln-cli/tests/closure_verify.rs
+++ b/crates/celln-cli/tests/closure_verify.rs
@@ -32,8 +32,11 @@ fn cli_verification_is_bound_read_only_and_rechecks_policy() {
     std::fs::write(&descriptor, &bytes).unwrap();
     let policy = root.path().join("trusted-closures.json");
     std::fs::write(&policy, serde_json::json!({"apiVersion":"celln.dev/closure-policy-v1","publishers":[signed.publisher],"revoked":[]}).to_string()).unwrap();
-    let run = |expected: &str| {
-        Command::new(env!("CARGO_BIN_EXE_celln"))
+    let toolfs = root.path().join("toolfs.ext2");
+    std::fs::write(&toolfs, b"test toolfs").unwrap();
+    let run = |expected: &str, with_toolfs: bool| {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_celln"));
+        command
             .arg("--root")
             .arg(root.path())
             .args(["closure", "verify"])
@@ -47,12 +50,14 @@ fn cli_verification_is_bound_read_only_and_rechecks_policy() {
                 "/tools/test",
                 "--executable",
                 &executable,
-            ])
-            .output()
-            .unwrap()
+            ]);
+        if with_toolfs {
+            command.arg("--toolfs").arg(&toolfs);
+        }
+        command.output().unwrap()
     };
     let identity = Hash::of(&bytes).0;
-    let accepted = run(&identity);
+    let accepted = run(&identity, false);
     assert!(
         accepted.status.success(),
         "{}",
@@ -63,11 +68,30 @@ fn cli_verification_is_bound_read_only_and_rechecks_policy() {
     assert_eq!(report["closure"], identity);
     assert_eq!(report["artifactReadiness"], "not_checked");
     assert!(!root.path().join("closures").exists());
-    let mismatch = run(&Hash::of(b"wrong").0);
+    let local = run(&identity, true);
+    assert!(
+        local.status.success(),
+        "{}",
+        String::from_utf8_lossy(&local.stderr)
+    );
+    let local: serde_json::Value = serde_json::from_slice(&local.stdout).unwrap();
+    assert_eq!(local["localToolfsVerified"], true);
+    assert_eq!(local["localToolfsBytes"], 11);
+    assert_eq!(local["artifactReadiness"], "not_checked");
+    assert_eq!(local["conformance"], "not_checked");
+    assert_eq!(local["scope"], "descriptor-and-local-toolfs-bytes");
+    // This intentionally non-ext2 fixture proves only byte identity; no
+    // filesystem parsing, executable membership or ABI claim is manufactured.
+    std::fs::write(&toolfs, b"tampered").unwrap();
+    let tampered = run(&identity, true);
+    assert!(!tampered.status.success());
+    assert!(tampered.stdout.is_empty());
+    std::fs::write(&toolfs, b"test toolfs").unwrap();
+    let mismatch = run(&Hash::of(b"wrong").0, false);
     assert!(!mismatch.status.success());
     assert!(mismatch.stdout.is_empty());
     std::fs::write(&policy, serde_json::json!({"apiVersion":"celln.dev/closure-policy-v1","publishers":[signed.publisher],"revoked":[identity]}).to_string()).unwrap();
-    let revoked = run(&identity);
+    let revoked = run(&identity, true);
     assert!(!revoked.status.success());
     assert!(revoked.stdout.is_empty());
     assert!(!root.path().join("closures").exists());

--- a/docs/CLOSURE_VERIFICATION.md
+++ b/docs/CLOSURE_VERIFICATION.md
@@ -36,8 +36,30 @@ upgrading. No wire-format or signature-domain change is introduced.
 
 ## Deliberately limited evidence
 
-`scope=descriptor-authenticity-only`, `artifactReadiness=not_checked` and
-`conformance=not_checked` are explicit. The command does not fetch or inspect
+### Optional local filesystem-byte verification
+
+Add `--toolfs /absolute/operator-staged/toolfs.ext2` to hash the exact local
+artifact against the signed filesystem identity. Inputs must be nonempty regular
+files of at most 512 MiB; Unix symlinks/special files refuse. Reads remain bounded
+if files grow. No mount, filesystem parser, guest or store write is involved.
+Policy is rechecked after reading; policy changes during verification refuse.
+
+This emits `scope=descriptor-and-local-toolfs-bytes`, `localToolfsVerified=true`
+and `localToolfsBytes`. Without the option the previous report is unchanged.
+**Both forms retain `artifactReadiness=not_checked` and
+`conformance=not_checked`.** Hashing bytes does not prove filesystem/member
+semantics, dependency ABI, execution behavior, distribution or prewarm. A
+publisher can sign broken bytes; guest/conformance gates must still refuse
+those. Reports are byte snapshots, not leases on files or publisher policy.
+
+`cargo run -p celln-cli --example prepare_review_fixture -- NEW_DIRECTORY`
+creates a public deterministic fixture for Sympozium review tests. Its
+filesystem is deliberately **non-executable**, with valid signed identities
+and restricted schemas. The generator validates the schemas itself. Never
+install its publisher as production trust or use this as a Ready fixture.
+
+Without `--toolfs`, `scope=descriptor-authenticity-only`, `artifactReadiness=not_checked` and
+`conformance=not_checked` are explicit. By default the command does not fetch or inspect
 filesystem/member bytes, verify schema documents, approve behavior or lending
 limits, distribute/prewarm artifacts, run a guest, grant invocation authority,
 or write an admission store. The policy hash is a snapshot identifier, not a


### PR DESCRIPTION
## Scope

Dependency for sympozium-ai/sympozium#426 / #335 operator catalogue review.

- Optional `closure verify --toolfs` hashes bounded regular local filesystem bytes against the signed descriptor. Existing invocation/report stays compatible.
- Refuses missing/empty/oversized/mismatched/symlink inputs; rechecks publisher/revocation policy after reading.
- Reports local byte verification only. Artifact readiness and conformance remain `not_checked`; no filesystem parser, member/ABI certification, distribution, prewarm or execution.
- Adds a deterministic non-executable review fixture with validated bounded schemas. It is deliberately not a Ready fixture.

## Validation

`CARGO_TARGET_DIR=target/validation make ci` passed, plus actual CLI positive, tampered-artifact and revoked-policy cases and bounded/nonregular input tests. Paired Sympozium real-binary and isolated Kubernetes API review tests passed. No model calls or production deployment changes.

Full epic remains open; this does not certify tool behavior or runnable admission.
