### PR TITLE
feat(harness): schema-bound JSON borrowed tools and real-model proof

### DIFF
--- a/crates/celln-pilot/Cargo.toml
+++ b/crates/celln-pilot/Cargo.toml
@@ -48,6 +48,15 @@ name = "celln-harness-reference"
 path = "src/harness_reference.rs"
 
 [[bin]]
+name = "celln-harness-json"
+path = "src/harness_json.rs"
+
+[[bin]]
+name = "celln-json-harness-proof"
+path = "src/json_harness_proof.rs"
+required-features = ["kvm"]
+
+[[bin]]
 name = "celln-harness-proof"
 path = "src/harness_proof.rs"
 required-features = ["kvm"]

--- a/crates/celln-pilot/src/harness_io.rs
+++ b/crates/celln-pilot/src/harness_io.rs
@@ -1,0 +1,151 @@
+//! Bounded, concurrent pipe draining for a tool within an already sealed cell.
+//! The enclosing host cell watchdog remains the final descendant/teardown bound.
+use anyhow::{ensure, Context, Result};
+use std::io::{Read, Write};
+use std::os::fd::AsRawFd;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn nonblocking(fd: i32) -> Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    ensure!(
+        flags >= 0 && unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } >= 0,
+        "cannot bound child pipes"
+    );
+    Ok(())
+}
+
+fn drain(pipe: &mut impl Read, output: &mut Vec<u8>, limit: usize, eof: &mut bool) -> Result<()> {
+    let mut bytes = [0u8; 4096];
+    loop {
+        match pipe.read(&mut bytes) {
+            Ok(0) => {
+                *eof = true;
+                return Ok(());
+            }
+            Ok(n) => {
+                ensure!(
+                    n <= limit.saturating_sub(output.len()),
+                    "child output exceeded limit"
+                );
+                output.extend_from_slice(&bytes[..n]);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+pub fn child(
+    path: &str,
+    args: &[String],
+    input: &[u8],
+    output_limit: usize,
+    timeout: Duration,
+) -> Result<Vec<u8>> {
+    ensure!(
+        input.len() <= 65536
+            && output_limit > 0
+            && output_limit <= 1_048_576
+            && !timeout.is_zero()
+            && timeout <= Duration::from_secs(45),
+        "invalid child budget"
+    );
+    let mut child = Command::new(path)
+        .args(args)
+        .env_clear()
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("starting lent executable")?;
+    let result = (|| -> Result<Vec<u8>> {
+        let mut stdin = child.stdin.take();
+        let mut stdout = child.stdout.take().context("stdout unavailable")?;
+        let mut stderr = child.stderr.take().context("stderr unavailable")?;
+        nonblocking(stdin.as_ref().context("stdin unavailable")?.as_raw_fd())?;
+        nonblocking(stdout.as_raw_fd())?;
+        nonblocking(stderr.as_raw_fd())?;
+        let start = Instant::now();
+        let (mut output, mut errors) = (Vec::new(), Vec::new());
+        let (mut out_eof, mut err_eof, mut written) = (false, false, 0);
+        loop {
+            ensure!(start.elapsed() < timeout, "tool deadline exceeded");
+            if let Some(pipe) = stdin.as_mut() {
+                if written == input.len() {
+                    stdin.take();
+                } else {
+                    match pipe.write(&input[written..]) {
+                        Ok(0) => anyhow::bail!("tool input pipe closed"),
+                        Ok(n) => written += n,
+                        Err(e)
+                            if matches!(
+                                e.kind(),
+                                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
+                            ) => {}
+                        Err(e) => return Err(e.into()),
+                    }
+                }
+            }
+            if !out_eof {
+                drain(&mut stdout, &mut output, output_limit, &mut out_eof)?;
+            }
+            if !err_eof {
+                drain(&mut stderr, &mut errors, 4096, &mut err_eof)?;
+            }
+            if let Some(status) = child.try_wait()? {
+                ensure!(status.success(), "lent executable failed");
+                if out_eof && err_eof {
+                    ensure!(written == input.len(), "tool exited before input delivery");
+                    return Ok(output);
+                }
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    })();
+    if result.is_err() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn bounded_pipes_and_deadline() {
+        let args = |script: &str| vec!["-c".into(), script.into()];
+        assert_eq!(
+            child(
+                "/bin/sh",
+                &args("cat"),
+                br#"{"text":"borrowed"}"#,
+                1024,
+                Duration::from_secs(2)
+            )
+            .unwrap(),
+            br#"{"text":"borrowed"}"#
+        );
+        assert!(child(
+            "/bin/sh",
+            &args("printf 123456"),
+            b"",
+            3,
+            Duration::from_secs(1)
+        )
+        .is_err());
+        assert!(child(
+            "/bin/sh",
+            &args("exec sleep 3"),
+            b"",
+            3,
+            Duration::from_millis(20)
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("deadline"));
+        assert!(child("/bin/sh", &args("exit 7"), b"", 3, Duration::from_secs(1)).is_err());
+    }
+}

--- a/crates/celln-pilot/src/harness_json.rs
+++ b/crates/celln-pilot/src/harness_json.rs
@@ -1,0 +1,74 @@
+//! Native schema-bound JSON/stdin-stdout adapter; no arbitrary OCI compatibility.
+#[cfg(target_os = "linux")]
+fn run() -> anyhow::Result<()> {
+    use anyhow::{ensure, Context};
+    use celln_manifest::Hash;
+    use std::io::Read;
+    let raw = std::env::args()
+        .nth(1)
+        .context("missing host configuration")?;
+    ensure!(raw.len() <= 65536, "configuration exceeds delivery limit");
+    let config: pilot::json_harness::Config = serde_json::from_str(&raw)?;
+    pilot::json_harness::validate(&config)?;
+    // The host must deliver this runtime and all lent executables as a signed
+    // sealed closure. These checks are fail-closed diagnostics, not a substitute
+    // for the host's hardware sealing or grant verification.
+    for tool in &config.tools {
+        let mut options = std::fs::OpenOptions::new();
+        use std::os::unix::fs::OpenOptionsExt;
+        options
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        let file = options.open(&tool.path)?;
+        ensure!(file.metadata()?.is_file(), "tool is not a regular file");
+        let mut bytes = Vec::new();
+        file.take(536870913).read_to_end(&mut bytes)?;
+        ensure!(
+            bytes.len() <= 536870912 && Hash::of(&bytes).0 == tool.hash,
+            "lent executable identity mismatch"
+        );
+        ensure!(
+            std::fs::OpenOptions::new()
+                .write(true)
+                .open(&tool.path)
+                .is_err(),
+            "lent executable is writable"
+        );
+    }
+    pilot::json_harness::run(
+        &config,
+        |wire| {
+            pilot::harness_io::child(
+                "/pilot-fetch",
+                &["--json-stdin".into()],
+                wire,
+                1_048_576,
+                std::time::Duration::from_secs(45),
+            )
+        },
+        |tool, input| {
+            pilot::harness_io::child(
+                &tool.path,
+                &[],
+                input,
+                tool.output_bytes,
+                std::time::Duration::from_millis(tool.timeout_ms),
+            )
+        },
+        |event| println!("CELLN_HARNESS_EVENT {event}"),
+    )?;
+    Ok(())
+}
+
+fn main() {
+    #[cfg(target_os = "linux")]
+    if let Err(error) = run() {
+        eprintln!("CELLN_HARNESS_ERROR {error:#}");
+        std::process::exit(1);
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("Unsupported: JSON-tool adapter requires Linux sealed-cell execution");
+        std::process::exit(5);
+    }
+}

--- a/crates/celln-pilot/src/json_harness.rs
+++ b/crates/celln-pilot/src/json_harness.rs
@@ -1,0 +1,211 @@
+//! Native bounded JSON-tool Harness contract. Model output selects only an
+//! already lent name; schemas and limits are immutable host-provided ceilings.
+use anyhow::{bail, ensure, Context, Result};
+use celln_manifest::{tool_schema::ToolSchema, Hash};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::collections::BTreeSet;
+
+pub const CONTRACT: &str = "celln.json-tools/v1";
+
+#[cfg(test)]
+#[path = "json_harness_tests.rs"]
+mod tests;
+
+pub fn validate(config: &Config) -> Result<()> {
+    compile(config).map(|_| ())
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Schema {
+    pub bytes: String,
+    pub hash: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Tool {
+    pub name: String,
+    pub path: String,
+    pub hash: String,
+    pub description: String,
+    pub input_schema: Schema,
+    pub output_schema: Schema,
+    pub input_bytes: usize,
+    pub output_bytes: usize,
+    pub timeout_ms: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    pub contract: String,
+    pub task: String,
+    pub system: String,
+    pub url: String,
+    pub model: String,
+    pub tools: Vec<Tool>,
+    pub max_turns: usize,
+    pub max_calls: usize,
+}
+
+struct CheckedTool<'a> {
+    tool: &'a Tool,
+    input: ToolSchema,
+    output: ToolSchema,
+    definition: Value,
+}
+
+fn compile(config: &Config) -> Result<Vec<CheckedTool<'_>>> {
+    ensure!(config.contract == CONTRACT, "unsupported Harness contract");
+    ensure!(
+        !config.task.trim().is_empty() && config.task.len() <= 2048 && config.system.len() <= 2048,
+        "task/persona exceeds contract"
+    );
+    ensure!(
+        !config.model.is_empty()
+            && config.model.len() <= 128
+            && config.url.starts_with("https://")
+            && config.url.len() <= 512,
+        "invalid model selection"
+    );
+    ensure!(
+        (1..=6).contains(&config.max_turns) && config.max_calls <= 16 && config.tools.len() <= 16,
+        "turn/call/tool limit exceeds contract"
+    );
+    let mut names = BTreeSet::new();
+    let mut paths = BTreeSet::new();
+    config.tools.iter().map(|tool| {
+        ensure!(!tool.name.is_empty() && tool.name.len() <= 64 && tool.name.bytes().all(|b| b.is_ascii_alphanumeric() || b"_-".contains(&b))
+            && names.insert(&tool.name) && paths.insert(&tool.path), "invalid or duplicate tool identity");
+        ensure!(celln_manifest::closure::canonical_path(&tool.path) && tool.path.len() <= 256
+            && tool.path != "/pilot-fetch" && tool.hash.len() == 71 && tool.hash.starts_with("blake3:")
+            && tool.hash.as_bytes()[7..].iter().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(b)), "invalid tool path/hash");
+        ensure!(!tool.description.is_empty() && tool.description.len() <= 512
+            && (1..=65536).contains(&tool.input_bytes) && (1..=65536).contains(&tool.output_bytes)
+            && (1..=30000).contains(&tool.timeout_ms), "invalid tool ceilings");
+        let input = ToolSchema::parse(tool.input_schema.bytes.as_bytes(), &Hash(tool.input_schema.hash.clone())).map_err(anyhow::Error::msg)?;
+        let output = ToolSchema::parse(tool.output_schema.bytes.as_bytes(), &Hash(tool.output_schema.hash.clone())).map_err(anyhow::Error::msg)?;
+        let parameters: Value = serde_json::from_str(&tool.input_schema.bytes)?;
+        ensure!(parameters["type"] == "object", "JSON-tool inputs must use an object schema");
+        let definition = json!({"type":"function","function":{"name":tool.name,"description":tool.description,"parameters":parameters}});
+        Ok(CheckedTool { tool, input, output, definition })
+    }).collect()
+}
+
+/// Executes the bounded model loop through injected broker/tool transports.
+/// No ambient tool discovery, implicit all-tools call requirement or shell.
+/// Tool transport receives exact model argument bytes AFTER schema validation.
+pub fn run(
+    config: &Config,
+    mut broker: impl FnMut(&[u8]) -> Result<Vec<u8>>,
+    mut execute: impl FnMut(&Tool, &[u8]) -> Result<Vec<u8>>,
+    mut event: impl FnMut(Value),
+) -> Result<String> {
+    let tools = compile(config)?;
+    let mut messages = Vec::new();
+    if !config.system.is_empty() {
+        messages.push(json!({"role":"system","content":config.system}));
+    }
+    messages.push(json!({"role":"user","content":config.task}));
+    let mut ids = BTreeSet::new();
+    let mut calls = 0usize;
+    for turn in 0..config.max_turns {
+        let mut body =
+            json!({"model":config.model,"stream":false,"max_tokens":512,"messages":messages});
+        if !tools.is_empty() {
+            body["tools"] = json!(tools.iter().map(|t| &t.definition).collect::<Vec<_>>());
+            body["tool_choice"] = json!("auto");
+        }
+        let wire = serde_json::to_vec(
+            &json!({"apiVersion":"celln.fetch/v1","method":"POST","url":config.url,"body":body}),
+        )?;
+        ensure!(
+            wire.len() <= 8192,
+            "conversation/schema envelope exceeds broker byte limit"
+        );
+        let response = broker(&wire)?;
+        ensure!(response.len() <= 1_048_576, "model response exceeds limit");
+        let response: Value = serde_json::from_slice(&response)?;
+        let choices = response["choices"]
+            .as_array()
+            .context("missing model choices")?;
+        ensure!(choices.len() == 1, "exactly one model choice required");
+        let message = &choices[0]["message"];
+        ensure!(message["role"] == "assistant", "invalid response role");
+        let tool_calls = match message.get("tool_calls") {
+            None | Some(Value::Null) => vec![],
+            Some(Value::Array(calls)) => calls.clone(),
+            _ => bail!("invalid tool call list"),
+        };
+        ensure!(
+            tool_calls.len() <= config.max_calls.saturating_sub(calls),
+            "tool call budget exhausted"
+        );
+        event(json!({"type":"model","turn":turn,"model":config.model}));
+        if tool_calls.is_empty() {
+            let answer = message["content"]
+                .as_str()
+                .context("missing final answer")?;
+            ensure!(
+                !answer.trim().is_empty() && answer.len() <= 4096,
+                "final answer is empty or exceeds limit"
+            );
+            event(json!({"type":"completed","answer":answer,"calls":calls}));
+            return Ok(answer.into());
+        }
+        // Validate the complete batch before any side effects. Preserve only
+        // the supported assistant fields, never arbitrary provider extensions.
+        let mut pending = Vec::new();
+        let mut sanitized = Vec::new();
+        for call in &tool_calls {
+            let id = call["id"].as_str().context("missing tool-call ID")?;
+            ensure!(
+                !id.is_empty()
+                    && id.len() <= 128
+                    && ids.insert(id.to_owned())
+                    && call["type"] == "function",
+                "duplicate or invalid tool call"
+            );
+            let name = call["function"]["name"]
+                .as_str()
+                .context("missing tool name")?;
+            let tool = tools
+                .iter()
+                .find(|t| t.tool.name == name)
+                .context("unselected tool requested")?;
+            let arguments = call["function"]["arguments"]
+                .as_str()
+                .context("missing JSON arguments")?;
+            tool.input
+                .validate(arguments.as_bytes(), tool.tool.input_bytes)
+                .map_err(anyhow::Error::msg)?;
+            pending.push((id, tool, arguments));
+            sanitized.push(
+                json!({"id":id,"type":"function","function":{"name":name,"arguments":arguments}}),
+            );
+        }
+        ensure!(
+            message["content"].is_null() || message["content"].is_string(),
+            "invalid assistant content"
+        );
+        messages
+            .push(json!({"role":"assistant","content":message["content"],"tool_calls":sanitized}));
+        for (id, tool, arguments) in pending {
+            let output = execute(tool.tool, arguments.as_bytes())?;
+            tool.output
+                .validate(&output, tool.tool.output_bytes)
+                .map_err(anyhow::Error::msg)?;
+            let text = String::from_utf8(output)?;
+            calls += 1;
+            event(
+                json!({"type":"tool","id":id,"name":tool.tool.name,"hash":tool.tool.hash,
+                "inputSchema":tool.tool.input_schema.hash,"outputSchema":tool.tool.output_schema.hash,
+                "arguments":serde_json::from_str::<Value>(arguments)?,"result":serde_json::from_str::<Value>(&text)?}),
+            );
+            messages.push(json!({"role":"tool","tool_call_id":id,"content":text}));
+        }
+    }
+    bail!("model turn budget exhausted")
+}

--- a/crates/celln-pilot/src/json_harness.rs
+++ b/crates/celln-pilot/src/json_harness.rs
@@ -155,6 +155,12 @@ pub fn run(
             event(json!({"type":"completed","answer":answer,"calls":calls}));
             return Ok(answer.into());
         }
+        // Do not start side effects when the configured turn budget already
+        // makes returning their results to the model impossible.
+        ensure!(
+            turn + 1 < config.max_turns,
+            "model budget leaves no tool result turn"
+        );
         // Validate the complete batch before any side effects. Preserve only
         // the supported assistant fields, never arbitrary provider extensions.
         let mut pending = Vec::new();

--- a/crates/celln-pilot/src/json_harness_proof.rs
+++ b/crates/celln-pilot/src/json_harness_proof.rs
@@ -1,0 +1,253 @@
+//! Explicit KVM functional proof: scripted by default; --real-model is billable.
+use anyhow::{ensure, Context, Result};
+use celln_manifest::{
+    closure::{Closure, Member},
+    Author, Entry, Hash, Manifest, Tier,
+};
+use serde_json::json;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+    process::Command,
+    time::Duration,
+};
+use warden::vmm::boot::{BootConfig, BootEnd, LinuxCell};
+
+fn main() -> Result<()> {
+    let real_model = std::env::args().any(|arg| arg == "--real-model");
+    let token = if real_model {
+        Some(PathBuf::from(
+            std::env::var_os("CELLN_MODEL_TOKEN_FILE")
+                .context("real model requires explicit host credential file")?,
+        ))
+    } else {
+        None
+    };
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let binaries = PathBuf::from(
+        std::env::var_os("CELLN_PILOT_DIR")
+            .context("explicit static guest binary directory required")?,
+    );
+    let work = root.join(format!("target/json-harness-proof-{}", std::process::id()));
+    std::fs::create_dir(&work)?;
+    std::fs::copy(binaries.join("celln-harness-json"), work.join("harness"))?;
+    for (name, fixture, uppercase) in [
+        ("pilot-fetch", "json_broker.rs", false),
+        ("uppercase", "json_tool.rs", true),
+        ("length", "json_tool.rs", false),
+    ] {
+        if real_model && name == "pilot-fetch" {
+            std::fs::copy(binaries.join("pilot-fetch"), work.join(name))?;
+            continue;
+        }
+        let mut build = Command::new("rustc");
+        build.args([
+            "--edition=2021",
+            "-O",
+            "--target",
+            "x86_64-unknown-linux-musl",
+        ]);
+        if uppercase {
+            build.args(["--cfg", "uppercase_tool"]);
+        }
+        ensure!(
+            build
+                .arg(root.join("crates/celln-pilot/tests/fixtures").join(fixture))
+                .arg("-o")
+                .arg(work.join(name))
+                .status()?
+                .success(),
+            "fixture build failed"
+        );
+    }
+    std::fs::copy(work.join("uppercase"), work.join("unselected"))?;
+    let mut mk = Command::new(root.join("scripts/mktoolfs.sh"));
+    mk.arg(work.join("toolfs.img")).arg("32");
+    for name in [
+        "harness",
+        "pilot-fetch",
+        "uppercase",
+        "length",
+        "unselected",
+    ] {
+        mk.arg(work.join(name));
+    }
+    ensure!(mk.status()?.success(), "filesystem build failed");
+    let payload = std::fs::read(work.join("toolfs.img"))?;
+    let mut members = BTreeMap::new();
+    for name in ["harness", "pilot-fetch", "uppercase", "length"] {
+        members.insert(
+            format!("/{name}"),
+            Member {
+                hash: Hash::of(&std::fs::read(work.join(name))?).0,
+                dependencies: BTreeSet::new(),
+            },
+        );
+    }
+    members.get_mut("/harness").unwrap().dependencies = ["/pilot-fetch", "/uppercase", "/length"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+    let signed = Closure {
+        api_version: "celln.dev/closure-v1".into(),
+        toolfs: Hash::of(&payload).0,
+        entrypoint: "/harness".into(),
+        interpreter: false,
+        members: members.clone(),
+    }
+    .sign(&[42; 32])
+    .map_err(anyhow::Error::msg)?;
+    signed
+        .verify(&BTreeSet::from([signed.publisher.clone()]))
+        .map_err(anyhow::Error::msg)?;
+    let mut manifest = Manifest::new();
+    manifest.admit(Entry {
+        alias: "/harness".into(),
+        hash: Hash(members["/harness"].hash.clone()),
+        tier: Tier::Verified,
+        interpreter: false,
+        author: Author::Host,
+        recipe: None,
+    });
+    manifest.sign_standin();
+    std::fs::write(work.join("manifest.json"), serde_json::to_vec(&manifest)?)?;
+    ensure!(
+        Command::new(root.join("scripts/mkinitramfs.sh"))
+            .current_dir(&root)
+            .arg(work.join("initramfs.cpio"))
+            .env("CELLN_MANIFEST", work.join("manifest.json"))
+            .env("CELLN_PILOT_DIR", &binaries)
+            .env("CELLN_WARM_DISPATCH", "1")
+            .env_remove("CELLN_RUN_JSON")
+            .status()?
+            .success(),
+        "initrd build failed"
+    );
+    let kernel = BootConfig::host_kernel().context("readable kernel required")?;
+    let mut template = LinuxCell::boot(
+        BootConfig::new(kernel)
+            .with_pmem(payload.len())
+            .with_initrd(work.join("initramfs.cpio")),
+    )?;
+    template.seal_tool(&Hash::of(&payload), &payload)?;
+    template.stop_when_guest_prints("CELLN:mote=parked");
+    ensure!(
+        template.run()?.end == BootEnd::Parked,
+        "warm mote did not park"
+    );
+    let mote = template.park()?;
+    drop(template);
+    let input = r#"{"type":"object","properties":{"text":{"type":"string","minLength":1,"maxLength":64}},"required":["text"],"additionalProperties":false}"#;
+    let length = r#"{"type":"object","properties":{"length":{"type":"integer","minimum":0,"maximum":64}},"required":["length"],"additionalProperties":false}"#;
+    let schema = |s: &str| json!({"bytes":s,"hash":Hash::of(s.as_bytes()).0});
+    let mut cases = Vec::new();
+    let mut model_calls = 0;
+    for (task, expected) in [
+        ("normalize then measure", "CELLN has length 5"),
+        ("undeclared", "unselected tool requested"),
+        ("invalid-arguments", "tool value type mismatch"),
+        ("bad-result", "required tool field missing"),
+        ("sleep", "tool deadline exceeded"),
+        ("flood", "child output exceeded limit"),
+    ] {
+        if real_model && task != "normalize then measure" {
+            continue;
+        }
+        let mut config = json!({"contract":"celln.json-tools/v1","task":task,"system":"Use the explicitly lent tools.","url":"https://example.invalid/chat/completions",
+        "model":"scripted-not-ai","max_turns":6,"max_calls":6,"tools":[
+            {"name":"uppercase","path":"/uppercase","hash":members["/uppercase"].hash,"description":"Uppercase text","input_schema":schema(input),"output_schema":schema(input),"input_bytes":1024,"output_bytes":256,"timeout_ms":100},
+            {"name":"length","path":"/length","hash":members["/length"].hash,"description":"Measure text length","input_schema":schema(input),"output_schema":schema(length),"input_bytes":1024,"output_bytes":256,"timeout_ms":100}
+        ]});
+        if real_model {
+            config["url"] = json!("https://api.deepseek.com/chat/completions");
+            config["model"] = json!("deepseek-chat");
+            config["task"] = json!("Call uppercase with text celln, wait for its result, then call length with the uppercase result. Wait for both tool results. Finally answer exactly: CELLN has length 5");
+        }
+        let mut cell = LinuxCell::fork_from(&mote)?;
+        if let Some(token) = &token {
+            let mut policy = warden::egress::HttpPolicy::new(vec!["api.deepseek.com".into()]);
+            policy.timeout = Duration::from_secs(45);
+            policy.max_requests = 6;
+            policy.json_posts.push(warden::egress::JsonPostGrant {
+                url: "https://api.deepseek.com/chat/completions".into(),
+                bearer_token_file: token.clone(),
+                model: "deepseek-chat".into(),
+                max_output_tokens: 512,
+                max_total_output_tokens: 3072,
+            });
+            cell.enable_http_fetch(policy);
+        }
+        cell.set_invocation(&serde_json::to_vec(&json!({"path":"/harness","alias":"/harness","root":"/tools","args":[config.to_string()],"force_agent_lane":true,
+            "expected_hash":members["/harness"].hash,"workspace_access":"none","report_output_limit":8192,"closure_members":members,"allow_fetch":real_model}))?)?;
+        cell.set_timeout(Duration::from_secs(if real_model { 180 } else { 10 }));
+        let report = cell.run()?;
+        let activity = cell.fetch_activity();
+        model_calls += activity.0;
+        drop(cell);
+        std::fs::write(
+            work.join(format!("{}.console", task.replace(' ', "-"))),
+            &report.console,
+        )?;
+        // Workload bytes are framed as numeric arrays by pilot; decode outputs
+        // before inspecting them, never accept workload text as control frames.
+        let mut output = Vec::new();
+        let mut exit = None;
+        for line in report
+            .console
+            .lines()
+            .filter_map(|l| l.strip_prefix(pilot::dispatch_report::PREFIX))
+        {
+            match serde_json::from_str::<pilot::dispatch_report::Frame>(line)? {
+                pilot::dispatch_report::Frame::Output { bytes } => output.extend(bytes),
+                pilot::dispatch_report::Frame::Exit { code } => exit = Some(code),
+                _ => {}
+            }
+        }
+        let output = String::from_utf8(output)?;
+        if real_model {
+            let events: Vec<serde_json::Value> = output
+                .lines()
+                .filter_map(|l| l.strip_prefix("CELLN_HARNESS_EVENT "))
+                .map(serde_json::from_str)
+                .collect::<std::result::Result<_, _>>()?;
+            let tools: Vec<_> = events.iter().filter(|e| e["type"] == "tool").collect();
+            ensure!(
+                tools.len() == 2
+                    && tools[0]["name"] == "uppercase"
+                    && tools[0]["result"] == json!({"text":"CELLN"})
+                    && tools[1]["name"] == "length"
+                    && tools[1]["result"] == json!({"length":5})
+                    && activity.0 >= 3
+                    && activity.1 == 0,
+                "real model did not consume both verified tool results: {output}; see {}",
+                work.display()
+            );
+        }
+        ensure!(
+            report.end == BootEnd::Shutdown && output.contains(expected),
+            "case {task} failed: {output}; see {}",
+            work.display()
+        );
+        ensure!(
+            exit == Some(if task == "normalize then measure" {
+                0
+            } else {
+                1
+            }),
+            "unexpected exit for {task}: {exit:?}"
+        );
+        cases.push(json!({"task":task,"expected":expected,"exit":exit,"elapsedMicros":report.elapsed.as_micros(),"output":output}));
+    }
+    drop(mote);
+    let evidence = json!({"status":"passed","scope":if real_model {"direct-KVM-native-JSON-adapter-real-DeepSeek-not-dispatcher"} else {"real-KVM-native-adapter-with-scripted-broker-not-AI"},"modelCalls":model_calls,"cases":cases,"closure":signed,
+        "guestBinary":Hash::of(&std::fs::read(binaries.join("celln-harness-json"))?).0});
+    std::fs::write(
+        work.join("evidence.json"),
+        serde_json::to_vec_pretty(&evidence)?,
+    )?;
+    println!(
+        "PASS: JSON Harness KVM proof (real model: {real_model}); evidence {}",
+        work.display()
+    );
+    Ok(())
+}

--- a/crates/celln-pilot/src/json_harness_proof.rs
+++ b/crates/celln-pilot/src/json_harness_proof.rs
@@ -149,6 +149,7 @@ fn main() -> Result<()> {
         ("bad-result", "required tool field missing"),
         ("sleep", "tool deadline exceeded"),
         ("flood", "child output exceeded limit"),
+        ("last-turn", "model budget leaves no tool result turn"),
     ] {
         if real_model && task != "normalize then measure" {
             continue;
@@ -158,6 +159,9 @@ fn main() -> Result<()> {
             {"name":"uppercase","path":"/uppercase","hash":members["/uppercase"].hash,"description":"Uppercase text","input_schema":schema(input),"output_schema":schema(input),"input_bytes":1024,"output_bytes":256,"timeout_ms":100},
             {"name":"length","path":"/length","hash":members["/length"].hash,"description":"Measure text length","input_schema":schema(input),"output_schema":schema(length),"input_bytes":1024,"output_bytes":256,"timeout_ms":100}
         ]});
+        if task == "last-turn" {
+            config["max_turns"] = json!(1);
+        }
         if real_model {
             config["url"] = json!("https://api.deepseek.com/chat/completions");
             config["model"] = json!("deepseek-chat");
@@ -204,6 +208,12 @@ fn main() -> Result<()> {
             }
         }
         let output = String::from_utf8(output)?;
+        if task == "last-turn" {
+            ensure!(
+                !output.contains("\"type\":\"tool\""),
+                "last-turn batch emitted a completed tool event"
+            );
+        }
         if real_model {
             let events: Vec<serde_json::Value> = output
                 .lines()

--- a/crates/celln-pilot/src/json_harness_tests.rs
+++ b/crates/celln-pilot/src/json_harness_tests.rs
@@ -1,0 +1,179 @@
+use super::*;
+use std::cell::Cell;
+
+fn schema(bytes: &str) -> Schema {
+    Schema {
+        bytes: bytes.into(),
+        hash: Hash::of(bytes.as_bytes()).0,
+    }
+}
+fn config(names: &[&str]) -> Config {
+    let object = r#"{"type":"object","properties":{"text":{"type":"string","minLength":1,"maxLength":64}},"required":["text"],"additionalProperties":false}"#;
+    Config {
+        contract: CONTRACT.into(),
+        task: "use structured text tools".into(),
+        system: "Bounded agent".into(),
+        url: "https://api.deepseek.com/chat/completions".into(),
+        model: "deepseek-chat".into(),
+        max_turns: 6,
+        max_calls: 6,
+        tools: names
+            .iter()
+            .map(|name| Tool {
+                name: (*name).into(),
+                path: format!("/{name}"),
+                hash: Hash::of(name.as_bytes()).0,
+                description: "Returns structured text".into(),
+                input_schema: schema(object),
+                output_schema: schema(object),
+                input_bytes: 1024,
+                output_bytes: 1024,
+                timeout_ms: 1000,
+            })
+            .collect(),
+    }
+}
+fn call(id: &str, name: &str, args: &str) -> Value {
+    json!({"id":id,"type":"function","function":{"name":name,"arguments":args}})
+}
+fn response(calls: Vec<Value>) -> Vec<u8> {
+    serde_json::to_vec(
+        &json!({"choices":[{"message":{"role":"assistant","content":null,"tool_calls":calls}}]}),
+    )
+    .unwrap()
+}
+fn answer() -> Vec<u8> {
+    serde_json::to_vec(&json!({"choices":[{"message":{"role":"assistant","content":"completed structured task"}}]})).unwrap()
+}
+
+#[test]
+fn structured_tools_need_not_all_be_used_and_results_return_to_model() {
+    let cfg = config(&["echo", "second", "unused"]);
+    let count = Cell::new(0);
+    let mut events = Vec::new();
+    let result = run(
+        &cfg,
+        |wire| {
+            let wire: Value = serde_json::from_slice(wire).unwrap();
+            assert_eq!(wire["body"]["tool_choice"], "auto");
+            count.set(count.get() + 1);
+            match count.get() {
+                1 => Ok(response(vec![
+                    call(
+                        "one",
+                        "echo",
+                        r#"{"text":"borrowed strings, not integers"}"#,
+                    ),
+                    call("two", "second", r#"{"text":"second"}"#),
+                ])),
+                2 => {
+                    let messages = wire["body"]["messages"].as_array().unwrap();
+                    assert_eq!(messages.iter().filter(|m| m["role"] == "tool").count(), 2);
+                    assert!(messages
+                        .iter()
+                        .any(|m| m["content"] == r#"{"text":"borrowed strings, not integers"}"#));
+                    Ok(answer())
+                }
+                _ => panic!("unexpected broker call"),
+            }
+        },
+        |_, input| Ok(input.to_vec()),
+        |e| events.push(e),
+    )
+    .unwrap();
+    assert_eq!(result, "completed structured task");
+    assert_eq!(events.iter().filter(|e| e["type"] == "tool").count(), 2);
+}
+
+#[test]
+fn empty_selection_has_no_tools_and_can_complete_without_calls() {
+    let cfg = config(&[]);
+    run(
+        &cfg,
+        |wire| {
+            let wire: Value = serde_json::from_slice(wire).unwrap();
+            assert!(wire["body"].get("tools").is_none());
+            Ok(answer())
+        },
+        |_, _| panic!("no borrowed authority"),
+        |_| {},
+    )
+    .unwrap();
+}
+
+#[test]
+fn invalid_batches_never_execute_even_the_first_valid_member() {
+    for bad in [
+        call("two", "unselected", r#"{"text":"x"}"#),
+        call("one", "echo", r#"{"text":"x"}"#),
+        call("two", "echo", r#"{"text":"x","text":"duplicate"}"#),
+        call("two", "echo", r#"{"text":42}"#),
+        call("two", "echo", r#"{"text":"x","extra":true}"#),
+    ] {
+        let cfg = config(&["echo"]);
+        let bytes = response(vec![call("one", "echo", r#"{"text":"valid"}"#), bad]);
+        assert!(run(
+            &cfg,
+            |_| Ok(bytes.clone()),
+            |_, _| panic!("invalid batch executed"),
+            |_| {}
+        )
+        .is_err());
+    }
+}
+
+#[test]
+fn schema_identity_and_output_validation_are_authoritative() {
+    let mut cfg = config(&["echo"]);
+    cfg.tools[0].input_schema.bytes.push(' ');
+    assert!(run(
+        &cfg,
+        |_| panic!("invalid schema reached broker"),
+        |_, _| panic!(),
+        |_| {}
+    )
+    .is_err());
+    let cfg = config(&["echo"]);
+    let calls = Cell::new(0);
+    assert!(run(
+        &cfg,
+        |_| {
+            calls.set(calls.get() + 1);
+            Ok(response(vec![call("one", "echo", r#"{"text":"x"}"#)]))
+        },
+        |_, _| Ok(br#"{"unexpected":true}"#.to_vec()),
+        |_| {}
+    )
+    .is_err());
+    assert_eq!(
+        calls.get(),
+        1,
+        "invalid output must not feed another model call"
+    );
+}
+
+#[test]
+fn budgets_and_repeated_call_ids_stop_the_loop() {
+    let mut cfg = config(&["echo"]);
+    cfg.max_calls = 0;
+    assert!(run(
+        &cfg,
+        |_| Ok(response(vec![call("one", "echo", r#"{"text":"x"}"#)])),
+        |_, _| panic!(),
+        |_| {}
+    )
+    .is_err());
+    cfg.max_calls = 6;
+    let executes = Cell::new(0);
+    assert!(run(
+        &cfg,
+        |_| Ok(response(vec![call("repeated", "echo", r#"{"text":"x"}"#)])),
+        |_, input| {
+            executes.set(executes.get() + 1);
+            Ok(input.to_vec())
+        },
+        |_| {}
+    )
+    .is_err());
+    assert_eq!(executes.get(), 1);
+}

--- a/crates/celln-pilot/src/json_harness_tests.rs
+++ b/crates/celln-pilot/src/json_harness_tests.rs
@@ -177,3 +177,24 @@ fn budgets_and_repeated_call_ids_stop_the_loop() {
     .is_err());
     assert_eq!(executes.get(), 1);
 }
+
+#[test]
+fn final_model_turn_cannot_start_side_effects_without_a_result_turn() {
+    let mut cfg = config(&["echo"]);
+    cfg.max_turns = 1;
+    let executes = Cell::new(0);
+    let error = run(
+        &cfg,
+        |_| Ok(response(vec![call("one", "echo", r#"{"text":"x"}"#)])),
+        |_, input| {
+            executes.set(executes.get() + 1);
+            Ok(input.to_vec())
+        },
+        |_| {},
+    )
+    .unwrap_err();
+    assert_eq!(executes.get(), 0, "no turn remains to consume tool results");
+    assert!(error.to_string().contains("result turn"));
+    // The same last-turn budget must still permit a tool-free final answer.
+    assert!(run(&cfg, |_| Ok(answer()), |_, _| panic!(), |_| {}).is_ok());
+}

--- a/crates/celln-pilot/src/lib.rs
+++ b/crates/celln-pilot/src/lib.rs
@@ -14,6 +14,9 @@ use serde::Serialize;
 
 pub mod closure_check;
 pub mod dispatch_report;
+#[cfg(target_os = "linux")]
+pub mod harness_io;
+pub mod json_harness;
 
 /// The result of asking pilot to run something.
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/celln-pilot/tests/fixtures/json_broker.rs
+++ b/crates/celln-pilot/tests/fixtures/json_broker.rs
@@ -1,0 +1,18 @@
+//! Scripted protocol fixture. This is NOT an LLM/provider/AI proof.
+use std::io::Read;
+fn main() {
+    let mut input=String::new();
+    std::io::stdin().take(8193).read_to_string(&mut input).unwrap();
+    assert!(input.len()<=8192);
+    let (name,args)=if input.contains("undeclared") { ("unselected",r#"{\"text\":\"celln\"}"#) }
+        else if input.contains("invalid-arguments") { ("uppercase",r#"{\"text\":7}"#) }
+        else if input.contains("bad-result") { ("uppercase",r#"{\"text\":\"bad-result\"}"#) }
+        else if input.contains("sleep") { ("uppercase",r#"{\"text\":\"sleep\"}"#) }
+        else if input.contains("flood") { ("uppercase",r#"{\"text\":\"flood\"}"#) }
+        else { match input.matches("\"role\":\"tool\"").count() {
+            0 => ("uppercase",r#"{\"text\":\"celln\"}"#),
+            1 => ("length",r#"{\"text\":\"CELLN\"}"#),
+            _ => { println!(r#"{{"choices":[{{"message":{{"role":"assistant","content":"CELLN has length 5"}}}}]}}"#); return; }
+        }};
+    println!(r#"{{"choices":[{{"message":{{"role":"assistant","content":null,"tool_calls":[{{"id":"call-{name}","type":"function","function":{{"name":"{name}","arguments":"{args}"}}}}]}}}}]}}"#);
+}

--- a/crates/celln-pilot/tests/fixtures/json_tool.rs
+++ b/crates/celln-pilot/tests/fixtures/json_tool.rs
@@ -1,0 +1,16 @@
+//! Public static test tool; deliberately tiny fixture grammar, not the Harness parser.
+use std::io::Read;
+fn main() {
+    let mut input=String::new();
+    std::io::stdin().take(1025).read_to_string(&mut input).unwrap();
+    if input.contains("sleep") { std::thread::sleep(std::time::Duration::from_secs(5)); }
+    if input.contains("flood") { print!("{}", "x".repeat(1024)); return; }
+    if input.contains("bad-result") { print!("{{\"wrong\":true}}"); return; }
+    let input: String = input.chars().filter(|c| !c.is_ascii_whitespace()).collect();
+    let text=input.strip_prefix("{\"text\":\"").and_then(|s|s.strip_suffix("\"}")).expect("fixture text input");
+    assert!(text.bytes().all(|c|c.is_ascii_alphabetic() || c==b'-'));
+    #[cfg(uppercase_tool)]
+    print!("{{\"text\":\"{}\"}}",text.to_ascii_uppercase());
+    #[cfg(not(uppercase_tool))]
+    print!("{{\"length\":{}}}",text.len());
+}

--- a/docs/JSON_TOOL_HARNESS.md
+++ b/docs/JSON_TOOL_HARNESS.md
@@ -1,0 +1,112 @@
+# Native JSON-tool Harness adapter
+
+`celln-harness-json` implements the separate `celln.json-tools/v1` native
+adapter contract toward [Sympozium epic #426](https://github.com/sympozium-ai/sympozium/issues/426).
+Its agent loop runs inside a sealed cell and uses explicitly lent executables
+with immutable, bounded input/result schemas. It is no longer restricted to
+two integer-string functions or required to invoke every available tool.
+
+**Integration status:** this binary is not yet accepted by the dispatcher
+Harness binding or selectable through Sympozium. The existing
+`celln.reference-functions/v1` contract and refusal guards are unchanged.
+Do not label this as arbitrary OCI/Pi/Hermes compatibility, a finished user BYO
+workflow, or conversational HarnessSession support.
+
+## Contract and authority
+
+Host configuration is one bounded JSON argument (at most 64 KiB) containing:
+
+- `contract: celln.json-tools/v1`, `task`, `system`, `url`, `model`.
+- `max_turns` (1–6), `max_calls` (0–16) and `tools` (0–16 entries).
+- Each tool has `name`, canonical absolute `path`, executable BLAKE3 `hash`,
+  `description`, `input_schema`, `output_schema`, `input_bytes`, `output_bytes`
+  and `timeout_ms`.
+- Each schema has `bytes` (the exact JSON document as a string) and its BLAKE3
+  `hash`. Both must pass `celln.tool-schema/v1`; inputs must be object schemas.
+- Input/output bounds are 1–65536 bytes; tool deadlines are 1–30000 ms. Task and
+  system text are each bounded at 2048 bytes. The actual broker envelope still
+  has an 8192-byte ceiling, including schemas and accumulated conversation.
+
+Tool invocation is **JSON stdin → JSON stdout**, with no user arguments or
+shell. This is a new adapter ABI, not a silent reinterpretation of catalogue
+`celln.argv/v1`. The catalogue/runtime schema and independently authorized host
+binding must explicitly support it before integration can be enabled.
+
+Model arguments are validated as their original bytes before parsing, so
+duplicate keys, unknown fields, wrong types and excess budgets cannot disappear
+through JSON normalization. The whole proposed tool-call batch is checked
+before the first call executes. A requested unselected tool or repeated call ID
+refuses; omission grants nothing. A final answer may use no tools. Results must
+validate against the pinned output schema before returning to the model.
+
+There are no automatic tool retries. A failed result cannot undo an already
+completed side effect; it stops further execution. Tool pipes are nonblocking
+and drained while input is written, with bounded stdout and 4 KiB stderr.
+Per-tool deadlines kill/wait for the direct child. The enclosing host cell
+watchdog/dissolution remains the final bound for descendants; this is not
+per-tool microVM isolation within a shared runtime cell.
+
+The runtime clears child environments and verifies tool hashes/unwritability.
+Those checks do not manufacture hardware guarantees: the operator must deliver
+the runtime and exact lent executable/dependency set as a signed sealed closure.
+Raw standalone execution of this binary is not Celln isolation. All model
+requests use `/pilot-fetch` and the existing host-enforced provider/model/token
+grant; credentials remain host-side. Schema bytes are data, never executable
+authority. No runtime-generated code, ambient tool discovery, workspace, remote
+MCP authority or retained conversation state is implied.
+
+## Functional proof versus AI proof
+
+Build the actual static guest binaries:
+
+```sh
+CARGO_TARGET_DIR=target/validation cargo build --release \
+  --target x86_64-unknown-linux-musl -p celln-pilot \
+  --bin celln-pilot --bin pilot-fetch --bin celln-harness-json
+```
+
+The default proof uses a clearly labelled **scripted broker**, zero model calls:
+
+```sh
+CELLN_PILOT_DIR="$PWD/target/validation/x86_64-unknown-linux-musl/release" \
+CARGO_TARGET_DIR=target/validation cargo run -p celln-pilot --features kvm \
+  --bin celln-json-harness-proof
+```
+
+Six real warm-forked KVM cases exercise the compiled adapter: text uppercase
+then length, undeclared tool, invalid arguments, invalid output, child deadline
+and output overflow. Fixture tools deliberately use a tiny text grammar; the
+adapter itself uses the bounded JSON/schema parser. The signed filesystem also
+contains an unselected binary excluded from the lent closure; runtime selection
+refusal is tested here, not a new claim of a guest attempted-exec attack.
+
+An explicitly billable mode substitutes the real broker and host credential:
+
+```sh
+CELLN_MODEL_TOKEN_FILE=/absolute/private/host-token \
+CELLN_PILOT_DIR="$PWD/target/validation/x86_64-unknown-linux-musl/release" \
+CARGO_TARGET_DIR=target/validation cargo run -p celln-pilot --features kvm \
+  --bin celln-json-harness-proof -- --real-model
+```
+
+On 2026-09-07 this passed with real DeepSeek: three broker requests, two
+separately hashed tools, structured results `{"text":"CELLN"}` and
+`{"length":5}`, then answer `CELLN has length 5`. The temporary host credential
+copy was removed. This is **direct KVM**, not yet controller/router/catalogue
+dispatch. No cluster deployment was changed. Evidence records distinguish real
+and scripted modes and bind the guest binary and signed closure identities.
+
+Committed records: [scripted six-case KVM suite](evidence/json-harness-scripted-2026-09-07.json)
+and [real DeepSeek JSON-tool task](evidence/json-harness-deepseek-2026-09-07.json).
+Both used the same runtime binary. Full `make ci` passed on this implementation;
+the original reference Harness and dispatcher contracts remain unchanged.
+
+## Remaining integration gates
+
+Version the host grant/request and catalogue invocation ABI; bind the approved
+runtime plus tool/schema/policy identities through the authority resolver;
+verify and compose their exact closure; distribute and prewarm in the serving
+process; expose runtime/tool selections and refusals in Sympozium. Re-run real
+model and adversarial tests through that deployed path. External conversational
+state, general lifecycle mediation, live withdrawal and full release gates remain
+open. Neither these tests nor this binary mark the epic complete.

--- a/docs/JSON_TOOL_HARNESS.md
+++ b/docs/JSON_TOOL_HARNESS.md
@@ -38,6 +38,10 @@ through JSON normalization. The whole proposed tool-call batch is checked
 before the first call executes. A requested unselected tool or repeated call ID
 refuses; omission grants nothing. A final answer may use no tools. Results must
 validate against the pinned output schema before returning to the model.
+Tool-call batches on the last permitted model turn refuse before execution:
+there must be a remaining model turn to consume the results. A tool-free final
+answer on the last turn is allowed. This does not promise that a later provider
+request succeeds or that it has enough remaining host-granted allowance.
 
 There are no automatic tool retries. A failed result cannot undo an already
 completed side effect; it stops further execution. Tool pipes are nonblocking
@@ -73,9 +77,12 @@ CARGO_TARGET_DIR=target/validation cargo run -p celln-pilot --features kvm \
   --bin celln-json-harness-proof
 ```
 
-Six real warm-forked KVM cases exercise the compiled adapter: text uppercase
+Seven real warm-forked KVM cases exercise the compiled adapter: text uppercase
 then length, undeclared tool, invalid arguments, invalid output, child deadline
-and output overflow. Fixture tools deliberately use a tiny text grammar; the
+and output overflow, plus final-turn tool-batch refusal. The latter checks the
+compiled refusal path and absence of completed-tool events; the portable test
+directly proves the executor callback was never invoked. Fixture tools
+deliberately use a tiny text grammar; the
 adapter itself uses the bounded JSON/schema parser. The signed filesystem also
 contains an unselected binary excluded from the lent closure; runtime selection
 refusal is tested here, not a new claim of a guest attempted-exec attack.
@@ -100,6 +107,11 @@ Committed records: [scripted six-case KVM suite](evidence/json-harness-scripted-
 and [real DeepSeek JSON-tool task](evidence/json-harness-deepseek-2026-09-07.json).
 Both used the same runtime binary. Full `make ci` passed on this implementation;
 the original reference Harness and dispatcher contracts remain unchanged.
+
+PR review then reproduced and fixed final-turn side effects before exhaustion.
+The [reviewed seven-case scripted KVM record](evidence/json-harness-reviewed-scripted-2026-09-07.json)
+binds the revised binary, with full `make ci` passing again. It does not relabel
+the earlier real-model run as a measurement of this later binary.
 
 ## Remaining integration gates
 

--- a/docs/evidence/json-harness-deepseek-2026-09-07.json
+++ b/docs/evidence/json-harness-deepseek-2026-09-07.json
@@ -1,0 +1,53 @@
+{
+  "cases": [
+    {
+      "elapsedMicros": 3272852,
+      "exit": 0,
+      "expected": "CELLN has length 5",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"deepseek-chat\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"arguments\":{\"text\":\"celln\"},\"hash\":\"blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c\",\"id\":\"call_00_sIzJGjihwuTZeGOKYogr8961\",\"inputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"name\":\"uppercase\",\"outputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"result\":{\"text\":\"CELLN\"},\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"model\":\"deepseek-chat\",\"turn\":1,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"arguments\":{\"text\":\"CELLN\"},\"hash\":\"blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245\",\"id\":\"call_00_4G4pnUvbmR8ls7js0N6a0308\",\"inputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"name\":\"length\",\"outputSchema\":\"blake3:334d8ed405e3789cc513dc297a2137ee175e9f2b91743deb1e73e15517cf72d5\",\"result\":{\"length\":5},\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"model\":\"deepseek-chat\",\"turn\":2,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"answer\":\"CELLN has length 5\",\"calls\":2,\"type\":\"completed\"}\n",
+      "task": "normalize then measure"
+    }
+  ],
+  "closure": {
+    "closure": {
+      "apiVersion": "celln.dev/closure-v1",
+      "entrypoint": "/harness",
+      "interpreter": false,
+      "members": {
+        "/harness": {
+          "dependencies": [
+            "/length",
+            "/pilot-fetch",
+            "/uppercase"
+          ],
+          "hash": "blake3:7aaa9b62e104763d5659ff1642fed0121d95b0fc9194e0946ae3ebd6ed22a375"
+        },
+        "/length": {
+          "dependencies": [],
+          "hash": "blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245"
+        },
+        "/pilot-fetch": {
+          "dependencies": [],
+          "hash": "blake3:9afcf605962e29d25fd95fcd3d3a719210f644cd1ee0893ff3d5578eeb86888e"
+        },
+        "/uppercase": {
+          "dependencies": [],
+          "hash": "blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c"
+        }
+      },
+      "toolfs": "blake3:d9006c508a0c87c23bcc02b404bcb2d380580a6d0661dc63ba8813228c26a503"
+    },
+    "publisher": "197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61",
+    "signature": "5cde9631f84c780e47ae21b62fb2e00286ac6e34850fdd6d42adc13624e8d046e49ce656152922151a61055923ef6ac801f2b4f5cefd422b8e80995308d19a0d"
+  },
+  "guestBinary": "blake3:7aaa9b62e104763d5659ff1642fed0121d95b0fc9194e0946ae3ebd6ed22a375",
+  "modelCalls": 3,
+  "scope": "direct-KVM-native-JSON-adapter-real-DeepSeek-not-dispatcher",
+  "status": "passed",
+  "provenance": {
+    "baseRevision": "ef358f6",
+    "workingTreeChanges": true,
+    "source": "new native JSON adapter and proof on feat/json-tool-harness",
+    "productionDeploymentChanged": false
+  }
+}

--- a/docs/evidence/json-harness-reviewed-scripted-2026-09-07.json
+++ b/docs/evidence/json-harness-reviewed-scripted-2026-09-07.json
@@ -1,0 +1,95 @@
+{
+  "cases": [
+    {
+      "elapsedMicros": 100619,
+      "exit": 0,
+      "expected": "CELLN has length 5",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"arguments\":{\"text\":\"celln\"},\"hash\":\"blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c\",\"id\":\"call-uppercase\",\"inputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"name\":\"uppercase\",\"outputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"result\":{\"text\":\"CELLN\"},\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":1,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"arguments\":{\"text\":\"CELLN\"},\"hash\":\"blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245\",\"id\":\"call-length\",\"inputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"name\":\"length\",\"outputSchema\":\"blake3:334d8ed405e3789cc513dc297a2137ee175e9f2b91743deb1e73e15517cf72d5\",\"result\":{\"length\":5},\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":2,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"answer\":\"CELLN has length 5\",\"calls\":2,\"type\":\"completed\"}\n",
+      "task": "normalize then measure"
+    },
+    {
+      "elapsedMicros": 60451,
+      "exit": 1,
+      "expected": "unselected tool requested",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR unselected tool requested\n",
+      "task": "undeclared"
+    },
+    {
+      "elapsedMicros": 60444,
+      "exit": 1,
+      "expected": "tool value type mismatch",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR tool value type mismatch\n",
+      "task": "invalid-arguments"
+    },
+    {
+      "elapsedMicros": 60400,
+      "exit": 1,
+      "expected": "required tool field missing",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR required tool field missing\n",
+      "task": "bad-result"
+    },
+    {
+      "elapsedMicros": 160743,
+      "exit": 1,
+      "expected": "tool deadline exceeded",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR tool deadline exceeded\n",
+      "task": "sleep"
+    },
+    {
+      "elapsedMicros": 60458,
+      "exit": 1,
+      "expected": "child output exceeded limit",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR child output exceeded limit\n",
+      "task": "flood"
+    },
+    {
+      "elapsedMicros": 60295,
+      "exit": 1,
+      "expected": "model budget leaves no tool result turn",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR model budget leaves no tool result turn\n",
+      "task": "last-turn"
+    }
+  ],
+  "closure": {
+    "closure": {
+      "apiVersion": "celln.dev/closure-v1",
+      "entrypoint": "/harness",
+      "interpreter": false,
+      "members": {
+        "/harness": {
+          "dependencies": [
+            "/length",
+            "/pilot-fetch",
+            "/uppercase"
+          ],
+          "hash": "blake3:2d433dbf14b0e58b31b3768d645d191a7e0a95d2f7851296527128642fc749a3"
+        },
+        "/length": {
+          "dependencies": [],
+          "hash": "blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245"
+        },
+        "/pilot-fetch": {
+          "dependencies": [],
+          "hash": "blake3:d6e0f9b8e8f94b1f7e595cf117a38a98ef95b65d43edb081eb53b0a6178c0b01"
+        },
+        "/uppercase": {
+          "dependencies": [],
+          "hash": "blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c"
+        }
+      },
+      "toolfs": "blake3:f0f560ab049249eebd5fb42acd18681f5241010af579ee6be5239435485e1964"
+    },
+    "publisher": "197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61",
+    "signature": "4cfc23f4a2b9034d499378b2966a9e703cbfe02b6f135a4338ce751fc77ffcaa1d46edfae65521c1b7120f8da4c782dd529c7aeed624f4f4cde36b041dac3309"
+  },
+  "guestBinary": "blake3:2d433dbf14b0e58b31b3768d645d191a7e0a95d2f7851296527128642fc749a3",
+  "modelCalls": 0,
+  "scope": "real-KVM-native-adapter-with-scripted-broker-not-AI",
+  "status": "passed",
+  "provenance": {
+    "baseRevision": "33b6f2d2a5a69a076bf26314a1259520bc58dae1",
+    "workingTreeChanges": true,
+    "source": "PR85 review: refuse final-turn tool batches before side effects",
+    "productionDeploymentChanged": false
+  }
+}

--- a/docs/evidence/json-harness-scripted-2026-09-07.json
+++ b/docs/evidence/json-harness-scripted-2026-09-07.json
@@ -1,0 +1,88 @@
+{
+  "cases": [
+    {
+      "elapsedMicros": 100582,
+      "exit": 0,
+      "expected": "CELLN has length 5",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"arguments\":{\"text\":\"celln\"},\"hash\":\"blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c\",\"id\":\"call-uppercase\",\"inputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"name\":\"uppercase\",\"outputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"result\":{\"text\":\"CELLN\"},\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":1,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"arguments\":{\"text\":\"CELLN\"},\"hash\":\"blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245\",\"id\":\"call-length\",\"inputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"name\":\"length\",\"outputSchema\":\"blake3:334d8ed405e3789cc513dc297a2137ee175e9f2b91743deb1e73e15517cf72d5\",\"result\":{\"length\":5},\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":2,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"answer\":\"CELLN has length 5\",\"calls\":2,\"type\":\"completed\"}\n",
+      "task": "normalize then measure"
+    },
+    {
+      "elapsedMicros": 60418,
+      "exit": 1,
+      "expected": "unselected tool requested",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR unselected tool requested\n",
+      "task": "undeclared"
+    },
+    {
+      "elapsedMicros": 60464,
+      "exit": 1,
+      "expected": "tool value type mismatch",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR tool value type mismatch\n",
+      "task": "invalid-arguments"
+    },
+    {
+      "elapsedMicros": 60437,
+      "exit": 1,
+      "expected": "required tool field missing",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR required tool field missing\n",
+      "task": "bad-result"
+    },
+    {
+      "elapsedMicros": 160715,
+      "exit": 1,
+      "expected": "tool deadline exceeded",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR tool deadline exceeded\n",
+      "task": "sleep"
+    },
+    {
+      "elapsedMicros": 80467,
+      "exit": 1,
+      "expected": "child output exceeded limit",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR child output exceeded limit\n",
+      "task": "flood"
+    }
+  ],
+  "closure": {
+    "closure": {
+      "apiVersion": "celln.dev/closure-v1",
+      "entrypoint": "/harness",
+      "interpreter": false,
+      "members": {
+        "/harness": {
+          "dependencies": [
+            "/length",
+            "/pilot-fetch",
+            "/uppercase"
+          ],
+          "hash": "blake3:7aaa9b62e104763d5659ff1642fed0121d95b0fc9194e0946ae3ebd6ed22a375"
+        },
+        "/length": {
+          "dependencies": [],
+          "hash": "blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245"
+        },
+        "/pilot-fetch": {
+          "dependencies": [],
+          "hash": "blake3:d6e0f9b8e8f94b1f7e595cf117a38a98ef95b65d43edb081eb53b0a6178c0b01"
+        },
+        "/uppercase": {
+          "dependencies": [],
+          "hash": "blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c"
+        }
+      },
+      "toolfs": "blake3:01dc93c4fcd06d96e122a9a3ea56abfb9f4a3ebfbc58b899e0e4df7e68ed1cab"
+    },
+    "publisher": "197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61",
+    "signature": "d6b910f83f36d2aa90faee5afe6177eb3445c0861ce19dade35e740f91c93f83dbda36eb8f1fc5454d9cfec3f030f7a5019fde1a318fb1a8e4579e7231922a03"
+  },
+  "guestBinary": "blake3:7aaa9b62e104763d5659ff1642fed0121d95b0fc9194e0946ae3ebd6ed22a375",
+  "modelCalls": 0,
+  "scope": "real-KVM-native-adapter-with-scripted-broker-not-AI",
+  "status": "passed",
+  "provenance": {
+    "baseRevision": "ef358f6",
+    "workingTreeChanges": true,
+    "source": "new native JSON adapter and proof on feat/json-tool-harness",
+    "productionDeploymentChanged": false
+  }
+}


### PR DESCRIPTION
## Outcome

Progresses sympozium-ai/sympozium#426 toward a useful Harness beyond the two-integer-function reference. Adds a separate native `celln.json-tools/v1` adapter: 0–16 explicitly lent JSON stdin/stdout tools, pinned bounded input/result schemas, persona/task, model loop, bounded calls/turns, nonblocking bounded child pipes and per-tool deadlines.

The complete proposed call batch is validated before any tool executes. Unknown selections, repeated IDs, duplicate/malformed arguments, schema mismatches, invalid results and budgets refuse. Results return to the model as tool data. No shell or ambient discovery; no requirement to invoke every lent tool.

## Evidence

- Full `make ci` passed.
- Portable protocol/schema/pipe/deadline tests passed.
- Real KVM with the compiled adapter and a **scripted broker** passed six cases: two-tool structured text task, undeclared tool, invalid arguments, invalid result, timeout and output overflow.
- **Real DeepSeek through the host broker and warm-forked KVM cell passed:** uppercase(celln) → {text:CELLN}, length(CELLN) → {length:5}, final answer `CELLN has length 5`; 3 model requests, 2 separately hashed tools with schema-bound inputs/results. Temporary authorized credential copy removed. No cluster deployment changes.
- Both proof modes use the same runtime binary. Durable, explicitly scoped evidence and reproduction commands are in `docs/JSON_TOOL_HARNESS.md` and `docs/evidence/json-harness-{scripted,deepseek}-2026-09-07.json`.

## Integration limits

This is a new ABI, not a reinterpretation of `celln.argv/v1` or `celln.reference-functions/v1`. Dispatcher and Sympozium guards remain unchanged and do not yet accept/select this adapter. Next is the versioned host grant/request and catalogue ABI/schema binding, then approved composition/distribution/prewarm and the deployed user lending journey. Conversations and full release gates remain open. No arbitrary OCI/Pi/Hermes compatibility or completed epic claim.
