### PR TITLE
feat(harness): host-authorized JSON tool dispatch and real-model proof

### DIFF
--- a/crates/celln-cli/src/capabilities.rs
+++ b/crates/celln-cli/src/capabilities.rs
@@ -24,8 +24,15 @@ impl DispatcherCapabilities {
             binary_version: env!("CARGO_PKG_VERSION").into(),
             preflight_only: true,
             node,
-            request_versions: vec!["celln.dev/v1alpha1".into(), "celln.dev/v1alpha2".into()],
-            harness_contracts: vec!["celln.reference-functions/v1".into()],
+            request_versions: vec![
+                "celln.dev/v1alpha1".into(),
+                "celln.dev/v1alpha2".into(),
+                "celln.dev/v1alpha3".into(),
+            ],
+            harness_contracts: vec![
+                "celln.reference-functions/v1".into(),
+                "celln.json-tools/v1".into(),
+            ],
             persistent_sessions: false,
             artifact_readiness: "not_checked".into(),
         }

--- a/crates/celln-cli/src/dispatch_harness.rs
+++ b/crates/celln-cli/src/dispatch_harness.rs
@@ -1,6 +1,6 @@
 //! Operator-owned grants: possessing artifact bytes is not model authority.
 use celln_manifest::Hash;
-use celln_spec::{BorrowedTool, ExecutionRequest};
+use celln_spec::{BorrowedTool, ExecutionRequest, JsonHarnessOptions};
 use serde::Deserialize;
 use std::{
     io::{Read, Write},
@@ -11,6 +11,10 @@ use std::{
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Grant {
     api_version: String,
+    #[serde(default)]
+    contract_version: Option<String>,
+    #[serde(default)]
+    json: Option<JsonHarnessOptions>,
     caller: String,
     mote: String,
     runtime: String,
@@ -27,6 +31,10 @@ pub struct Resolved {
     pub policy: warden::egress::HttpPolicy,
     pub args: Vec<String>,
 }
+
+#[cfg(test)]
+#[path = "dispatch_harness_json_tests.rs"]
+mod json_tests;
 
 pub fn resolve(
     request: &ExecutionRequest,
@@ -53,7 +61,20 @@ pub fn resolve(
         return Err("Harness grant revision mismatch".into());
     }
     let grant: Grant = serde_json::from_slice(&bytes).map_err(|_| "invalid Harness grant")?;
-    if grant.api_version != "celln.dev/harness-grant-v1"
+    let contract_authorized = match binding.contract_version.as_str() {
+        "celln.reference-functions/v1" => {
+            grant.api_version == "celln.dev/harness-grant-v1"
+                && grant.contract_version.is_none()
+                && grant.json.is_none()
+        }
+        "celln.json-tools/v1" => {
+            grant.api_version == "celln.dev/harness-grant-v2"
+                && grant.contract_version.as_deref() == Some("celln.json-tools/v1")
+                && grant.json == binding.json
+        }
+        _ => false,
+    };
+    if !contract_authorized
         || grant.caller != request.workload.caller
         || grant.mote != request.mote.as_ref().unwrap().hash
         || grant.runtime != request.tools[0].hash
@@ -100,6 +121,11 @@ pub fn resolve(
     {
         return Err("unsupported Harness closure composition".into());
     }
+    let config = if binding.contract_version == "celln.json-tools/v1" {
+        json_config(request, &grant, root)?
+    } else {
+        serde_json::json!({"task":binding.task,"url":grant.url,"model":grant.model,"tools":binding.borrowed_tools}).to_string()
+    };
     let mut policy =
         warden::egress::HttpPolicy::new(vec![origin.trim_start_matches("https://").into()]);
     policy.max_requests = grant.max_requests;
@@ -113,11 +139,61 @@ pub fn resolve(
         max_output_tokens: grant.max_output_tokens,
         max_total_output_tokens: grant.max_total_output_tokens,
     });
-    let config = serde_json::json!({"task":binding.task,"url":grant.url,"model":grant.model,"tools":binding.borrowed_tools});
     Ok(Some(Resolved {
         policy,
-        args: vec![config.to_string()],
+        args: vec![config],
     }))
+}
+
+fn json_config(request: &ExecutionRequest, grant: &Grant, root: &Path) -> Result<String, String> {
+    let binding = request.harness.as_ref().ok_or("missing Harness")?;
+    let options = binding
+        .json
+        .as_ref()
+        .ok_or("missing JSON Harness options")?;
+    if grant.max_requests < options.max_turns
+        || grant.max_total_output_tokens < (options.max_turns as u64) * 512
+    {
+        return Err("model grant cannot fund the configured JSON Harness turn ceiling".into());
+    }
+    // Public schema data may be distributed in a store. Only the independently
+    // authorized exact hashes above can select bytes from it; no host path is
+    // accepted from a request and no schema becomes executable authority.
+    let store = celln_store::Store::open(root.join("tool-schemas"))
+        .map_err(|_| "tool schema store unavailable")?;
+    let schema = |hash: &str| -> Result<serde_json::Value, String> {
+        let bytes = store
+            .get_bounded(
+                &Hash(hash.into()),
+                celln_manifest::tool_schema::MAX_SCHEMA_BYTES,
+            )
+            .map_err(|_| "tool schema unavailable or revision mismatch")?;
+        let bytes = String::from_utf8(bytes).map_err(|_| "tool schema is not UTF-8")?;
+        Ok(serde_json::json!({"hash":hash,"bytes":bytes}))
+    };
+    let mut tools = Vec::new();
+    for tool in &binding.borrowed_tools {
+        let io = tool.json_stdio.as_ref().ok_or("missing JSON tool ABI")?;
+        tools.push(serde_json::json!({
+            "name":tool.name,"path":tool.path,"hash":tool.hash,"description":tool.description,
+            "input_schema":schema(&io.input_schema)?,"output_schema":schema(&io.output_schema)?,
+            "input_bytes":io.input_bytes,"output_bytes":io.output_bytes,"timeout_ms":io.timeout_ms
+        }));
+    }
+    let config = serde_json::json!({
+        "contract":binding.contract_version,"task":binding.task,"system":options.system,
+        "url":grant.url,"model":grant.model,"max_turns":options.max_turns,
+        "max_calls":options.max_calls,"tools":tools
+    });
+    let encoded = config.to_string();
+    if encoded.len() > 65536 {
+        return Err("JSON Harness configuration exceeds delivery limit".into());
+    }
+    let typed: pilot::json_harness::Config =
+        serde_json::from_value(config).map_err(|_| "invalid JSON Harness configuration")?;
+    pilot::json_harness::validate(&typed)
+        .map_err(|e| format!("invalid JSON Harness contract: {e}"))?;
+    Ok(encoded)
 }
 
 /// Conservative durable local tombstone: restart must not recreate allowance

--- a/crates/celln-cli/src/dispatch_harness_json_tests.rs
+++ b/crates/celln-cli/src/dispatch_harness_json_tests.rs
@@ -1,0 +1,230 @@
+//! Binding tests, not a substitute for signed admission or KVM execution.
+use super::*;
+use celln_manifest::closure::{Closure, Member};
+use serde_json::{json, Value};
+use std::collections::{BTreeMap, BTreeSet};
+
+const SCHEMA: &str = r#"{"type":"object","properties":{"text":{"type":"string","minLength":0,"maxLength":64}},"required":["text"],"additionalProperties":false}"#;
+
+fn fixture(root: &Path) -> (ExecutionRequest, super::super::closure::Admitted, Value) {
+    let mut wire: Value = serde_json::from_str(include_str!(
+        "../../../examples/execution/harness-reference.json"
+    ))
+    .unwrap();
+    let schema = celln_store::Store::open(root.join("tool-schemas"))
+        .unwrap()
+        .put(SCHEMA.as_bytes())
+        .unwrap();
+    wire["apiVersion"] = json!("celln.dev/v1alpha3");
+    wire["harness"]["contractVersion"] = json!("celln.json-tools/v1");
+    wire["harness"]["json"] = json!({"system":"Approved persona","maxTurns":3,"maxCalls":2});
+    for tool in wire["harness"]["borrowedTools"].as_array_mut().unwrap() {
+        tool["jsonStdio"] = json!({"abi":"celln.json-stdio/v1","inputSchema":schema.0,
+            "outputSchema":schema.0,"inputBytes":1024,"outputBytes":1024,"timeoutMs":1000});
+    }
+    let request: ExecutionRequest = serde_json::from_value(wire).unwrap();
+    let h = request.harness.as_ref().unwrap();
+    let mut members = BTreeMap::new();
+    for tool in &h.borrowed_tools {
+        members.insert(
+            tool.path.clone(),
+            Member {
+                hash: tool.hash.clone(),
+                dependencies: BTreeSet::new(),
+            },
+        );
+    }
+    members.insert(
+        "/pilot-fetch".into(),
+        Member {
+            hash: Hash::of(b"fetch").0,
+            dependencies: BTreeSet::new(),
+        },
+    );
+    members.insert(
+        "/harness".into(),
+        Member {
+            hash: request.tools[0].hash.clone(),
+            dependencies: members.keys().cloned().collect(),
+        },
+    );
+    let signed = Closure {
+        api_version: "celln.dev/closure-v1".into(),
+        toolfs: Hash::of(b"image").0,
+        entrypoint: "/harness".into(),
+        interpreter: false,
+        members,
+    }
+    .sign(&[19; 32])
+    .unwrap();
+    let admitted = super::super::closure::Admitted {
+        provenance: super::super::closure::Provenance {
+            hash: request.tools[0].closure.as_ref().unwrap().hash.clone(),
+            publisher: signed.publisher.clone(),
+            toolfs: signed.closure.toolfs.clone(),
+            members: signed.closure.members.clone(),
+        },
+        signed,
+    };
+    let grant = json!({"apiVersion":"celln.dev/harness-grant-v2","contractVersion":h.contract_version,
+        "json":h.json,"caller":request.workload.caller,"mote":request.mote.as_ref().unwrap().hash,
+        "runtime":request.tools[0].hash,"closure":admitted.provenance.hash,"borrowedTools":h.borrowed_tools,
+        "url":"https://api.deepseek.com/chat/completions","model":h.model,"credentialFile":"/not-read-or-delivered",
+        "maxRequests":3,"maxOutputTokens":512,"maxTotalOutputTokens":1536});
+    (request, admitted, grant)
+}
+
+fn install(root: &Path, request: &mut ExecutionRequest, grant: &Value) -> PathBuf {
+    let bytes = serde_json::to_vec(grant).unwrap();
+    let hash = Hash::of(&bytes);
+    request.harness.as_mut().unwrap().model_grant.hash = hash.0.clone();
+    let dir = root.join("trusted-harness");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{}.json", hash.0.trim_start_matches("blake3:")));
+    std::fs::write(&path, bytes).unwrap();
+    path
+}
+
+#[test]
+fn json_resolution_pins_schema_bytes_and_never_delivers_host_credentials() {
+    let root = tempfile::tempdir().unwrap();
+    let (mut request, admitted, grant) = fixture(root.path());
+    assert!(request.problems().is_empty());
+    assert!(resolve(&request, Some(&admitted), root.path()).is_err());
+    let path = install(root.path(), &mut request, &grant);
+    let resolved = resolve(&request, Some(&admitted), root.path())
+        .unwrap()
+        .unwrap();
+    let config: Value = serde_json::from_str(&resolved.args[0]).unwrap();
+    assert_eq!(config["contract"], "celln.json-tools/v1");
+    assert_eq!(config["tools"][0]["input_schema"]["bytes"], SCHEMA);
+    assert_eq!(config["max_turns"], 3);
+    assert_eq!(resolved.policy.max_requests, 3);
+    assert!(!resolved.args[0].contains("not-read-or-delivered"));
+    for pointer in [
+        "/harness/json/system",
+        "/harness/json/maxCalls",
+        "/harness/borrowedTools/0/jsonStdio/inputSchema",
+        "/harness/borrowedTools/0/jsonStdio/outputBytes",
+        "/harness/borrowedTools/0/jsonStdio/timeoutMs",
+        "/workload/caller",
+    ] {
+        let mut changed = serde_json::to_value(&request).unwrap();
+        let slot = changed.pointer_mut(pointer).unwrap();
+        *slot = if slot.is_number() {
+            json!(1)
+        } else if pointer.ends_with("Schema") {
+            json!(Hash::of(b"other").0)
+        } else {
+            json!("other")
+        };
+        let bad: ExecutionRequest = serde_json::from_value(changed).unwrap();
+        assert!(
+            bad.problems().is_empty(),
+            "must test host grant mismatch, not only syntax: {pointer}"
+        );
+        assert!(
+            resolve(&bad, Some(&admitted), root.path()).is_err(),
+            "{pointer}"
+        );
+    }
+    std::fs::remove_file(path).unwrap();
+    assert!(resolve(&request, Some(&admitted), root.path()).is_err());
+}
+
+#[test]
+fn legacy_grants_budget_shortfalls_and_wrong_contracts_cannot_authorize_json() {
+    let root = tempfile::tempdir().unwrap();
+    let (request, admitted, grant) = fixture(root.path());
+    for (field, replacement) in [
+        ("apiVersion", json!("celln.dev/harness-grant-v1")),
+        ("contractVersion", json!("celln.reference-functions/v1")),
+        ("json", Value::Null),
+        ("maxRequests", json!(2)),
+        ("maxTotalOutputTokens", json!(1024)),
+    ] {
+        let mut grant = grant.clone();
+        grant[field] = replacement;
+        let mut request = request.clone();
+        install(root.path(), &mut request, &grant);
+        assert!(
+            resolve(&request, Some(&admitted), root.path()).is_err(),
+            "{field}"
+        );
+    }
+}
+
+#[test]
+fn stored_schema_must_be_present_bounded_valid_and_exact() {
+    let root = tempfile::tempdir().unwrap();
+    let (mut request, admitted, mut grant) = fixture(root.path());
+    let store = celln_store::Store::open(root.path().join("tool-schemas")).unwrap();
+    for bytes in [
+        b"not a schema".to_vec(),
+        br#"{"type":"string"}"#.to_vec(),
+        vec![b' '; celln_manifest::tool_schema::MAX_SCHEMA_BYTES + 1],
+    ] {
+        let hash = store.put(&bytes).unwrap();
+        request.harness.as_mut().unwrap().borrowed_tools[0]
+            .json_stdio
+            .as_mut()
+            .unwrap()
+            .input_schema = hash.0;
+        grant["borrowedTools"] =
+            serde_json::to_value(&request.harness.as_ref().unwrap().borrowed_tools).unwrap();
+        install(root.path(), &mut request, &grant);
+        assert!(resolve(&request, Some(&admitted), root.path()).is_err());
+    }
+    let hash = Hash::of(SCHEMA.as_bytes());
+    request.harness.as_mut().unwrap().borrowed_tools[0]
+        .json_stdio
+        .as_mut()
+        .unwrap()
+        .input_schema = hash.0.clone();
+    grant["borrowedTools"] =
+        serde_json::to_value(&request.harness.as_ref().unwrap().borrowed_tools).unwrap();
+    install(root.path(), &mut request, &grant);
+    let hex = hash.0.trim_start_matches("blake3:");
+    let path = root
+        .path()
+        .join("tool-schemas/objects")
+        .join(&hex[..2])
+        .join(hex);
+    std::fs::write(&path, b"tampered").unwrap();
+    assert!(resolve(&request, Some(&admitted), root.path()).is_err());
+    std::fs::remove_file(path).unwrap();
+    assert!(resolve(&request, Some(&admitted), root.path()).is_err());
+}
+
+#[test]
+fn empty_selection_requires_an_exact_runtime_and_broker_only_closure() {
+    let root = tempfile::tempdir().unwrap();
+    let (mut request, mut admitted, mut grant) = fixture(root.path());
+    request.harness.as_mut().unwrap().borrowed_tools.clear();
+    grant["borrowedTools"] = json!([]);
+    install(root.path(), &mut request, &grant);
+    assert!(request.problems().is_empty());
+    assert!(
+        resolve(&request, Some(&admitted), root.path()).is_err(),
+        "unselected members must not leak into the closure"
+    );
+    admitted
+        .signed
+        .closure
+        .members
+        .retain(|path, _| path == "/harness" || path == "/pilot-fetch");
+    admitted
+        .signed
+        .closure
+        .members
+        .get_mut("/harness")
+        .unwrap()
+        .dependencies = BTreeSet::from(["/pilot-fetch".into()]);
+    let resolved = resolve(&request, Some(&admitted), root.path())
+        .unwrap()
+        .unwrap();
+    let config: Value = serde_json::from_str(&resolved.args[0]).unwrap();
+    assert_eq!(config["tools"], json!([]));
+    admitted.signed.closure.interpreter = true;
+    assert!(resolve(&request, Some(&admitted), root.path()).is_err());
+}

--- a/crates/celln-cli/src/dispatch_harness_tests.rs
+++ b/crates/celln-cli/src/dispatch_harness_tests.rs
@@ -80,6 +80,16 @@ fn controller_hook(
 #[test]
 #[ignore = "billable: requires CELLN_HARNESS_PACKAGE, CELLN_MODEL_TOKEN_FILE and real KVM"]
 fn harness_model_over_authenticated_dispatch() {
+    model_over_authenticated_dispatch(false);
+}
+
+#[test]
+#[ignore = "billable: requires JSON CELLN_HARNESS_PACKAGE, CELLN_MODEL_TOKEN_FILE and real KVM"]
+fn json_harness_model_over_authenticated_dispatch() {
+    model_over_authenticated_dispatch(true);
+}
+
+fn model_over_authenticated_dispatch(json_adapter: bool) {
     let _lock = crate::dispatch::warm::PROOF_LOCK.lock().unwrap();
     let package = PathBuf::from(
         std::env::var_os("CELLN_HARNESS_PACKAGE")
@@ -96,6 +106,10 @@ fn harness_model_over_authenticated_dispatch() {
     let root = work.path();
     let namespace = format!("celln-harness-proof-{}", std::process::id());
     let hook = std::env::var_os("CELLN_HARNESS_CONTROLLER_HOOK");
+    assert!(
+        !json_adapter || hook.is_none(),
+        "JSON Sympozium controller contract is not implemented yet"
+    );
     let caller = if hook.is_some() {
         format!("sympozium:{namespace}/harness-proof")
     } else {
@@ -127,11 +141,32 @@ fn harness_model_over_authenticated_dispatch() {
         json!({"apiVersion":"celln.dev/v1alpha1","bundles":[mote.0]}).to_string(),
     )
     .unwrap();
-    let borrowed = json!([
-        {"name":"add","path":"/add","hash":signed.closure.members["/add"].hash,"description":"Add two integer strings."},
-        {"name":"multiply","path":"/multiply","hash":signed.closure.members["/multiply"].hash,"description":"Multiply two integer strings."}
-    ]);
-    let grant = serde_json::to_vec(&json!({"apiVersion":"celln.dev/harness-grant-v1","caller":caller,"mote":mote.0,"runtime":runtime.0,"closure":closure.0,"borrowedTools":borrowed,"url":"https://api.deepseek.com/chat/completions","model":"deepseek-chat","credentialFile":token,"maxRequests":3,"maxOutputTokens":512,"maxTotalOutputTokens":1536})).unwrap();
+    let borrowed = if json_adapter {
+        let store = Store::open(root.join("tool-schemas")).unwrap();
+        let input = store.put(br#"{"type":"object","properties":{"text":{"type":"string","minLength":1,"maxLength":64}},"required":["text"],"additionalProperties":false}"#).unwrap();
+        let length = store.put(br#"{"type":"object","properties":{"length":{"type":"integer","minimum":0,"maximum":64}},"required":["length"],"additionalProperties":false}"#).unwrap();
+        let io = |output: &str| {
+            json!({"abi":"celln.json-stdio/v1","inputSchema":input.0,"outputSchema":output,
+            "inputBytes":1024,"outputBytes":1024,"timeoutMs":1000})
+        };
+        json!([
+            {"name":"uppercase","path":"/uppercase","hash":signed.closure.members["/uppercase"].hash,"description":"Uppercase text","jsonStdio":io(&input.0)},
+            {"name":"length","path":"/length","hash":signed.closure.members["/length"].hash,"description":"Measure text length","jsonStdio":io(&length.0)}
+        ])
+    } else {
+        json!([
+            {"name":"add","path":"/add","hash":signed.closure.members["/add"].hash,"description":"Add two integer strings."},
+            {"name":"multiply","path":"/multiply","hash":signed.closure.members["/multiply"].hash,"description":"Multiply two integer strings."}
+        ])
+    };
+    let options = json!({"system":"Use the explicitly lent tools.","maxTurns":3,"maxCalls":2});
+    let mut grant = json!({"apiVersion":"celln.dev/harness-grant-v1","caller":caller,"mote":mote.0,"runtime":runtime.0,"closure":closure.0,"borrowedTools":borrowed,"url":"https://api.deepseek.com/chat/completions","model":"deepseek-chat","credentialFile":token,"maxRequests":3,"maxOutputTokens":512,"maxTotalOutputTokens":1536});
+    if json_adapter {
+        grant["apiVersion"] = json!("celln.dev/harness-grant-v2");
+        grant["contractVersion"] = json!("celln.json-tools/v1");
+        grant["json"] = options.clone();
+    }
+    let grant = serde_json::to_vec(&grant).unwrap();
     let grant_hash = Hash::of(&grant);
     let grant_dir = root.join("trusted-harness");
     std::fs::create_dir(&grant_dir).unwrap();
@@ -141,6 +176,14 @@ fn harness_model_over_authenticated_dispatch() {
     ));
     std::fs::write(&grant_file, &grant).unwrap();
     let request: ExecutionRequest = serde_json::from_value(json!({"apiVersion":"celln.dev/v1alpha2","id":"harness-dispatch-proof","workload":{"id":"test-run","caller":caller},"mote":{"hash":mote.0},"tools":[{"alias":"/harness","hash":runtime.0,"closure":{"hash":closure.0}}],"invocation":{"alias":"/harness"},"harness":{"model":"deepseek-chat","contractVersion":"celln.reference-functions/v1","modelGrant":{"hash":grant_hash.0},"task":"Use add with args [\"37\",\"5\"], wait for its result, then multiply that result by \"2\". Reply with exactly the final integer.","borrowedTools":borrowed},"capabilities":{"workspace":"none","egress":["https://api.deepseek.com"],"timeoutMs":180000,"memoryBytes":268435456,"outputBytes":65536},"execution":{"lane":"agent","requireHardwareIsolation":true}})).unwrap();
+    let mut request = request;
+    if json_adapter {
+        request.api_version = "celln.dev/v1alpha3".into();
+        let binding = request.harness.as_mut().unwrap();
+        binding.contract_version = "celln.json-tools/v1".into();
+        binding.json = Some(serde_json::from_value(options).unwrap());
+        binding.task = "Call uppercase with text celln, wait for its result, then call length with the uppercase result. Wait for both tool results. Finally answer exactly: CELLN has length 5".into();
+    }
     assert!(request.problems().is_empty(), "{:?}", request.problems());
     let state = State {
         token_file: PathBuf::new(),
@@ -193,7 +236,7 @@ fn harness_model_over_authenticated_dispatch() {
         thread::sleep(Duration::from_millis(200));
     };
     assert_eq!(terminal["phase"], "Succeeded", "{terminal}");
-    assert_eq!(terminal["receipt"]["apiVersion"], "celln.dev/v1alpha2");
+    assert_eq!(terminal["receipt"]["apiVersion"], request.api_version);
     let events: Vec<Value> = terminal["output"]
         .as_str()
         .unwrap()
@@ -203,12 +246,39 @@ fn harness_model_over_authenticated_dispatch() {
         .collect();
     let calls: Vec<_> = events.iter().filter(|e| e["type"] == "tool").collect();
     assert_eq!(calls.len(), 2);
-    assert_eq!(calls[0]["result"], "42\n");
-    assert_eq!(calls[1]["args"], json!(["42", "2"]));
-    assert_eq!(calls[1]["result"], "84\n");
+    if json_adapter {
+        assert_eq!(calls[0]["name"], "uppercase");
+        assert_eq!(calls[0]["result"], json!({"text":"CELLN"}));
+        assert_eq!(calls[1]["name"], "length");
+        assert_eq!(calls[1]["arguments"], json!({"text":"CELLN"}));
+        assert_eq!(calls[1]["result"], json!({"length":5}));
+        for (call, tool) in calls
+            .iter()
+            .zip(&request.harness.as_ref().unwrap().borrowed_tools)
+        {
+            assert_eq!(call["hash"], tool.hash);
+            assert_eq!(
+                call["inputSchema"],
+                tool.json_stdio.as_ref().unwrap().input_schema
+            );
+            assert_eq!(
+                call["outputSchema"],
+                tool.json_stdio.as_ref().unwrap().output_schema
+            );
+        }
+    } else {
+        assert_eq!(calls[0]["result"], "42\n");
+        assert_eq!(calls[1]["args"], json!(["42", "2"]));
+        assert_eq!(calls[1]["result"], "84\n");
+    }
+    let expected_answer = if json_adapter {
+        "CELLN has length 5"
+    } else {
+        "84"
+    };
     assert!(events
         .iter()
-        .any(|e| e["type"] == "completed" && e["answer"] == "84"));
+        .any(|e| e["type"] == "completed" && e["answer"] == expected_answer));
     let (_, audit) = http(
         &state,
         "GET",

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -1291,7 +1291,18 @@ mod tests {
         assert!(report.compatible());
         assert!(!report.node.eligible()); // Configured stores are absent.
         assert!(!report.persistent_sessions);
-        assert_eq!(report.harness_contracts, ["celln.reference-functions/v1"]);
+        assert_eq!(
+            report.harness_contracts,
+            ["celln.reference-functions/v1", "celln.json-tools/v1"]
+        );
+        assert_eq!(
+            report.request_versions,
+            [
+                "celln.dev/v1alpha1",
+                "celln.dev/v1alpha2",
+                "celln.dev/v1alpha3"
+            ]
+        );
         assert_eq!(report.artifact_readiness, "not_checked");
         assert!(state.executions.lock().unwrap().is_empty());
         assert!(!work.path().join("execution-journal").exists());

--- a/crates/celln-pilot/src/json_harness.rs
+++ b/crates/celln-pilot/src/json_harness.rs
@@ -13,7 +13,8 @@ pub const CONTRACT: &str = "celln.json-tools/v1";
 mod tests;
 
 pub fn validate(config: &Config) -> Result<()> {
-    compile(config).map(|_| ())
+    let tools = compile(config)?;
+    model_request(config, &tools, &initial_messages(config)).map(|_| ())
 }
 
 #[derive(Deserialize)]
@@ -104,27 +105,11 @@ pub fn run(
     mut event: impl FnMut(Value),
 ) -> Result<String> {
     let tools = compile(config)?;
-    let mut messages = Vec::new();
-    if !config.system.is_empty() {
-        messages.push(json!({"role":"system","content":config.system}));
-    }
-    messages.push(json!({"role":"user","content":config.task}));
+    let mut messages = initial_messages(config);
     let mut ids = BTreeSet::new();
     let mut calls = 0usize;
     for turn in 0..config.max_turns {
-        let mut body =
-            json!({"model":config.model,"stream":false,"max_tokens":512,"messages":messages});
-        if !tools.is_empty() {
-            body["tools"] = json!(tools.iter().map(|t| &t.definition).collect::<Vec<_>>());
-            body["tool_choice"] = json!("auto");
-        }
-        let wire = serde_json::to_vec(
-            &json!({"apiVersion":"celln.fetch/v1","method":"POST","url":config.url,"body":body}),
-        )?;
-        ensure!(
-            wire.len() <= 8192,
-            "conversation/schema envelope exceeds broker byte limit"
-        );
+        let wire = model_request(config, &tools, &messages)?;
         let response = broker(&wire)?;
         ensure!(response.len() <= 1_048_576, "model response exceeds limit");
         let response: Value = serde_json::from_slice(&response)?;
@@ -214,4 +199,34 @@ pub fn run(
         }
     }
     bail!("model turn budget exhausted")
+}
+
+fn initial_messages(config: &Config) -> Vec<Value> {
+    let mut messages = Vec::new();
+    if !config.system.is_empty() {
+        messages.push(json!({"role":"system","content":config.system}));
+    }
+    messages.push(json!({"role":"user","content":config.task}));
+    messages
+}
+
+fn model_request(
+    config: &Config,
+    tools: &[CheckedTool<'_>],
+    messages: &[Value],
+) -> Result<Vec<u8>> {
+    let mut body =
+        json!({"model":config.model,"stream":false,"max_tokens":512,"messages":messages});
+    if !tools.is_empty() {
+        body["tools"] = json!(tools.iter().map(|t| &t.definition).collect::<Vec<_>>());
+        body["tool_choice"] = json!("auto");
+    }
+    let wire = serde_json::to_vec(
+        &json!({"apiVersion":"celln.fetch/v1","method":"POST","url":config.url,"body":body}),
+    )?;
+    ensure!(
+        wire.len() <= 8192,
+        "conversation/schema envelope exceeds broker byte limit"
+    );
+    Ok(wire)
 }

--- a/crates/celln-pilot/src/json_harness_proof.rs
+++ b/crates/celln-pilot/src/json_harness_proof.rs
@@ -15,6 +15,11 @@ use warden::vmm::boot::{BootConfig, BootEnd, LinuxCell};
 
 fn main() -> Result<()> {
     let real_model = std::env::args().any(|arg| arg == "--real-model");
+    let package_only = std::env::args().any(|arg| arg == "--package-only");
+    ensure!(
+        !(real_model && package_only),
+        "choose real-model or package-only, not both"
+    );
     let token = if real_model {
         Some(PathBuf::from(
             std::env::var_os("CELLN_MODEL_TOKEN_FILE")
@@ -36,7 +41,7 @@ fn main() -> Result<()> {
         ("uppercase", "json_tool.rs", true),
         ("length", "json_tool.rs", false),
     ] {
-        if real_model && name == "pilot-fetch" {
+        if (real_model || package_only) && name == "pilot-fetch" {
             std::fs::copy(binaries.join("pilot-fetch"), work.join(name))?;
             continue;
         }
@@ -100,6 +105,10 @@ fn main() -> Result<()> {
     signed
         .verify(&BTreeSet::from([signed.publisher.clone()]))
         .map_err(anyhow::Error::msg)?;
+    std::fs::write(
+        work.join("signed-closure.json"),
+        serde_json::to_vec(&signed)?,
+    )?;
     let mut manifest = Manifest::new();
     manifest.admit(Entry {
         alias: "/harness".into(),
@@ -123,6 +132,10 @@ fn main() -> Result<()> {
             .success(),
         "initrd build failed"
     );
+    if package_only {
+        println!("PACKAGED: native JSON Harness with real broker client; no model call or KVM execution; {}", work.display());
+        return Ok(());
+    }
     let kernel = BootConfig::host_kernel().context("readable kernel required")?;
     let mut template = LinuxCell::boot(
         BootConfig::new(kernel)

--- a/crates/celln-pilot/src/json_harness_tests.rs
+++ b/crates/celln-pilot/src/json_harness_tests.rs
@@ -198,3 +198,21 @@ fn final_model_turn_cannot_start_side_effects_without_a_result_turn() {
     // The same last-turn budget must still permit a tool-free final answer.
     assert!(run(&cfg, |_| Ok(answer()), |_, _| panic!(), |_| {}).is_ok());
 }
+
+#[test]
+fn host_validation_rejects_initial_envelope_overflow_before_execution() {
+    let names: Vec<_> = (0..16).map(|n| format!("tool{n}")).collect();
+    let refs: Vec<_> = names.iter().map(String::as_str).collect();
+    let mut cfg = config(&refs);
+    for tool in &mut cfg.tools {
+        tool.description = "x".repeat(512);
+    }
+    assert!(validate(&cfg).unwrap_err().to_string().contains("envelope"));
+    assert!(run(
+        &cfg,
+        |_| panic!("must refuse before broker"),
+        |_, _| panic!(),
+        |_| {}
+    )
+    .is_err());
+}

--- a/crates/celln-spec/src/harness.rs
+++ b/crates/celln-spec/src/harness.rs
@@ -1,7 +1,7 @@
 use super::*;
 use std::collections::BTreeSet;
 
-/// Experimental text/two-integer-function adapter. Runtime identity is the
+/// Explicitly versioned native adapters. Runtime identity is the
 /// enclosing request's single executable and signed precomposed closure.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -11,6 +11,8 @@ pub struct HarnessBinding {
     pub model: String,
     pub task: String,
     pub borrowed_tools: Vec<BorrowedTool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub json: Option<JsonHarnessOptions>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -20,6 +22,59 @@ pub struct BorrowedTool {
     pub path: String,
     pub hash: String,
     pub description: String,
+    #[serde(rename = "jsonStdio", default, skip_serializing_if = "Option::is_none")]
+    pub json_stdio: Option<JsonToolIo>,
+}
+
+/// Exact host-granted persona and loop ceilings for the JSON adapter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct JsonHarnessOptions {
+    pub system: String,
+    pub max_turns: usize,
+    pub max_calls: usize,
+}
+
+/// Schema bytes are content-addressed data, never uploaded executable authority.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct JsonToolIo {
+    pub abi: String,
+    pub input_schema: String,
+    pub output_schema: String,
+    pub input_bytes: usize,
+    pub output_bytes: usize,
+    pub timeout_ms: u64,
+}
+
+fn valid_contract(version: &str, h: &HarnessBinding) -> bool {
+    match (version, h.contract_version.as_str()) {
+        ("celln.dev/v1alpha2", "celln.reference-functions/v1") => {
+            h.json.is_none()
+                && h.borrowed_tools.len() == 2
+                && h.borrowed_tools.iter().all(|t| t.json_stdio.is_none())
+        }
+        ("celln.dev/v1alpha3", "celln.json-tools/v1") => {
+            h.json.as_ref().is_some_and(|j| {
+                j.system.len() <= 2048
+                    && !j.system.contains('\0')
+                    && (1..=6).contains(&j.max_turns)
+                    && j.max_calls <= 16
+            }) && h.borrowed_tools.len() <= 16
+                && h.borrowed_tools.iter().all(|t| {
+                    t.path != "/pilot-fetch"
+                        && t.json_stdio.as_ref().is_some_and(|j| {
+                            j.abi == "celln.json-stdio/v1"
+                                && is_immutable_hash(&j.input_schema)
+                                && is_immutable_hash(&j.output_schema)
+                                && (1..=65536).contains(&j.input_bytes)
+                                && (1..=65536).contains(&j.output_bytes)
+                                && (1..=30000).contains(&j.timeout_ms)
+                        })
+                })
+        }
+        _ => false,
+    }
 }
 
 fn path(value: &str) -> bool {
@@ -36,12 +91,11 @@ fn path(value: &str) -> bool {
 
 pub(super) fn valid(request: &ExecutionRequest) -> bool {
     let Some(h) = &request.harness else {
-        return request.api_version != "celln.dev/v1alpha2";
+        return request.api_version == "celln.dev/v1alpha1";
     };
     let mut names = BTreeSet::new();
     let mut paths = BTreeSet::new();
-    request.api_version == "celln.dev/v1alpha2"
-        && h.contract_version == "celln.reference-functions/v1"
+    valid_contract(&request.api_version, h)
         && is_immutable_hash(&h.model_grant.hash)
         && !h.model.is_empty()
         && h.model.len() <= 128
@@ -61,7 +115,6 @@ pub(super) fn valid(request: &ExecutionRequest) -> bool {
         && request.execution.require_hardware_isolation
         && request.capabilities.workspace == WorkspaceAccess::None
         && request.capabilities.egress.len() == 1
-        && h.borrowed_tools.len() == 2
         && h.borrowed_tools.iter().all(|t| {
             !t.name.is_empty()
                 && t.name.len() <= 64
@@ -126,5 +179,68 @@ mod tests {
         let mut injected = value;
         injected["harness"]["credentialFile"] = json!("/etc/secret");
         assert!(serde_json::from_value::<ExecutionRequest>(injected).is_err());
+    }
+
+    #[test]
+    fn json_contract_cannot_be_confused_with_reference_or_argv() {
+        let mut value = wire();
+        value["apiVersion"] = json!("celln.dev/v1alpha3");
+        value["harness"]["contractVersion"] = json!("celln.json-tools/v1");
+        value["harness"]["json"] = json!({"system":"Approved persona","maxTurns":3,"maxCalls":2});
+        let hash = format!("blake3:{}", "a".repeat(64));
+        for tool in value["harness"]["borrowedTools"].as_array_mut().unwrap() {
+            tool["jsonStdio"] = json!({"abi":"celln.json-stdio/v1","inputSchema":hash,"outputSchema":hash,
+                "inputBytes":1024,"outputBytes":1024,"timeoutMs":1000});
+        }
+        let valid = |v| {
+            serde_json::from_value::<ExecutionRequest>(v)
+                .unwrap()
+                .problems()
+                .is_empty()
+        };
+        assert!(valid(value.clone()));
+        for (pointer, replacement) in [
+            ("/apiVersion", json!("celln.dev/v1alpha2")),
+            (
+                "/harness/contractVersion",
+                json!("celln.reference-functions/v1"),
+            ),
+            ("/harness/json", json!(null)),
+            ("/harness/json/maxTurns", json!(0)),
+            ("/harness/json/maxTurns", json!(7)),
+            ("/harness/json/maxCalls", json!(17)),
+            ("/harness/json/system", json!("x".repeat(2049))),
+            ("/harness/borrowedTools/0/jsonStdio", json!(null)),
+            (
+                "/harness/borrowedTools/0/jsonStdio/abi",
+                json!("celln.argv/v1"),
+            ),
+            (
+                "/harness/borrowedTools/0/jsonStdio/inputSchema",
+                json!("/etc/secret"),
+            ),
+            (
+                "/harness/borrowedTools/0/jsonStdio/outputSchema",
+                json!("mutable-tag"),
+            ),
+            ("/harness/borrowedTools/0/jsonStdio/inputBytes", json!(0)),
+            (
+                "/harness/borrowedTools/0/jsonStdio/outputBytes",
+                json!(65537),
+            ),
+            ("/harness/borrowedTools/0/jsonStdio/timeoutMs", json!(30001)),
+        ] {
+            let mut bad = value.clone();
+            *bad.pointer_mut(pointer).unwrap() = replacement;
+            assert!(!valid(bad), "{pointer}");
+        }
+        let mut reference = wire();
+        reference["harness"]["borrowedTools"][0]["jsonStdio"] =
+            value["harness"]["borrowedTools"][0]["jsonStdio"].clone();
+        assert!(!valid(reference));
+        value["harness"]["borrowedTools"] = json!([]);
+        assert!(valid(value.clone()), "an empty selection grants no tools");
+        value.as_object_mut().unwrap().remove("harness");
+        assert!(!valid(value));
     }
 }

--- a/crates/celln-spec/src/lib.rs
+++ b/crates/celln-spec/src/lib.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 mod harness;
-pub use harness::{BorrowedTool, HarnessBinding};
+pub use harness::{BorrowedTool, HarnessBinding, JsonHarnessOptions, JsonToolIo};
 
 /// A cell specification.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -423,16 +423,17 @@ impl ExecutionRequest {
         let mut problems = Vec::new();
         if !matches!(
             self.api_version.as_str(),
-            "celln.dev/v1alpha1" | "celln.dev/v1alpha2"
+            "celln.dev/v1alpha1" | "celln.dev/v1alpha2" | "celln.dev/v1alpha3"
         ) {
             problems.push(ExecutionProblem {
                 code: ExecutionProblemCode::UnsupportedVersion,
                 field: "apiVersion".into(),
-                message: "must be celln.dev/v1alpha1 or celln.dev/v1alpha2".into(),
+                message: "must be celln.dev/v1alpha1, celln.dev/v1alpha2 or celln.dev/v1alpha3"
+                    .into(),
             });
         }
         if !harness::valid(self) {
-            problems.push(ExecutionProblem { code: ExecutionProblemCode::InvalidHarness, field:"harness".into(), message:"v1alpha2 requires a bounded declared reference Harness binding; v1alpha1 forbids one".into() });
+            problems.push(ExecutionProblem { code: ExecutionProblemCode::InvalidHarness, field:"harness".into(), message:"v1alpha2 requires the reference Harness; v1alpha3 requires the bounded JSON Harness; v1alpha1 forbids Harness bindings".into() });
         }
         for (field, value) in [
             ("id", self.id.as_str()),
@@ -637,12 +638,13 @@ impl ExecutionReceipt {
         let mut problems = Vec::new();
         if !matches!(
             self.api_version.as_str(),
-            "celln.dev/v1alpha1" | "celln.dev/v1alpha2"
+            "celln.dev/v1alpha1" | "celln.dev/v1alpha2" | "celln.dev/v1alpha3"
         ) {
             problems.push(ExecutionProblem {
                 code: ExecutionProblemCode::UnsupportedVersion,
                 field: "apiVersion".into(),
-                message: "must be celln.dev/v1alpha1".into(),
+                message: "must be celln.dev/v1alpha1, celln.dev/v1alpha2 or celln.dev/v1alpha3"
+                    .into(),
             });
         }
         for (field, value) in [

--- a/docs/HARNESS_DISPATCH.md
+++ b/docs/HARNESS_DISPATCH.md
@@ -1,5 +1,9 @@
 # Experimental reference Harness dispatch
 
+This page retains the v1alpha2 reference contract. The separately versioned
+native JSON-tool adapter uses [v1alpha3 requests and v2 grants](JSON_HARNESS_DISPATCH.md);
+it does not change the reference tool ABI.
+
 Tracks [Sympozium #426](https://github.com/sympozium-ai/sympozium/issues/426).
 Measured 2026-09-07: **actual Sympozium controller → isolated Kind Kubernetes
 API → authenticated host dispatcher → warm-forked cell → DeepSeek → two lent

--- a/docs/JSON_HARNESS_DISPATCH.md
+++ b/docs/JSON_HARNESS_DISPATCH.md
@@ -1,0 +1,128 @@
+# Native JSON Harness: host-authorized dispatch
+
+Progresses [Sympozium epic #426](https://github.com/sympozium-ai/sympozium/issues/426).
+The [native JSON adapter](JSON_TOOL_HARNESS.md) now has an explicitly versioned
+request, operator grant and authenticated HTTP dispatcher proof. This does not
+yet connect it to Sympozium runtime/catalogue selection or the lending UI.
+
+## Request and immutable authority
+
+`celln.dev/v1alpha3` requires `harness.contractVersion: celln.json-tools/v1`.
+v1alpha1 has no Harness; v1alpha2 retains the two-integer reference contract.
+Cross-version/contract substitutions refuse. Receipt v1alpha3 uses the existing
+receipt shape; consumers must explicitly support the version, not downgrade it.
+
+The enclosing request identifies one admitted mote and one primary runtime with
+its signed precomposed closure. Only agent lane, required hardware isolation,
+one HTTPS origin, no workspace/inputs/forge and no user invocation arguments are
+supported. The closure contains exactly the runtime, `/pilot-fetch` and the
+0–16 selected static tools; extra members and interpreter closures refuse.
+Dynamic dependency composition remains a separate implementation gate.
+
+The Harness binding includes `modelGrant.hash`, `model`, bounded `task`,
+`borrowedTools` and `json: {system, maxTurns, maxCalls}`. The persona is at most
+2048 bytes, turns 1–6 and calls 0–16. Each tool retains its unique name/path,
+executable hash and description, and requires `jsonStdio`:
+
+| Field | Meaning |
+|---|---|
+| `abi` | Exactly `celln.json-stdio/v1`; never interpreted as argv |
+| `inputSchema`, `outputSchema` | Exact BLAKE3 hashes of bounded schema bytes |
+| `inputBytes`, `outputBytes` | Explicit 1–65536-byte ceilings |
+| `timeoutMs` | Explicit 1–30000-ms child deadline |
+
+Schema data lives in the host content-addressed `STATE/tool-schemas` store.
+The host reads each object with the schema byte ceiling, verifies its hash and
+compiles the exact schema through the same bounded parser as the guest. Inputs
+must be object schemas. Missing, tampered, oversized or unsupported schemas
+refuse before warm preparation/model I/O. No request supplies a host file path.
+Public store membership is not approval: the operator grant must independently
+authorize every selected executable, schema identity and limit.
+
+`STATE/trusted-harness/<grant-hash-hex>.json` remains operator-owned, not a
+user-uploadable artifact store. JSON grants require:
+
+- `apiVersion: celln.dev/harness-grant-v2` and
+  `contractVersion: celln.json-tools/v1`.
+- Exact `caller`, `mote`, `runtime`, `closure`, `model`, ordered `borrowedTools`
+  (including ABI/schema/limit fields), and `json` persona/loop options.
+- `url`: the sole requested HTTPS origin plus `/chat/completions`.
+- Absolute host-only `credentialFile`, `maxRequests` (1–6), `maxOutputTokens`
+  (512), and `maxTotalOutputTokens` (512–3072).
+
+The request's exact JSON turn ceiling must fit both `maxRequests` and the total
+512-token-per-request reservation budget. This prevents a configured loop from
+being knowingly underfunded; it is not currency billing or a provider-success
+promise. A v1 grant cannot authorize JSON execution. Only task data varies
+without a new exact grant; catalogue-driven grant issuance/intersection remains
+to be implemented. No request can self-issue a grant by uploading its bytes.
+
+The host constructs and validates the guest configuration (64 KiB ceiling),
+including the initial model envelope (8 KiB ceiling). Later conversation growth
+can still exhaust the envelope; the loop fails closed and does not retry tool
+side effects. Static maxima are ceilings, not a promise every maximum-size
+selection fits simultaneously.
+
+The grant/schema resolution is repeated after warm preparation. Credentials and
+model authority attach only to the forked cell. The existing synced local
+attempt tombstone forbids automatic replay with fresh allowance, including after
+restart. Local grant removal refuses new launches; live/fleet withdrawal and
+distributed metering/recovery are not implemented by this contract.
+
+## Actual proof and reproduction
+
+The [real DeepSeek dispatch record](evidence/json-harness-dispatch-2026-09-07.json)
+captures authenticated loopback HTTP → dispatcher → warm-forked KVM cell →
+schema-bound `uppercase({"text":"celln"})` → `length({"text":"CELLN"})` →
+`CELLN has length 5`. It asserts two executable/schema identities, three broker
+requests, a matching v1alpha3 receipt, correlated audit, and caller/tool/grant,
+local replay and grant-withdrawal refusals. Audit records dissolution. This is
+not the router/Kind/Sympozium path. The temporary credential copy was removed;
+no cluster deployment or production configuration changed.
+
+The same guest binary also passed the [seven-case scripted KVM regression](evidence/json-harness-dispatch-scripted-2026-09-07.json),
+including invalid selection/arguments/results, child deadline/output overflow
+and final-turn refusal. That suite is explicitly not an AI test.
+
+Portable tests separately cover persona/schema/limit grant mismatches,
+underfunded model budgets, schema absence/tampering/limits, legacy-contract
+confusion and initial-envelope overflow. Runtime tool-call events are transcript
+evidence, not individually hardware-attested per-tool receipts. The receipt
+identifies the runtime; the request and audit correlate the selected closure and
+grant. No general HarnessSession, MCP or arbitrary OCI compatibility is implied.
+
+Build the static binaries as in the adapter guide, then package without model
+calls or KVM execution:
+
+```sh
+CELLN_PILOT_DIR="$PWD/target/validation/x86_64-unknown-linux-musl/release" \
+CARGO_TARGET_DIR=target/validation cargo run -p celln-pilot --features kvm \
+  --bin celln-json-harness-proof -- --package-only
+```
+
+Use the printed package directory and a private authorized host credential:
+
+```sh
+CELLN_HARNESS_PACKAGE=/absolute/printed/package \
+CELLN_MODEL_TOKEN_FILE=/absolute/private/provider-token \
+CARGO_TARGET_DIR=target/validation cargo test -p celln-cli --bin celln \
+  dispatch_http::harness_tests::json_harness_model_over_authenticated_dispatch \
+  -- --ignored --exact --nocapture
+```
+
+This explicitly billable test requires real KVM and a readable kernel; explicit
+execution fails rather than claiming success when hardware is unavailable. Do
+not set the reference-only controller hook for this test. Its state/grants are
+temporary; the [example request](../examples/execution/harness-json.json) records
+the proof identities, not installed authority on another host.
+
+## Remaining product gates
+
+Extend Sympozium's catalogue/runtime ABI and trusted authority resolver, connect
+approved selection and bounded grant issuance, compose/distribute exact runtime
+and tool closures, verify functional admission and serving-process prewarm, and
+expose permissions/refusals/results in the UI. Then repeat real-model and
+adversarial proofs through the deployed user journey and implement external
+conversation state/lifecycle. Capability discovery remains preflight-only with
+artifact readiness `not_checked`, not a positive readiness claim for any named
+runtime/tool selection. The epic remains open.

--- a/docs/JSON_TOOL_HARNESS.md
+++ b/docs/JSON_TOOL_HARNESS.md
@@ -6,8 +6,10 @@ Its agent loop runs inside a sealed cell and uses explicitly lent executables
 with immutable, bounded input/result schemas. It is no longer restricted to
 two integer-string functions or required to invoke every available tool.
 
-**Integration status:** this binary is not yet accepted by the dispatcher
-Harness binding or selectable through Sympozium. The existing
+**Integration status:** the dispatcher accepts this binary only through the
+explicit v1alpha3 binding and independent v2 operator grant described in
+[JSON Harness dispatch](JSON_HARNESS_DISPATCH.md). It is not yet selectable
+through Sympozium. The existing
 `celln.reference-functions/v1` contract and refusal guards are unchanged.
 Do not label this as arbitrary OCI/Pi/Hermes compatibility, a finished user BYO
 workflow, or conversational HarnessSession support.
@@ -30,7 +32,8 @@ Host configuration is one bounded JSON argument (at most 64 KiB) containing:
 Tool invocation is **JSON stdin → JSON stdout**, with no user arguments or
 shell. This is a new adapter ABI, not a silent reinterpretation of catalogue
 `celln.argv/v1`. The catalogue/runtime schema and independently authorized host
-binding must explicitly support it before integration can be enabled.
+binding explicitly name `celln.json-stdio/v1`; the Sympozium catalogue/runtime
+schema still needs that support before its integration can be enabled.
 
 Model arguments are validated as their original bytes before parsing, so
 duplicate keys, unknown fields, wrong types and excess budgets cannot disappear
@@ -115,7 +118,8 @@ the earlier real-model run as a measurement of this later binary.
 
 ## Remaining integration gates
 
-Version the host grant/request and catalogue invocation ABI; bind the approved
+The host grant/request is now versioned and tested through authenticated HTTP
+dispatch. Extend the Sympozium catalogue invocation ABI; bind the approved
 runtime plus tool/schema/policy identities through the authority resolver;
 verify and compose their exact closure; distribute and prewarm in the serving
 process; expose runtime/tool selections and refusals in Sympozium. Re-run real

--- a/docs/evidence/json-harness-dispatch-2026-09-07.json
+++ b/docs/evidence/json-harness-dispatch-2026-09-07.json
@@ -1,0 +1,238 @@
+{
+  "audit": {
+    "apiVersion": "celln.dev/audit-v1alpha1",
+    "caller": "test:controller",
+    "events": [
+      {
+        "at": "2026-09-07T14:45:54Z",
+        "phase": "Admitting",
+        "sequence": 0
+      },
+      {
+        "at": "2026-09-07T14:45:54Z",
+        "phase": "Resolving",
+        "sequence": 1
+      },
+      {
+        "at": "2026-09-07T14:45:56Z",
+        "phase": "CellRunning",
+        "sequence": 2
+      },
+      {
+        "at": "2026-09-07T14:46:00Z",
+        "phase": "Dissolved",
+        "sequence": 3
+      },
+      {
+        "at": "2026-09-07T14:46:00Z",
+        "phase": "Succeeded",
+        "sequence": 4
+      }
+    ],
+    "execution": {
+      "broker": {
+        "denied": 0,
+        "requests": 3,
+        "responseBytes": 1717
+      },
+      "cellId": "a463c9222a4f",
+      "exitCode": 0,
+      "granted": {
+        "egress": [
+          "https://api.deepseek.com"
+        ],
+        "memoryBytes": 268435456,
+        "outputBytes": 65536,
+        "timeoutMs": 180000,
+        "workspace": "none"
+      },
+      "inputs": [],
+      "modelGrant": "blake3:990a55bee6a36cf8b52aeda83e8c376f0f130238321ec02b72c7071e1f099ec3",
+      "pilot": {
+        "fetch": true,
+        "lane": "agent",
+        "tool": "blake3:e0b47f4d4473dabec0a759f5915bf7b85f3c146a08d504ab6104f9b95ff8fa47",
+        "workspace": "none"
+      },
+      "signal": null,
+      "substrate": {
+        "closure": {
+          "hash": "blake3:181806441f4de12d61b5989e6bb932dd6ca799d5ffe083e28837630b46a96abe",
+          "members": {
+            "/harness": {
+              "dependencies": [
+                "/length",
+                "/pilot-fetch",
+                "/uppercase"
+              ],
+              "hash": "blake3:e0b47f4d4473dabec0a759f5915bf7b85f3c146a08d504ab6104f9b95ff8fa47"
+            },
+            "/length": {
+              "dependencies": [],
+              "hash": "blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245"
+            },
+            "/pilot-fetch": {
+              "dependencies": [],
+              "hash": "blake3:9afcf605962e29d25fd95fcd3d3a719210f644cd1ee0893ff3d5578eeb86888e"
+            },
+            "/uppercase": {
+              "dependencies": [],
+              "hash": "blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c"
+            }
+          },
+          "publisher": "197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61",
+          "toolfs": "blake3:f4238a38b96cd27d699e2a8a3ce19f3ca3520099c272bf4111f3bd0b3c4c94a5"
+        },
+        "initrd": "blake3:b46c44a356a6f060e01f7fae116376a98b3ff2aee547bfc9068b9c7cc8e9186a",
+        "invocation": "blake3:f6a08e152755fe3ca28ed3435921457a810a16d2511228d0654d373e87ca2235",
+        "kernel": "blake3:e8e05482b24c4d9019ff7298f42f6f2730fcf656cbcb429ec44150ceac0e4ca8",
+        "toolfs": "blake3:f4238a38b96cd27d699e2a8a3ce19f3ca3520099c272bf4111f3bd0b3c4c94a5"
+      },
+      "watchdogStopped": false
+    },
+    "node": "harness-proof-node",
+    "receipt": {
+      "apiVersion": "celln.dev/v1alpha3",
+      "cellId": "a463c9222a4f",
+      "completedAt": "2026-09-07T14:46:00Z",
+      "node": "harness-proof-node",
+      "output": {
+        "bytes": 1100,
+        "hash": "blake3:df56994a6d00e2d383fd950bddd6d2e108b6ea6b3169978c8a65900c4e6bacc6",
+        "mediaType": "application/octet-stream"
+      },
+      "phase": "succeeded",
+      "requestId": "harness-dispatch-proof",
+      "resolved": {
+        "inputs": [],
+        "mote": "blake3:eee24b8031b33534417dafb4097c4d7947694afec717078286a0e3c8acbe9534",
+        "tools": [
+          "blake3:e0b47f4d4473dabec0a759f5915bf7b85f3c146a08d504ab6104f9b95ff8fa47"
+        ]
+      },
+      "startedAt": "2026-09-07T14:45:54Z"
+    },
+    "requestId": "harness-dispatch-proof",
+    "workload": "test-run"
+  },
+  "callerMismatchDenied": true,
+  "grantWithdrawalDenied": true,
+  "localReplayDenied": true,
+  "request": {
+    "apiVersion": "celln.dev/v1alpha3",
+    "capabilities": {
+      "egress": [
+        "https://api.deepseek.com"
+      ],
+      "memoryBytes": 268435456,
+      "outputBytes": 65536,
+      "timeoutMs": 180000,
+      "workspace": "none"
+    },
+    "execution": {
+      "lane": "agent",
+      "requireHardwareIsolation": true
+    },
+    "forge": null,
+    "harness": {
+      "borrowedTools": [
+        {
+          "description": "Uppercase text",
+          "hash": "blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c",
+          "jsonStdio": {
+            "abi": "celln.json-stdio/v1",
+            "inputBytes": 1024,
+            "inputSchema": "blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6",
+            "outputBytes": 1024,
+            "outputSchema": "blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6",
+            "timeoutMs": 1000
+          },
+          "name": "uppercase",
+          "path": "/uppercase"
+        },
+        {
+          "description": "Measure text length",
+          "hash": "blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245",
+          "jsonStdio": {
+            "abi": "celln.json-stdio/v1",
+            "inputBytes": 1024,
+            "inputSchema": "blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6",
+            "outputBytes": 1024,
+            "outputSchema": "blake3:334d8ed405e3789cc513dc297a2137ee175e9f2b91743deb1e73e15517cf72d5",
+            "timeoutMs": 1000
+          },
+          "name": "length",
+          "path": "/length"
+        }
+      ],
+      "contractVersion": "celln.json-tools/v1",
+      "json": {
+        "maxCalls": 2,
+        "maxTurns": 3,
+        "system": "Use the explicitly lent tools."
+      },
+      "model": "deepseek-chat",
+      "modelGrant": {
+        "hash": "blake3:990a55bee6a36cf8b52aeda83e8c376f0f130238321ec02b72c7071e1f099ec3"
+      },
+      "task": "Call uppercase with text celln, wait for its result, then call length with the uppercase result. Wait for both tool results. Finally answer exactly: CELLN has length 5"
+    },
+    "id": "harness-dispatch-proof",
+    "inputs": [],
+    "invocation": {
+      "alias": "/harness",
+      "args": []
+    },
+    "mote": {
+      "hash": "blake3:eee24b8031b33534417dafb4097c4d7947694afec717078286a0e3c8acbe9534"
+    },
+    "tools": [
+      {
+        "alias": "/harness",
+        "closure": {
+          "hash": "blake3:181806441f4de12d61b5989e6bb932dd6ca799d5ffe083e28837630b46a96abe"
+        },
+        "hash": "blake3:e0b47f4d4473dabec0a759f5915bf7b85f3c146a08d504ab6104f9b95ff8fa47"
+      }
+    ],
+    "workload": {
+      "caller": "test:controller",
+      "id": "test-run"
+    }
+  },
+  "scope": "authenticated host HTTP dispatcher; not router/Sympozium/Kind",
+  "terminal": {
+    "output": "CELLN_HARNESS_EVENT {\"model\":\"deepseek-chat\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"arguments\":{\"text\":\"celln\"},\"hash\":\"blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c\",\"id\":\"call_00_8zE0hIL3fKw1GQUrhNVM2623\",\"inputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"name\":\"uppercase\",\"outputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"result\":{\"text\":\"CELLN\"},\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"model\":\"deepseek-chat\",\"turn\":1,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"arguments\":{\"text\":\"CELLN\"},\"hash\":\"blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245\",\"id\":\"call_00_sm56wgiAMIyOU9RpavQz4492\",\"inputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"name\":\"length\",\"outputSchema\":\"blake3:334d8ed405e3789cc513dc297a2137ee175e9f2b91743deb1e73e15517cf72d5\",\"result\":{\"length\":5},\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"model\":\"deepseek-chat\",\"turn\":2,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"answer\":\"CELLN has length 5\",\"calls\":2,\"type\":\"completed\"}\n",
+    "phase": "Succeeded",
+    "receipt": {
+      "apiVersion": "celln.dev/v1alpha3",
+      "cellId": "a463c9222a4f",
+      "completedAt": "2026-09-07T14:46:00Z",
+      "node": "harness-proof-node",
+      "output": {
+        "bytes": 1100,
+        "hash": "blake3:df56994a6d00e2d383fd950bddd6d2e108b6ea6b3169978c8a65900c4e6bacc6",
+        "mediaType": "application/octet-stream"
+      },
+      "phase": "succeeded",
+      "requestId": "harness-dispatch-proof",
+      "resolved": {
+        "inputs": [],
+        "mote": "blake3:eee24b8031b33534417dafb4097c4d7947694afec717078286a0e3c8acbe9534",
+        "tools": [
+          "blake3:e0b47f4d4473dabec0a759f5915bf7b85f3c146a08d504ab6104f9b95ff8fa47"
+        ]
+      },
+      "startedAt": "2026-09-07T14:45:54Z"
+    },
+    "requestId": "harness-dispatch-proof"
+  },
+  "toolMismatchDenied": true,
+  "unknownGrantDenied": true,
+  "provenance": {
+    "baseRevision": "7d9116f30f5fa6be428a7e859491af2fef3ebd4c",
+    "workingTreeChanges": true,
+    "source": "feat/json-harness-dispatch: versioned request/grant/schema host binding",
+    "productionDeploymentChanged": false
+  }
+}

--- a/docs/evidence/json-harness-dispatch-scripted-2026-09-07.json
+++ b/docs/evidence/json-harness-dispatch-scripted-2026-09-07.json
@@ -1,0 +1,95 @@
+{
+  "cases": [
+    {
+      "elapsedMicros": 100674,
+      "exit": 0,
+      "expected": "CELLN has length 5",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"arguments\":{\"text\":\"celln\"},\"hash\":\"blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c\",\"id\":\"call-uppercase\",\"inputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"name\":\"uppercase\",\"outputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"result\":{\"text\":\"CELLN\"},\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":1,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"arguments\":{\"text\":\"CELLN\"},\"hash\":\"blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245\",\"id\":\"call-length\",\"inputSchema\":\"blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6\",\"name\":\"length\",\"outputSchema\":\"blake3:334d8ed405e3789cc513dc297a2137ee175e9f2b91743deb1e73e15517cf72d5\",\"result\":{\"length\":5},\"type\":\"tool\"}\nCELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":2,\"type\":\"model\"}\nCELLN_HARNESS_EVENT {\"answer\":\"CELLN has length 5\",\"calls\":2,\"type\":\"completed\"}\n",
+      "task": "normalize then measure"
+    },
+    {
+      "elapsedMicros": 60482,
+      "exit": 1,
+      "expected": "unselected tool requested",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR unselected tool requested\n",
+      "task": "undeclared"
+    },
+    {
+      "elapsedMicros": 60416,
+      "exit": 1,
+      "expected": "tool value type mismatch",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR tool value type mismatch\n",
+      "task": "invalid-arguments"
+    },
+    {
+      "elapsedMicros": 60352,
+      "exit": 1,
+      "expected": "required tool field missing",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR required tool field missing\n",
+      "task": "bad-result"
+    },
+    {
+      "elapsedMicros": 160736,
+      "exit": 1,
+      "expected": "tool deadline exceeded",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR tool deadline exceeded\n",
+      "task": "sleep"
+    },
+    {
+      "elapsedMicros": 81064,
+      "exit": 1,
+      "expected": "child output exceeded limit",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR child output exceeded limit\n",
+      "task": "flood"
+    },
+    {
+      "elapsedMicros": 60413,
+      "exit": 1,
+      "expected": "model budget leaves no tool result turn",
+      "output": "CELLN_HARNESS_EVENT {\"model\":\"scripted-not-ai\",\"turn\":0,\"type\":\"model\"}\nCELLN_HARNESS_ERROR model budget leaves no tool result turn\n",
+      "task": "last-turn"
+    }
+  ],
+  "closure": {
+    "closure": {
+      "apiVersion": "celln.dev/closure-v1",
+      "entrypoint": "/harness",
+      "interpreter": false,
+      "members": {
+        "/harness": {
+          "dependencies": [
+            "/length",
+            "/pilot-fetch",
+            "/uppercase"
+          ],
+          "hash": "blake3:e0b47f4d4473dabec0a759f5915bf7b85f3c146a08d504ab6104f9b95ff8fa47"
+        },
+        "/length": {
+          "dependencies": [],
+          "hash": "blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245"
+        },
+        "/pilot-fetch": {
+          "dependencies": [],
+          "hash": "blake3:d6e0f9b8e8f94b1f7e595cf117a38a98ef95b65d43edb081eb53b0a6178c0b01"
+        },
+        "/uppercase": {
+          "dependencies": [],
+          "hash": "blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c"
+        }
+      },
+      "toolfs": "blake3:9348abe7b264f24ea54f5122702818fb7dbe2e0a3651b3d43a3b54cee45fd33a"
+    },
+    "publisher": "197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61",
+    "signature": "ef94de080a76c314dbba05d5a30cb736252c6b4205be014ac42cd4b040dcceefb0849a5dd810469d65921d9077ec1b1034a35a7c3d05d4a7a50d47419f95930b"
+  },
+  "guestBinary": "blake3:e0b47f4d4473dabec0a759f5915bf7b85f3c146a08d504ab6104f9b95ff8fa47",
+  "modelCalls": 0,
+  "scope": "real-KVM-native-adapter-with-scripted-broker-not-AI",
+  "status": "passed",
+  "provenance": {
+    "baseRevision": "7d9116f30f5fa6be428a7e859491af2fef3ebd4c",
+    "workingTreeChanges": true,
+    "source": "feat/json-harness-dispatch: shared host/guest initial-envelope validation",
+    "productionDeploymentChanged": false
+  }
+}

--- a/examples/execution/harness-json.json
+++ b/examples/execution/harness-json.json
@@ -1,0 +1,82 @@
+{
+  "apiVersion": "celln.dev/v1alpha3",
+  "capabilities": {
+    "egress": [
+      "https://api.deepseek.com"
+    ],
+    "memoryBytes": 268435456,
+    "outputBytes": 65536,
+    "timeoutMs": 180000,
+    "workspace": "none"
+  },
+  "execution": {
+    "lane": "agent",
+    "requireHardwareIsolation": true
+  },
+  "forge": null,
+  "harness": {
+    "borrowedTools": [
+      {
+        "description": "Uppercase text",
+        "hash": "blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c",
+        "jsonStdio": {
+          "abi": "celln.json-stdio/v1",
+          "inputBytes": 1024,
+          "inputSchema": "blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6",
+          "outputBytes": 1024,
+          "outputSchema": "blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6",
+          "timeoutMs": 1000
+        },
+        "name": "uppercase",
+        "path": "/uppercase"
+      },
+      {
+        "description": "Measure text length",
+        "hash": "blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245",
+        "jsonStdio": {
+          "abi": "celln.json-stdio/v1",
+          "inputBytes": 1024,
+          "inputSchema": "blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6",
+          "outputBytes": 1024,
+          "outputSchema": "blake3:334d8ed405e3789cc513dc297a2137ee175e9f2b91743deb1e73e15517cf72d5",
+          "timeoutMs": 1000
+        },
+        "name": "length",
+        "path": "/length"
+      }
+    ],
+    "contractVersion": "celln.json-tools/v1",
+    "json": {
+      "maxCalls": 2,
+      "maxTurns": 3,
+      "system": "Use the explicitly lent tools."
+    },
+    "model": "deepseek-chat",
+    "modelGrant": {
+      "hash": "blake3:990a55bee6a36cf8b52aeda83e8c376f0f130238321ec02b72c7071e1f099ec3"
+    },
+    "task": "Call uppercase with text celln, wait for its result, then call length with the uppercase result. Wait for both tool results. Finally answer exactly: CELLN has length 5"
+  },
+  "id": "harness-dispatch-proof",
+  "inputs": [],
+  "invocation": {
+    "alias": "/harness",
+    "args": []
+  },
+  "mote": {
+    "hash": "blake3:eee24b8031b33534417dafb4097c4d7947694afec717078286a0e3c8acbe9534"
+  },
+  "tools": [
+    {
+      "alias": "/harness",
+      "closure": {
+        "hash": "blake3:181806441f4de12d61b5989e6bb932dd6ca799d5ffe083e28837630b46a96abe"
+      },
+      "hash": "blake3:e0b47f4d4473dabec0a759f5915bf7b85f3c146a08d504ab6104f9b95ff8fa47"
+    }
+  ],
+  "workload": {
+    "caller": "test:controller",
+    "id": "test-run"
+  }
+}


### PR DESCRIPTION
## Outcome

Progresses sympozium-ai/sympozium#426 and the remaining lending/distribution scope of sympozium-ai/sympozium#335. Integrates the native JSON adapter merged in #85 with independently authorized host dispatch.

- Explicit `celln.dev/v1alpha3` / `celln.json-tools/v1`, separate from legacy reference requests and grants.
- `celln.dev/harness-grant-v2` binds caller, mote/runtime/closure, model, persona/loop options, ordered lent tools, `celln.json-stdio/v1`, schema hashes and byte/time ceilings.
- Bounded hash-checked schema store reads; shared host/guest schema validation and initial model-envelope budget check; no request-supplied host paths or guest credentials.
- Exact static closure membership, model-reservation budget sufficiency, existing post-warm grant recheck/local replay refusal preserved.
- Discovery advertises protocol support only; artifact readiness remains `not_checked`.

## Verification

- Full `make ci` and workspace/all-target/all-feature Clippy with warnings denied passed.
- Portable contract/grant/schema/budget/legacy-confusion/empty-selection refusals passed.
- **Real DeepSeek through authenticated HTTP → dispatcher → warm-forked KVM → uppercase → length passed**, three model requests and final `CELLN has length 5`. Tool executable/input/output schema identities, v1alpha3 receipt, audit, local replay and grant withdrawal verified. Temporary credential copy removed.
- Same runtime binary passed all seven scripted-broker KVM regression cases. Scripted proof is explicitly not AI evidence.
- Durable evidence and reproduction commands: `docs/JSON_HARNESS_DISPATCH.md`, `docs/evidence/json-harness-dispatch{,-scripted}-2026-09-07.json`.

## Not completed by this PR

No Sympozium runtime/catalogue selector, grant issuance, BYO lending UI, dynamic composition/distribution/serving-process prewarm, conversational lifecycle or full release gate. The JSON controller hook deliberately refuses until its contract is implemented. No cluster/production deployment changed; evidence is host HTTP dispatch, not router/Kind/Sympozium. This does not close either linked issue.
