### PR TITLE
feat(closure): sealed guest member verification without tool execution

### DIFF
--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -17,6 +17,7 @@ pub(crate) mod harness;
 
 #[path = "dispatch_substrate.rs"]
 mod substrate;
+pub(crate) use substrate::check_members;
 pub(crate) use substrate::launch_declared;
 #[path = "dispatch_inputs.rs"]
 pub(crate) mod inputs;

--- a/crates/celln-cli/src/dispatch_closure_tests.rs
+++ b/crates/celln-cli/src/dispatch_closure_tests.rs
@@ -183,6 +183,39 @@ fn signed_closure_on_real_kvm() {
         "execution":{"lane":"tool","requireHardwareIsolation":true}
     })).unwrap();
     let preparations = super::super::warm::PREPARATIONS.load(std::sync::atomic::Ordering::SeqCst);
+    let mut member_request = request.clone();
+    member_request.invocation.as_mut().unwrap().args.clear();
+    let check_started = std::time::Instant::now();
+    let member_report =
+        super::super::check_members(&member_request, &motes, &tools, &state).unwrap();
+    let member_check_micros = check_started.elapsed().as_micros();
+    assert_eq!(member_report["memberIntegrity"], "verified-in-sealed-cell");
+    assert_eq!(member_report["memberCount"], signed.closure.members.len());
+    assert_eq!(member_report["toolExecution"], false);
+    assert_eq!(member_report["artifactReadiness"], "not_checked");
+    assert_eq!(member_report["conformance"], "not_checked");
+    // Execution arguments cannot turn this read-only operation into a run.
+    assert!(super::super::check_members(&request, &motes, &tools, &state).is_err());
+    let member_request_file = work.path().join("member-check.json");
+    std::fs::write(
+        &member_request_file,
+        serde_json::to_vec(&member_request).unwrap(),
+    )
+    .unwrap();
+    let binary = std::env::var_os("CELLN_TEST_BINARY")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/celln"));
+    let cli_bytes = command(
+        Command::new(binary)
+            .arg("--root")
+            .arg(&state)
+            .args(["closure", "check-members"])
+            .arg(&member_request_file),
+    );
+    let cli_report: serde_json::Value = serde_json::from_slice(&cli_bytes).unwrap();
+    assert_eq!(cli_report["memberIntegrity"], "verified-in-sealed-cell");
+    assert_eq!(cli_report["closure"], closure_hash.0);
+    assert_eq!(cli_report["toolExecution"], false);
     let mut measurements = Vec::new();
     for mode in ["none", "read-only", "read-write"] {
         request.capabilities.workspace = serde_json::from_value(json!(mode)).unwrap();
@@ -239,6 +272,12 @@ fn signed_closure_on_real_kvm() {
         .unwrap()
         .0;
     let (out, _) = super::super::launch_declared(&denied, &motes, &tools, &state).unwrap();
+    member_request.tools = denied.tools.clone();
+    assert!(
+        super::super::check_members(&member_request, &motes, &tools, &state)
+            .unwrap_err()
+            .contains("verification failed")
+    );
     assert_eq!(
         out.denial.as_deref(),
         Some("sealed closure member mismatch")
@@ -259,6 +298,12 @@ fn signed_closure_on_real_kvm() {
     );
     assert!(out.execution.is_none());
     let mut forged_signature = signed.clone();
+    member_request.tools = denied.tools.clone();
+    assert!(
+        super::super::check_members(&member_request, &motes, &tools, &state)
+            .unwrap_err()
+            .contains("verification failed")
+    );
     forged_signature.signature = celln_manifest::closure::hex(&[0; 64]);
     denied.tools[0].closure.as_mut().unwrap().hash = closure_store
         .put(&serde_json::to_vec(&forged_signature).unwrap())
@@ -349,6 +394,11 @@ fn signed_closure_on_real_kvm() {
     );
     let evidence = json!({"status":"passed","closure":closure_hash.0,"publisher":signed.publisher,"members":signed.closure.members,"toolfsBytes":image_bytes.len(),"materialisationMicros":materialisation.as_micros(),"runs":measurements,"warmPreparations":1,"replacementDenied":true,"dependencyRevocationDenied":true,"signatureForgeryDenied":true,"publisherWithdrawalDenied":true,"memberMismatchDenied":true,"symlinkMemberDenied":true,"daxRevocationKilledGuest":true,"executableScratchMappingDenied":true,"liveForkSurvivedEviction":true,"unusedPagesCollected":true,"simultaneousForks":8,"additionalToolAllocations":0,"sharedToolBytes":shared_bytes});
     let evidence_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/closure-proof");
+    let mut evidence = evidence;
+    evidence["sealedMemberCheck"] = member_report;
+    evidence["sealedMemberCLICheck"] = cli_report;
+    evidence["memberCheckIncludingPreparationMicros"] = json!(member_check_micros);
+    evidence["executionSamples"] = json!("prewarmed-by-member-check");
     std::fs::create_dir_all(&evidence_dir).unwrap();
     std::fs::write(
         evidence_dir.join(format!("{}.json", std::process::id())),

--- a/crates/celln-cli/src/dispatch_substrate.rs
+++ b/crates/celln-cli/src/dispatch_substrate.rs
@@ -184,6 +184,135 @@ pub(crate) fn launch_declared(
     }
 }
 
+/// Offline operator verification, using the same pinned warm substrate and
+/// sealed image as execution. No executable invocation or broker is delivered.
+pub(crate) fn check_members(
+    request: &ExecutionRequest,
+    mote_root: &Path,
+    tool_root: &Path,
+    state_root: &Path,
+) -> Result<serde_json::Value, String> {
+    if !request.problems().is_empty()
+        || request.harness.is_some()
+        || request.forge.is_some()
+        || !request.inputs.is_empty()
+        || !request.capabilities.egress.is_empty()
+        || request.capabilities.workspace != celln_spec::WorkspaceAccess::None
+        || request
+            .invocation
+            .as_ref()
+            .map_or(true, |i| !i.args.is_empty())
+    {
+        return Err("member check requires a valid closure request with no args, inputs, workspace, forge, harness or egress".into());
+    }
+    super::check_supported_authority(request)?;
+    authorize(request, state_root)?;
+    let resolved = super::resolve_bundle(request, mote_root, tool_root)?;
+    let closure = super::closure::resolve(request, &resolved, state_root)?
+        .ok_or("signed closure required for member verification")?;
+    for member in closure.signed.closure.members.values() {
+        local_agent_constraint(&member.hash, state_root)?;
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        Err("Unsupported: sealed member verification requires Linux KVM".into())
+    }
+    #[cfg(target_os = "linux")]
+    {
+        use pilot::closure_check::{Envelope, Report, Request, PREFIX, VERSION};
+        use std::io::Read;
+        let work = crate::agent::tempdir().map_err(|e| e.to_string())?;
+        let kernel = work.path().join("kernel");
+        let initrd = work.path().join("initrd");
+        if !resolved.initrd_bytes.starts_with(b"070701") {
+            return Err("unsupported initrd: warm format requires uncompressed newc".into());
+        }
+        let mut random = [0u8; 32];
+        std::fs::File::open("/dev/urandom")
+            .and_then(|mut f| f.read_exact(&mut random))
+            .map_err(|e| e.to_string())?;
+        let envelope = Envelope {
+            verify_closure: Request {
+                version: VERSION.into(),
+                challenge: celln_manifest::Hash::of(&random).0,
+                members: closure.signed.closure.members.clone(),
+            },
+        };
+        if !envelope.verify_closure.valid() {
+            return Err("unsupported closure member check".into());
+        }
+        let run = serde_json::to_vec(&envelope).map_err(|e| e.to_string())?;
+        if run.len() > warden::MAX_INVOCATION_BYTES {
+            return Err("member check exceeds bounded invocation channel".into());
+        }
+        let mut initrd_bytes = resolved.initrd_bytes.clone();
+        while initrd_bytes.len() % 4 != 0 {
+            initrd_bytes.push(0);
+        }
+        initrd_bytes.extend(file_archive("celln/dispatch-warm", b"pio-v1\n"));
+        let mut cell = super::warm::fork(
+            format!(
+                "{}:{}",
+                resolved.bundle_hash, request.capabilities.memory_bytes
+            ),
+            vec![],
+            || {
+                std::fs::write(&kernel, &resolved.kernel_bytes).map_err(|e| e.to_string())?;
+                std::fs::write(&initrd, &initrd_bytes).map_err(|e| e.to_string())?;
+                let mut cfg = warden::vmm::boot::BootConfig::new(kernel)
+                    .with_initrd(initrd)
+                    .with_pmem(resolved.toolfs_bytes.len());
+                cfg.mem_size = request.capabilities.memory_bytes as usize;
+                Ok((cfg, resolved.toolfs_bytes.clone()))
+            },
+        )?;
+        cell.set_invocation(&run).map_err(|e| e.to_string())?;
+        cell.set_timeout(std::time::Duration::from_millis(
+            request.capabilities.timeout_ms.min(10000),
+        ));
+        let result = cell.run().map_err(|e| e.to_string())?;
+        drop(cell);
+        if result.end != warden::vmm::boot::BootEnd::Shutdown {
+            return Err("sealed member check did not shut down cleanly".into());
+        }
+        if result.console.contains("CELLN:out-begin")
+            || result.console.contains("\"kind\":\"started\"")
+        {
+            return Err("unexpected executable invocation during member check".into());
+        }
+        let mut reports = result
+            .console
+            .lines()
+            .filter_map(|line| line.strip_prefix(PREFIX));
+        let report: Report = serde_json::from_str(
+            reports
+                .next()
+                .ok_or("Unsupported: pilot did not report sealed-member verification")?,
+        )
+        .map_err(|_| "invalid sealed-member report")?;
+        if reports.next().is_some() || !report.matches(&envelope, &run) {
+            return Err("sealed-member verification failed or report is unbound".into());
+        }
+        // A potentially slow preparation/check cannot exempt later revocation.
+        authorize(request, state_root)?;
+        super::closure::resolve(request, &resolved, state_root)?;
+        for member in closure.signed.closure.members.values() {
+            local_agent_constraint(&member.hash, state_root)?;
+        }
+        Ok(serde_json::json!({
+            "apiVersion":"celln.dev/sealed-members-verification-v1",
+            "scope":"sealed-member-identities-only", "mote":resolved.bundle_hash,
+            "closure":closure.provenance.hash, "publisher":closure.provenance.publisher,
+            "toolfs":resolved.toolfs_hash, "kernel":resolved.kernel_hash,
+            "initrd":celln_manifest::Hash::of(&initrd_bytes).0,
+            "memberCount":report.member_count, "requestHash":report.request_hash,
+            "challenge":report.challenge, "memberIntegrity":"verified-in-sealed-cell",
+            "toolExecution":false, "cellDissolved":true,
+            "conformance":"not_checked", "artifactReadiness":"not_checked"
+        }))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -336,6 +336,9 @@ enum NodeCmd {
 
 #[derive(Subcommand)]
 enum ClosureCmd {
+    /// Hash signed closure members inside a sealed cell without executing them.
+    /// Requires an operator-pinned declared request, with empty args and no egress.
+    CheckMembers { request: PathBuf },
     /// Offline signing; write the signed descriptor to stdout (never the key).
     Sign {
         descriptor: PathBuf,
@@ -438,6 +441,15 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             key_file,
         }) => closure_cli::sign(descriptor, key_file),
         Cmd::Closure(ClosureCmd::Admit { descriptor }) => closure_cli::admit(descriptor, &root),
+        Cmd::Closure(ClosureCmd::CheckMembers { request }) => {
+            let bytes = closure_policy::read_bounded(request).map_err(anyhow::Error::msg)?;
+            let request = serde_json::from_slice(&bytes)?;
+            let report =
+                dispatch::check_members(&request, &root.join("motes"), &root.join("tools"), &root)
+                    .map_err(anyhow::Error::msg)?;
+            println!("{}", serde_json::to_string(&report)?);
+            Ok(0)
+        }
         Cmd::Closure(ClosureCmd::Verify {
             descriptor,
             expected_hash,

--- a/crates/celln-pilot/src/closure_check.rs
+++ b/crates/celln-pilot/src/closure_check.rs
@@ -1,0 +1,118 @@
+//! Read-only sealed-member verification protocol. This is not an execution
+//! request and carries no path/alias fallback understood by older pilots.
+use celln_manifest::{closure::Member, Hash};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub const PREFIX: &str = "CELLN:closure-members=";
+pub const VERSION: &str = "celln.dev/sealed-members-v1";
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Envelope {
+    pub verify_closure: Request,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Request {
+    pub version: String,
+    pub challenge: String,
+    pub members: BTreeMap<String, Member>,
+}
+
+impl Request {
+    pub fn valid(&self) -> bool {
+        fn hash(s: &str) -> bool {
+            s.len() == 71
+                && s.starts_with("blake3:")
+                && s.as_bytes()[7..]
+                    .iter()
+                    .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(b))
+        }
+        self.version == VERSION
+            && hash(&self.challenge)
+            && !self.members.is_empty()
+            && self.members.len() <= 256
+            && self.members.iter().all(|(path, member)| {
+                celln_manifest::closure::canonical_path(path)
+                    && path.len() <= 256
+                    && hash(&member.hash)
+                    && member.dependencies.len() <= 256
+                    && member
+                        .dependencies
+                        .iter()
+                        .all(|p| self.members.contains_key(p))
+            })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Report {
+    pub version: String,
+    pub challenge: String,
+    pub request_hash: String,
+    pub verified: bool,
+    pub member_count: usize,
+}
+
+impl Report {
+    pub fn matches(&self, request: &Envelope, bytes: &[u8]) -> bool {
+        request.verify_closure.valid()
+            && self.version == VERSION
+            && self.challenge == request.verify_closure.challenge
+            && self.request_hash == Hash::of(bytes).0
+            && self.verified
+            && self.member_count == request.verify_closure.members.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn report_binds_challenge_request_and_complete_member_set() {
+        let request = Envelope {
+            verify_closure: Request {
+                version: VERSION.into(),
+                challenge: Hash::of(b"challenge").0,
+                members: BTreeMap::from([(
+                    "/tool".into(),
+                    Member {
+                        hash: Hash::of(b"bytes").0,
+                        dependencies: Default::default(),
+                    },
+                )]),
+            },
+        };
+        let bytes = serde_json::to_vec(&request).unwrap();
+        let mut report = Report {
+            version: VERSION.into(),
+            challenge: request.verify_closure.challenge.clone(),
+            request_hash: Hash::of(&bytes).0,
+            verified: true,
+            member_count: 1,
+        };
+        assert!(report.matches(&request, &bytes));
+        report.verified = false;
+        assert!(!report.matches(&request, &bytes));
+        report.verified = true;
+        report.member_count = 0;
+        assert!(!report.matches(&request, &bytes));
+        report.member_count = 1;
+        assert!(!report.matches(&request, b"different request"));
+        report.challenge = Hash::of(b"replayed").0;
+        assert!(!report.matches(&request, &bytes));
+    }
+    #[test]
+    fn mixed_execution_and_verification_refuses() {
+        assert!(serde_json::from_str::<Envelope>(r#"{"verify_closure":{"version":"x","challenge":"x","members":{}},"path":"/evil","alias":"/evil"}"#).is_err());
+        let request = Request {
+            version: VERSION.into(),
+            challenge: Hash::of(b"nonce").0,
+            members: BTreeMap::new(),
+        };
+        assert!(!request.valid());
+    }
+}

--- a/crates/celln-pilot/src/guest.rs
+++ b/crates/celln-pilot/src/guest.rs
@@ -1100,6 +1100,15 @@ fn run_requested(manifest: &Manifest) {
     } else {
         return; // nothing asked of this cell
     };
+    // A separate envelope with no executable path/alias: older pilots run
+    // nothing, and mixed-mode envelopes must never fall through to execution.
+    if serde_json::from_slice::<serde_json::Value>(&bytes)
+        .ok()
+        .is_some_and(|v| v.get("verify_closure").is_some())
+    {
+        check_sealed_members(&bytes);
+        return;
+    }
     let file: RunFile = match serde_json::from_slice(&bytes) {
         Ok(r) => r,
         Err(e) => {
@@ -1134,6 +1143,31 @@ fn run_requested(manifest: &Manifest) {
         }
         run_one(manifest, &req);
     }
+}
+
+fn check_sealed_members(bytes: &[u8]) {
+    use pilot::closure_check::{Envelope, Report, PREFIX, VERSION};
+    let Ok(envelope) = serde_json::from_slice::<Envelope>(bytes) else {
+        return;
+    };
+    let request = envelope.verify_closure;
+    let verified = request.valid()
+        && request.members.iter().all(|(path, member)| {
+            sealed_member_path(path)
+                && open_and_hash(&format!("/tools{path}"))
+                    .is_ok_and(|(_, hash)| hash.0 == member.hash)
+        });
+    let report = Report {
+        version: VERSION.into(),
+        challenge: request.challenge,
+        request_hash: Hash::of(bytes).0,
+        verified,
+        member_count: request.members.len(),
+    };
+    println!(
+        "{PREFIX}{}",
+        serde_json::to_string(&report).expect("serializable check report")
+    );
 }
 
 /// One-shot host data, not executable authority. The I/O permission is revoked
@@ -1385,6 +1419,14 @@ fn finish(code: i32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn member_check_envelope_has_no_legacy_execution_fallback() {
+        let bytes = br#"{"verify_closure":{"version":"celln.dev/sealed-members-v1","challenge":"test","members":{}}}"#;
+        // RunFile intentionally retains the pre-extension execution parser.
+        let legacy: RunFile = serde_json::from_slice(bytes).unwrap();
+        assert!(legacy.invocations().is_empty());
+    }
 
     #[test]
     fn replacing_the_verified_path_cannot_change_what_executes() {

--- a/crates/celln-pilot/src/lib.rs
+++ b/crates/celln-pilot/src/lib.rs
@@ -12,6 +12,7 @@
 use celln_manifest::{ExecDenied, Hash, Input, Lane, Manifest};
 use serde::Serialize;
 
+pub mod closure_check;
 pub mod dispatch_report;
 
 /// The result of asking pilot to run something.

--- a/docs/SEALED_MEMBER_VERIFICATION.md
+++ b/docs/SEALED_MEMBER_VERIFICATION.md
@@ -1,0 +1,89 @@
+# Sealed closure member identity verification
+
+For Sympozium epic [#426](https://github.com/sympozium-ai/sympozium/issues/426),
+operator review must progress beyond hashing a signed filesystem blob. The
+read-only `celln closure check-members REQUEST.json` command verifies declared
+member paths and hashes **inside a sealed cell**, using the same pinned
+substrate and guest checks as declared execution. No tool is invoked.
+
+## Inputs and trust
+
+`REQUEST.json` is an existing valid declared `celln.dev/v1alpha1` execution
+request selecting one approved mote, executable and signed closure. Its
+invocation arguments must be empty; workspace must be `none`; inputs, egress,
+forge and Harness binding must be absent. This check never interprets a task
+as a command or forwards execution arguments. All ordinary request validation
+and host mote/publisher/revocation policies remain authoritative.
+
+```sh
+celln --root /absolute/operator/node-state closure check-members REQUEST.json
+```
+
+The operator root contains `motes/`, `tools/`, `closures/`, `trusted-motes.json`
+and `trusted-closures.json`, as for declared dispatch. Kernel/initrd must be
+independently operator-approved; a submitted filesystem cannot supply its own
+verification pilot. This does not import a submitted publisher or bypass local
+withdrawal. Stores are read by exact content identity and verified bytes are
+held for loading, not reopened by mutable path. Missing KVM/compatible pilot
+cannot produce a successful verification report.
+
+## How it works
+
+Cold preparation boots the pinned substrate into its existing authority-free
+park point. The check, including the first one, forks that warm mote. The host
+delivers a separate `verify_closure` envelope containing bounded signed member
+metadata and an unpredictable challenge; it has **no executable path/alias**.
+Older pilots interpret it as zero invocations and cannot silently execute the
+tool. New pilots refuse mixed verification/execution envelopes without falling
+through to an execution path. No model or network broker is enabled.
+
+Pilot traverses canonical paths under the sealed `/tools` mount, refusing
+symlinks, nonregular/oversized files and absent members, then hashes actual
+member bytes. It emits a versioned report bound to the challenge, exact request
+bytes and member count. The host requires exactly one matching successful
+report, clean shutdown and no execution markers. Each check cell is dropped;
+the bounded warm template may remain cached. The cell run has a watchdog of at
+most ten seconds; cold preparation retains its existing separate watchdog.
+Policies are rechecked after the potentially slow operation.
+
+Success reports `scope=sealed-member-identities-only`,
+`memberIntegrity=verified-in-sealed-cell`, `toolExecution=false`, exact
+mote/kernel/initrd/toolfs/closure identities and `cellDissolved=true`.
+**`conformance` and `artifactReadiness` remain `not_checked`.** This establishes
+member identity, not ELF/loader/ABI correctness, application behavior, tool schema
+semantics, permission suitability, node distribution/prewarm leases or full
+Harness conformance. The report is not a signed attestation or a grant. A
+future trusted verifier must bind the current catalogue/runtime/policy identities
+and complete those remaining gates before exposing runnable readiness.
+
+## Reproduction and evidence
+
+The existing ignored signed-closure suite now exercises positive sealed-member
+verification and the real CLI, alongside altered-library and symlink-member
+refusals and the existing dynamic execution/revocation/hostile-guest cases:
+
+```sh
+CARGO_TARGET_DIR=target/validation cargo build --release \
+  --target x86_64-unknown-linux-musl -p celln-pilot \
+  --bin celln-pilot --bin pilot-fetch
+CARGO_TARGET_DIR=target/validation cargo build -p celln-cli
+CELLN_TEST_BINARY="$PWD/target/validation/debug/celln" \
+CELLN_PILOT_DIR="$PWD/target/validation/x86_64-unknown-linux-musl/release" \
+CARGO_TARGET_DIR=target/validation cargo test -p celln-cli \
+  signed_closure_on_real_kvm -- --ignored --nocapture
+```
+
+Unavailable prerequisites are explicitly skipped, not counted as hardware
+passes. Reports are saved in `target/closure-proof/`. The revised evidence
+separates member-check preparation time from subsequent execution samples:
+those executions are now prewarmed by the member check and must **not** be
+described as cold-start measurements. Protocol tests cover mixed envelopes and
+the absence of a legacy executable fallback. Normal `make ci` remains required.
+
+On 2026-09-07, `make ci` passed and the explicit KVM/CLI suite passed in
+10.20 seconds with no prerequisite skips. The
+[committed report](evidence/sealed-members-2026-09-07.json) includes both
+four-member verification reports, binary fingerprints and working-tree
+provenance. Initial member checking including preparation took 2,746,416 µs.
+These are single-host fixture measurements, not fleet or full-Harness claims.
+No cluster deployment or provider credentials were changed or used.

--- a/docs/SEALED_MEMBER_VERIFICATION.md
+++ b/docs/SEALED_MEMBER_VERIFICATION.md
@@ -46,6 +46,11 @@ the bounded warm template may remain cached. The cell run has a watchdog of at
 most ten seconds; cold preparation retains its existing separate watchdog.
 Policies are rechecked after the potentially slow operation.
 
+The warm cache is process-local. A standalone CLI exits and releases its
+template; checking members in that process does **not** prewarm a separate
+dispatcher or make a node selection ready. Distribution/prewarm must be proven
+in the actual serving process before advertising readiness.
+
 Success reports `scope=sealed-member-identities-only`,
 `memberIntegrity=verified-in-sealed-cell`, `toolExecution=false`, exact
 mote/kernel/initrd/toolfs/closure identities and `cellDissolved=true`.

--- a/docs/evidence/sealed-members-2026-09-07.json
+++ b/docs/evidence/sealed-members-2026-09-07.json
@@ -1,0 +1,104 @@
+{
+  "additionalToolAllocations": 0,
+  "closure": "blake3:3ec54ccc82ca4c3f39c28cd5d50916293090ce3ec3ae8915afa98dd1f3fcdef2",
+  "daxRevocationKilledGuest": true,
+  "dependencyRevocationDenied": true,
+  "executableScratchMappingDenied": true,
+  "executionSamples": "prewarmed-by-member-check",
+  "liveForkSurvivedEviction": true,
+  "materialisationMicros": 407480,
+  "memberCheckIncludingPreparationMicros": 2746416,
+  "memberMismatchDenied": true,
+  "members": {
+    "/bin/program": {
+      "dependencies": [
+        "/lib64/ld-linux-x86-64.so.2",
+        "/lib64/libc.so.6",
+        "/lib64/libgcc_s.so.1"
+      ],
+      "hash": "blake3:5e2ee6c9dc3c928a5e08d0786539d55916ed7e35a8147cd3108b816df77306e1"
+    },
+    "/lib64/ld-linux-x86-64.so.2": {
+      "dependencies": [],
+      "hash": "blake3:d7f70e3bf8867805e3456d4a21623ad07c345076a6c64439cb4e731a3e121541"
+    },
+    "/lib64/libc.so.6": {
+      "dependencies": [],
+      "hash": "blake3:63a42174f3226dcbf4416f186c34da12643ca46da4dbb7a30d8f5f35cdb9a5e4"
+    },
+    "/lib64/libgcc_s.so.1": {
+      "dependencies": [],
+      "hash": "blake3:b69e42521beba7959bea17be219b67241af5c0724e4b17107416247821cd4fc2"
+    }
+  },
+  "publisher": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+  "publisherWithdrawalDenied": true,
+  "replacementDenied": true,
+  "runs": [
+    {
+      "elapsedMicros": 145385,
+      "workspace": "none"
+    },
+    {
+      "elapsedMicros": 131380,
+      "workspace": "read-only"
+    },
+    {
+      "elapsedMicros": 132844,
+      "workspace": "read-write"
+    }
+  ],
+  "sealedMemberCLICheck": {
+    "apiVersion": "celln.dev/sealed-members-verification-v1",
+    "artifactReadiness": "not_checked",
+    "cellDissolved": true,
+    "challenge": "blake3:69e34c34628968224903d204a564ecd73562bc72310f1b8a397ea4e68b9a8436",
+    "closure": "blake3:3ec54ccc82ca4c3f39c28cd5d50916293090ce3ec3ae8915afa98dd1f3fcdef2",
+    "conformance": "not_checked",
+    "initrd": "blake3:288828207d1c2dbc0544b3689825110fed953a8e6b24a72d473e9c72723d3f01",
+    "kernel": "blake3:e8e05482b24c4d9019ff7298f42f6f2730fcf656cbcb429ec44150ceac0e4ca8",
+    "memberCount": 4,
+    "memberIntegrity": "verified-in-sealed-cell",
+    "mote": "blake3:7330208526f5dac199eda94008d2a5173ff58a51c2df03d17d210c02b712af54",
+    "publisher": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+    "requestHash": "blake3:09d1cf5a69095c4cdd9900dcf05c86d20bdb5ae7376329ac48fe134ccf9e1531",
+    "scope": "sealed-member-identities-only",
+    "toolExecution": false,
+    "toolfs": "blake3:24a3e3b4758450c0dafedc7d308d0559d32dd7df1c6bdcc40b8df96818e4d2a0"
+  },
+  "sealedMemberCheck": {
+    "apiVersion": "celln.dev/sealed-members-verification-v1",
+    "artifactReadiness": "not_checked",
+    "cellDissolved": true,
+    "challenge": "blake3:9bc50f93aafe262d5e00b396bd692c468d179cb9496e3189b0e66e858361479b",
+    "closure": "blake3:3ec54ccc82ca4c3f39c28cd5d50916293090ce3ec3ae8915afa98dd1f3fcdef2",
+    "conformance": "not_checked",
+    "initrd": "blake3:288828207d1c2dbc0544b3689825110fed953a8e6b24a72d473e9c72723d3f01",
+    "kernel": "blake3:e8e05482b24c4d9019ff7298f42f6f2730fcf656cbcb429ec44150ceac0e4ca8",
+    "memberCount": 4,
+    "memberIntegrity": "verified-in-sealed-cell",
+    "mote": "blake3:7330208526f5dac199eda94008d2a5173ff58a51c2df03d17d210c02b712af54",
+    "publisher": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+    "requestHash": "blake3:06553eefb8c207926abfa2fb06259e52c99c1d7377587874954f25ab12993a20",
+    "scope": "sealed-member-identities-only",
+    "toolExecution": false,
+    "toolfs": "blake3:24a3e3b4758450c0dafedc7d308d0559d32dd7df1c6bdcc40b8df96818e4d2a0"
+  },
+  "sharedToolBytes": 33554432,
+  "signatureForgeryDenied": true,
+  "simultaneousForks": 8,
+  "status": "passed",
+  "symlinkMemberDenied": true,
+  "toolfsBytes": 33554432,
+  "unusedPagesCollected": true,
+  "warmPreparations": 1,
+  "provenance": {
+    "baseRevision": "a71147c",
+    "workingTreeChanges": true,
+    "scope": "sealed member identity and existing signed-closure regressions; not full Harness conformance",
+    "binarySHA256": [
+      "01c77ef7cce5d0e0b6802408524bfaaea476ef967d410958c1bf326dbd64b8e4  target/validation/debug/celln",
+      "d58329cf48410d867533511dca50f6e189306e0b85d00bc2dc8a452cae667a07  target/validation/x86_64-unknown-linux-musl/release/celln-pilot"
+    ]
+  }
+}


### PR DESCRIPTION
## Scope

Progresses sympozium-ai/sympozium#426 / #335 beyond metadata/blob identity review.

Adds `celln closure check-members REQUEST.json`: uses independently operator-pinned kernel/initrd/mote and signed closure, forks a warm sealed cell, and asks pilot to hash the actual declared files without executing any tool or enabling a broker.

- Separate bounded envelope has no path/alias execution fallback; mixed envelopes refuse, older pilots produce no successful report.
- Guest checks canonical non-symlink regular member files and exact hashes. Host requires a challenge/request-bound report, correct member count, clean shutdown and no execution markers; policies are rechecked after verification.
- Reports member integrity only. ELF/ABI/application conformance, distribution/prewarm readiness and grants remain explicitly unverified.
- Adds durable measured evidence and reproduction guide. Execution benchmark samples are now correctly labelled prewarmed by the member check.

## Validation

`CARGO_TARGET_DIR=target/validation make ci` passed. Explicit `signed_closure_on_real_kvm` passed in 10.20 s, including the actual new CLI, positive four-member hashing, altered dependency and symlink refusals, and existing dynamic-execution/revocation/hostile-guest/teardown regressions. No hardware prerequisite was skipped. Public challenge/report binding and legacy no-exec fallback have portable tests.

Evidence: `docs/evidence/sealed-members-2026-09-07.json`; guide: `docs/SEALED_MEMBER_VERIFICATION.md`.

No model calls or cluster changes. This does not close the epic or establish general Harness conformance/readiness. Requires a newly built/pinned pilot; an older pilot cannot falsely pass.
