### PR TITLE
feat: signed runtime/tool closure composition

### DIFF
--- a/crates/celln-cli/examples/prepare_review_fixture.rs
+++ b/crates/celln-cli/examples/prepare_review_fixture.rs
@@ -23,6 +23,7 @@ fn main() -> Result<()> {
     let executable = Hash::of(b"declared example member").0;
     let signed = Closure {
         api_version: "celln.dev/closure-v1".into(),
+        sources: Vec::new(),
         toolfs: Hash::of(filesystem).0,
         entrypoint: "/example".into(),
         interpreter: false,

--- a/crates/celln-cli/src/closure_cli.rs
+++ b/crates/celln-cli/src/closure_cli.rs
@@ -9,6 +9,17 @@ fn read(path: &Path) -> Result<Vec<u8>> {
 
 pub fn sign(descriptor: &Path, key: &Path) -> Result<u8> {
     let closure: Closure = serde_json::from_slice(&read(descriptor)?)?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&sign_descriptor(closure, key)?)?
+    );
+    Ok(0)
+}
+
+pub(crate) fn sign_descriptor(
+    closure: Closure,
+    key: &Path,
+) -> Result<celln_manifest::closure::SignedClosure> {
     let mut seed = zeroize::Zeroizing::new([0u8; 32]);
     let mut source = std::fs::File::open(key).context("opening private seed file")?;
     source
@@ -19,9 +30,7 @@ pub fn sign(descriptor: &Path, key: &Path) -> Result<u8> {
         source.read(&mut extra)? == 0,
         "private seed must contain exactly 32 raw bytes"
     );
-    let signed = closure.sign(&seed).map_err(anyhow::Error::msg);
-    println!("{}", serde_json::to_string_pretty(&signed?)?);
-    Ok(0)
+    closure.sign(&seed).map_err(anyhow::Error::msg)
 }
 
 pub fn admit(descriptor: &Path, root: &Path) -> Result<u8> {
@@ -189,6 +198,7 @@ mod tests {
         let executable = Hash::of(b"fixture executable").0;
         let signed = Closure {
             api_version: "celln.dev/closure-v1".into(),
+            sources: Vec::new(),
             toolfs: Hash::of(b"fixture filesystem").0,
             entrypoint: "/tools/example".into(),
             interpreter: false,

--- a/crates/celln-cli/src/closure_policy.rs
+++ b/crates/celln-cli/src/closure_policy.rs
@@ -46,6 +46,14 @@ pub fn verify(bytes: &[u8], root: &Path) -> Result<Verified, String> {
         serde_json::from_slice(bytes).map_err(|_| "invalid signed closure")?;
     signed.verify(&policy.publishers)?;
     let identity = Hash::of(bytes);
+    for source in &signed.closure.sources {
+        let descriptor = source.parse()?;
+        if policy.revoked.contains(&source.hash)
+            || policy.revoked.contains(&descriptor.closure.toolfs)
+        {
+            return Err("composition source or source filesystem revoked".into());
+        }
+    }
     if policy.revoked.contains(&identity.0)
         || policy.revoked.contains(&signed.closure.toolfs)
         || signed

--- a/crates/celln-cli/src/composition_cli.rs
+++ b/crates/celln-cli/src/composition_cli.rs
@@ -107,6 +107,22 @@ mod tests {
         assert!(crate::closure_policy::verify(&descriptor, root).is_err());
         assert!(build(&plan, &key, &root.join("refused"), builder, root).is_err());
         assert!(!root.join("refused").exists());
+        publishers.insert(source.publisher);
+        write_policy(vec![], &publishers);
+        // A trusted descriptor must not turn absent/corrupt store bytes into a
+        // published composition. Staging is removed on both failure paths.
+        let hash = Hash::of(b"/tools/tool").0;
+        let hex = hash.strip_prefix("blake3:").unwrap();
+        let blob = root.join("tools/objects").join(&hex[..2]).join(hex);
+        fs::write(&blob, b"corrupted member").unwrap();
+        let corrupt_output = root.join("corrupt-output");
+        assert!(build(&plan, &key, &corrupt_output, builder, root).is_err());
+        assert!(!corrupt_output.join("signed-closure.json").exists());
+        assert_eq!(fs::read_dir(&corrupt_output).unwrap().count(), 0);
+        fs::remove_file(&blob).unwrap();
+        let missing_output = root.join("missing-output");
+        assert!(build(&plan, &key, &missing_output, builder, root).is_err());
+        assert_eq!(fs::read_dir(&missing_output).unwrap().count(), 0);
     }
 }
 

--- a/crates/celln-cli/src/composition_cli.rs
+++ b/crates/celln-cli/src/composition_cli.rs
@@ -1,0 +1,303 @@
+//! Operator-side packaging; never runs source members or mounts input images.
+use anyhow::Result;
+use std::path::Path;
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use celln_manifest::{
+        closure::{Closure, Member},
+        Hash,
+    };
+    use celln_store::Store;
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        fs,
+    };
+
+    #[test]
+    fn composition_builds_real_image_and_source_revocation_survives_signing() {
+        let builder = Path::new("/usr/sbin/mke2fs");
+        if !builder.is_file() {
+            eprintln!("SKIP: mke2fs unavailable");
+            return;
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let members = Store::open(root.join("tools")).unwrap();
+        let descriptors = Store::open(root.join("closures")).unwrap();
+        let mut sources = Vec::new();
+        let mut publishers = BTreeSet::new();
+        let mut filesystem = String::new();
+        for (path, seed) in [("/harness", 1), ("/tools/tool", 2)] {
+            let hash = members.put(path.as_bytes()).unwrap();
+            let source = Closure {
+                api_version: "celln.dev/closure-v1".into(),
+                toolfs: Hash::of(format!("source filesystem {seed}").as_bytes()).0,
+                entrypoint: path.into(),
+                interpreter: false,
+                members: BTreeMap::from([(
+                    path.into(),
+                    Member {
+                        hash: hash.0,
+                        dependencies: BTreeSet::new(),
+                    },
+                )]),
+                sources: vec![],
+            }
+            .sign(&[seed; 32])
+            .unwrap();
+            filesystem = source.closure.toolfs.clone();
+            publishers.insert(source.publisher.clone());
+            sources.push(
+                descriptors
+                    .put(&serde_json::to_vec(&source).unwrap())
+                    .unwrap()
+                    .0,
+            );
+        }
+        // Use the runtime publisher as the independently authorized composer.
+        let key = root.join("key");
+        fs::write(&key, [1; 32]).unwrap();
+        let policy = root.join("trusted-closures.json");
+        let write_policy = |revoked: Vec<String>, allowed: &BTreeSet<String>| {
+            fs::write(
+                &policy,
+                serde_json::to_vec(
+                    &serde_json::json!({"apiVersion":"celln.dev/closure-policy-v1",
+                "publishers":allowed,"revoked":revoked}),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        };
+        write_policy(vec![], &publishers);
+        let plan = root.join("plan.json");
+        fs::write(
+            &plan,
+            serde_json::to_vec(
+                &serde_json::json!({"apiVersion":"celln.dev/composition-plan-v1",
+            "sources":sources,"imageBytes":33554432}),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let output = root.join("output");
+        let report = build(&plan, &key, &output, builder, root).unwrap();
+        let image = fs::read(output.join("toolfs.ext2")).unwrap();
+        assert_eq!(image.len(), 33554432);
+        assert_eq!(&image[1080..1082], &[0x53, 0xef]); // ext2 superblock magic
+        assert_eq!(report["toolfs"], Hash::of(&image).0);
+        let descriptor = fs::read(output.join("signed-closure.json")).unwrap();
+        crate::closure_policy::verify(&descriptor, root).unwrap();
+        assert!(build(&plan, &key, &output, builder, root).is_err());
+        assert_eq!(
+            fs::read(output.join("signed-closure.json")).unwrap(),
+            descriptor
+        );
+        for revoked in [sources[1].clone(), filesystem, Hash::of(b"/tools/tool").0] {
+            write_policy(vec![revoked], &publishers);
+            assert!(crate::closure_policy::verify(&descriptor, root).is_err());
+        }
+        let source = descriptors.get(&Hash(sources[1].clone())).unwrap();
+        let source: celln_manifest::closure::SignedClosure =
+            serde_json::from_slice(&source).unwrap();
+        publishers.remove(&source.publisher);
+        write_policy(vec![], &publishers);
+        assert!(crate::closure_policy::verify(&descriptor, root).is_err());
+        assert!(build(&plan, &key, &root.join("refused"), builder, root).is_err());
+        assert!(!root.join("refused").exists());
+    }
+}
+
+pub fn run(plan: &Path, key: &Path, output: &Path, builder: &Path, root: &Path) -> Result<u8> {
+    #[cfg(target_os = "linux")]
+    {
+        let report = build(plan, key, output, builder, root)?;
+        println!("{}", serde_json::to_string(&report)?);
+        Ok(0)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (plan, key, output, builder, root);
+        anyhow::bail!("Unsupported: closure composition requires Linux")
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn build(
+    plan: &Path,
+    key: &Path,
+    output: &Path,
+    builder: &Path,
+    root: &Path,
+) -> Result<serde_json::Value> {
+    use anyhow::ensure;
+    use celln_manifest::{
+        closure::composition::{compose, Source},
+        Hash,
+    };
+    use celln_store::Store;
+    use std::{
+        fs,
+        io::{Read, Write},
+        os::unix::fs::PermissionsExt,
+        time::Duration,
+    };
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    struct Plan {
+        api_version: String,
+        sources: Vec<String>,
+        image_bytes: usize,
+    }
+    let bytes = crate::closure_policy::read_bounded(plan).map_err(anyhow::Error::msg)?;
+    ensure!(bytes.len() <= 65536, "composition plan exceeds 64 KiB");
+    let plan: Plan = serde_json::from_slice(&bytes)?;
+    ensure!(
+        plan.api_version == "celln.dev/composition-plan-v1",
+        "unsupported composition plan"
+    );
+    ensure!(
+        !plan.sources.is_empty() && plan.sources.len() <= 17,
+        "expected runtime and at most 16 tools"
+    );
+    ensure!(
+        (32 * 1024 * 1024..=512 * 1024 * 1024).contains(&plan.image_bytes)
+            && plan.image_bytes % (2 * 1024 * 1024) == 0,
+        "image must be 32..512 MiB and 2 MiB aligned"
+    );
+    ensure!(
+        builder.is_absolute(),
+        "builder must be an absolute trusted operator path"
+    );
+    let descriptors = Store::open(root.join("closures"))?;
+    let mut sources = Vec::new();
+    let mut policy_hash = None;
+    for hash in &plan.sources {
+        let descriptor = descriptors.get_bounded(&Hash(hash.clone()), 262144)?;
+        let verified =
+            crate::closure_policy::verify(&descriptor, root).map_err(anyhow::Error::msg)?;
+        if let Some(previous) = &policy_hash {
+            ensure!(
+                previous == &verified.policy_hash,
+                "policy changed during composition"
+            );
+        }
+        policy_hash = Some(verified.policy_hash);
+        sources.push(Source {
+            hash: hash.clone(),
+            descriptor: String::from_utf8(descriptor)?,
+        });
+    }
+    let graph =
+        compose(sources.clone(), &Hash::of(b"pending image")).map_err(anyhow::Error::msg)?;
+    // Check the signing key and composer authorization before running the builder.
+    let provisional = crate::closure_cli::sign_descriptor(graph.clone(), key)?;
+    crate::closure_policy::verify(&serde_json::to_vec(&provisional)?, root)
+        .map_err(anyhow::Error::msg)?;
+    for path in graph.members.keys() {
+        ensure!(
+            path != "/tmp"
+                && !path.starts_with("/tmp/")
+                && path != "/lost+found"
+                && !path.starts_with("/lost+found/"),
+            "member uses reserved filesystem path"
+        );
+    }
+    // Fail if the destination exists. Its private permissions protect staging
+    // from another local user substituting a symlink during construction.
+    use std::os::unix::fs::DirBuilderExt;
+    fs::DirBuilder::new().mode(0o700).create(output)?;
+    let output = fs::canonicalize(output)?;
+    let staging = tempfile::Builder::new()
+        .prefix("members-")
+        .tempdir_in(&output)?;
+    let store = Store::open(root.join("tools"))?;
+    let mut remaining = plan.image_bytes - 8 * 1024 * 1024;
+    for (path, member) in &graph.members {
+        let data = store.get_bounded(&Hash(member.hash.clone()), remaining)?;
+        remaining -= data.len();
+        let target = staging.path().join(path.trim_start_matches('/'));
+        fs::create_dir_all(target.parent().unwrap())?;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&target)?;
+        file.write_all(&data)?;
+        file.set_permissions(fs::Permissions::from_mode(0o555))?;
+    }
+    fs::create_dir(staging.path().join("tmp"))?;
+    fs::set_permissions(
+        staging.path().join("tmp"),
+        fs::Permissions::from_mode(0o1777),
+    )?;
+    let image = output.join("toolfs.ext2");
+    let image_file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(&image)?;
+    image_file.set_len(plan.image_bytes as u64)?;
+    let args = vec![
+        "-q".into(),
+        "-t".into(),
+        "ext2".into(),
+        "-b".into(),
+        "4096".into(),
+        "-m".into(),
+        "0".into(),
+        "-d".into(),
+        staging
+            .path()
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("non UTF-8 staging path"))?
+            .into(),
+        "-F".into(),
+        image
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("non UTF-8 image path"))?
+            .into(),
+        (plan.image_bytes / 4096).to_string(),
+    ];
+    pilot::harness_io::child(
+        builder
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("non UTF-8 builder path"))?,
+        &args,
+        &[],
+        65536,
+        Duration::from_secs(45),
+    )?;
+    let mut image_bytes = Vec::new();
+    fs::File::open(&image)?
+        .take(plan.image_bytes as u64 + 1)
+        .read_to_end(&mut image_bytes)?;
+    ensure!(
+        image_bytes.len() == plan.image_bytes,
+        "builder changed image size"
+    );
+    let toolfs = Hash::of(&image_bytes);
+    image_file.sync_all()?;
+    let closure = compose(sources, &toolfs).map_err(anyhow::Error::msg)?;
+    let signed = crate::closure_cli::sign_descriptor(closure, key)?;
+    let descriptor = serde_json::to_vec(&signed)?;
+    let verified = crate::closure_policy::verify(&descriptor, root).map_err(anyhow::Error::msg)?;
+    ensure!(
+        Some(&verified.policy_hash) == policy_hash.as_ref(),
+        "policy changed during composition"
+    );
+    // Descriptor is the final publication marker. A failed build leaves only
+    // an explicitly named diagnostic directory, never an admitted artifact.
+    let mut file = tempfile::NamedTempFile::new_in(&output)?;
+    file.write_all(&descriptor)?;
+    file.as_file().sync_all()?;
+    file.persist_noclobber(output.join("signed-closure.json"))?;
+    fs::File::open(&output)?.sync_all()?;
+    Ok(
+        serde_json::json!({"apiVersion":"celln.dev/composition-report-v1", "planHash":Hash::of(&bytes).0,
+        "policyHash":verified.policy_hash.0, "closure":verified.identity.0,"toolfs":toolfs.0,
+        "sources":plan.sources,"artifactReadiness":"not_checked","conformance":"not_checked"}),
+    )
+}

--- a/crates/celln-cli/src/dispatch_closure_tests.rs
+++ b/crates/celln-cli/src/dispatch_closure_tests.rs
@@ -115,6 +115,7 @@ fn signed_closure_on_real_kvm() {
     let image_hash = Hash::of(&image_bytes);
     let signed = Closure {
         api_version: "celln.dev/closure-v1".into(),
+        sources: Vec::new(),
         toolfs: image_hash.0.clone(),
         entrypoint: "/bin/program".into(),
         interpreter: false,
@@ -206,7 +207,7 @@ fn signed_closure_on_real_kvm() {
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/celln"));
     let cli_bytes = command(
-        Command::new(binary)
+        Command::new(&binary)
             .arg("--root")
             .arg(&state)
             .args(["closure", "check-members"])
@@ -235,6 +236,91 @@ fn signed_closure_on_real_kvm() {
         preparations + 1
     );
     assert_eq!(crate::cells::live_count(&state), 0);
+    // Exercise the actual compositor CLI with a dynamic source closure, then
+    // verify and execute its newly built image inside a sealed warm-forked cell.
+    let member_store = Store::open(&tools).unwrap();
+    for path in signed.closure.members.keys() {
+        member_store
+            .put(&std::fs::read(rootfs.join(path.trim_start_matches('/'))).unwrap())
+            .unwrap();
+    }
+    let plan = work.path().join("composition-plan.json");
+    std::fs::write(
+        &plan,
+        serde_json::to_vec(&json!({"apiVersion":"celln.dev/composition-plan-v1",
+        "sources":[closure_hash.0],"imageBytes":33554432}))
+        .unwrap(),
+    )
+    .unwrap();
+    let key = work.path().join("fixture-seed");
+    std::fs::write(&key, [17; 32]).unwrap();
+    let composed_dir = work.path().join("composed");
+    command(
+        Command::new(&binary)
+            .arg("--root")
+            .arg(&state)
+            .args(["closure", "compose"])
+            .arg(&plan)
+            .arg("--key-file")
+            .arg(&key)
+            .arg("--output-dir")
+            .arg(&composed_dir),
+    );
+    let composed_bytes = std::fs::read(composed_dir.join("signed-closure.json")).unwrap();
+    let composed = crate::closure_policy::verify(&composed_bytes, &state).unwrap();
+    assert_eq!(composed.signed.closure.api_version, "celln.dev/closure-v2");
+    let composed_hash = closure_store.put(&composed_bytes).unwrap();
+    let composed_image = store
+        .put(&std::fs::read(composed_dir.join("toolfs.ext2")).unwrap())
+        .unwrap();
+    let composed_bundle = store.put(&serde_json::to_vec(&json!({"apiVersion":"celln.dev/v1alpha1",
+        "format":"celln.warm-closure-v1","kernel":kernel_hash.0,"initrd":initrd_hash.0,
+        "toolfs":composed_image.0,"invocation":{"alias":"/closure/program","toolHash":program_hash.0}})).unwrap()).unwrap();
+    std::fs::write(
+        state.join("trusted-motes.json"),
+        serde_json::to_vec(&json!({"apiVersion":"celln.dev/v1alpha1",
+        "bundles":[bundle.0,composed_bundle.0]}))
+        .unwrap(),
+    )
+    .unwrap();
+    let mut composed_request = request.clone();
+    composed_request.id = "composed-closure-proof".into();
+    composed_request.mote.as_mut().unwrap().hash = composed_bundle.0;
+    composed_request.tools[0].closure.as_mut().unwrap().hash = composed_hash.0;
+    let mut composed_check = composed_request.clone();
+    composed_check.capabilities.workspace = serde_json::from_value(json!("none")).unwrap();
+    composed_check.invocation.as_mut().unwrap().args.clear();
+    let report = super::super::check_members(&composed_check, &motes, &tools, &state).unwrap();
+    assert_eq!(report["memberIntegrity"], "verified-in-sealed-cell");
+    let (out, _) =
+        super::super::launch_declared(&composed_request, &motes, &tools, &state).unwrap();
+    assert!(out.succeeded(), "{out:?}");
+    assert_eq!(
+        out.output.as_deref(),
+        Some(b"closure:read-write:dynamic-loader:replacement-denied\n".as_slice())
+    );
+    let mut source_revoked = policy.clone();
+    source_revoked["revoked"] = json!([closure_hash.0]);
+    std::fs::write(
+        state.join("trusted-closures.json"),
+        serde_json::to_vec(&source_revoked).unwrap(),
+    )
+    .unwrap();
+    assert!(
+        super::super::launch_declared(&composed_request, &motes, &tools, &state)
+            .unwrap_err()
+            .contains("revoked")
+    );
+    std::fs::write(
+        state.join("trusted-closures.json"),
+        serde_json::to_vec(&policy).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(crate::cells::live_count(&state), 0);
+    // The composed image can evict the original single-entry warm fixture.
+    // Prepare the original again before its existing live-withdrawal checks.
+    let (restored, _) = super::super::launch_declared(&request, &motes, &tools, &state).unwrap();
+    assert!(restored.succeeded(), "{restored:?}");
     let mut revoked_cell = super::super::warm::fork(
         format!("{}:268435456", bundle.0),
         vec![program_hash.0.clone()],

--- a/crates/celln-cli/src/dispatch_harness.rs
+++ b/crates/celln-cli/src/dispatch_harness.rs
@@ -98,7 +98,7 @@ pub fn resolve(
         return Err("unsupported Harness model policy".into());
     }
     let c = &closure.signed.closure;
-    // Static adapter only. Broader closures require a dependency/tool contract.
+    // Callable roots are distinct from their signed dependency members.
     let mut expected = std::collections::BTreeSet::from([c.entrypoint.as_str(), "/pilot-fetch"]);
     if expected.len() != 2 {
         return Err("Harness runtime cannot be the broker client".into());
@@ -112,12 +112,38 @@ pub fn resolve(
             return Err("borrowed tool is not a distinct matching closure member".into());
         }
     }
-    if c.interpreter
-        || c.members
-            .keys()
-            .map(String::as_str)
-            .collect::<std::collections::BTreeSet<_>>()
-            != expected
+    if c.interpreter {
+        return Err("unsupported Harness interpreter closure".into());
+    }
+    if c.api_version == "celln.dev/closure-v2" {
+        if binding.contract_version != "celln.json-tools/v1" {
+            return Err("composed closures require the JSON Harness contract".into());
+        }
+        // Admission checks signatures and live source policy. Reconstruct the
+        // source-derived graph here too; accepting extra files based merely on
+        // a composer signature would broaden the selected tool authority.
+        c.validate()?;
+        if c.sources.len() != binding.borrowed_tools.len() + 1 {
+            return Err("composition sources do not match selected tools".into());
+        }
+        let runtime = c.sources[0].parse()?.closure;
+        if runtime.entrypoint != c.entrypoint || !runtime.members.contains_key("/pilot-fetch") {
+            return Err("runtime source must own the Harness and broker client".into());
+        }
+        for (source, tool) in c.sources.iter().skip(1).zip(&binding.borrowed_tools) {
+            let source = source.parse()?.closure;
+            if source.entrypoint != tool.path
+                || source.members[&source.entrypoint].hash != tool.hash
+            {
+                return Err("composition source order or root differs from selected tools".into());
+            }
+        }
+    } else if c
+        .members
+        .keys()
+        .map(String::as_str)
+        .collect::<std::collections::BTreeSet<_>>()
+        != expected
     {
         return Err("unsupported Harness closure composition".into());
     }
@@ -271,6 +297,7 @@ mod tests {
         // this unit test exercises binding, not filesystem/signature admission.
         let signed = Closure {
             api_version: "celln.dev/closure-v1".into(),
+            sources: Vec::new(),
             toolfs: Hash::of(b"image").0,
             entrypoint: "/harness".into(),
             interpreter: false,

--- a/crates/celln-cli/src/dispatch_harness_json_tests.rs
+++ b/crates/celln-cli/src/dispatch_harness_json_tests.rs
@@ -6,6 +6,78 @@ use std::collections::{BTreeMap, BTreeSet};
 
 const SCHEMA: &str = r#"{"type":"object","properties":{"text":{"type":"string","minLength":0,"maxLength":64}},"required":["text"],"additionalProperties":false}"#;
 
+#[test]
+fn composed_json_sources_bind_exact_selected_roots_and_keep_dependencies_out_of_tool_list() {
+    use celln_manifest::closure::composition::{compose, Source};
+    let root = tempfile::tempdir().unwrap();
+    let (mut request, mut admitted, mut grant) = fixture(root.path());
+    let original = &admitted.signed.closure;
+    let mut runtime = original.clone();
+    for tool in &request.harness.as_ref().unwrap().borrowed_tools {
+        runtime.members.remove(&tool.path);
+        runtime
+            .members
+            .get_mut("/harness")
+            .unwrap()
+            .dependencies
+            .remove(&tool.path);
+    }
+    let to_source = |closure: Closure| {
+        let descriptor = serde_json::to_string(&closure.sign(&[19; 32]).unwrap()).unwrap();
+        Source {
+            hash: Hash::of(descriptor.as_bytes()).0,
+            descriptor,
+        }
+    };
+    let mut sources = vec![to_source(runtime)];
+    for tool in &request.harness.as_ref().unwrap().borrowed_tools {
+        let library = "/lib/shared.so".to_string();
+        let mut member = original.members[&tool.path].clone();
+        member.dependencies.insert(library.clone());
+        sources.push(to_source(Closure {
+            api_version: "celln.dev/closure-v1".into(),
+            sources: vec![],
+            toolfs: Hash::of(tool.path.as_bytes()).0,
+            entrypoint: tool.path.clone(),
+            interpreter: false,
+            members: BTreeMap::from([
+                (tool.path.clone(), member),
+                (
+                    library,
+                    Member {
+                        hash: Hash::of(b"shared library").0,
+                        dependencies: BTreeSet::new(),
+                    },
+                ),
+            ]),
+        }));
+    }
+    let mut bind = |sources: Vec<Source>| {
+        let signed = compose(sources, &Hash::of(b"composed image"))
+            .unwrap()
+            .sign(&[19; 32])
+            .unwrap();
+        let identity = Hash::of(&serde_json::to_vec(&signed).unwrap()).0;
+        admitted.provenance.hash = identity.clone();
+        admitted.provenance.toolfs = signed.closure.toolfs.clone();
+        admitted.provenance.members = signed.closure.members.clone();
+        admitted.signed = signed;
+        request.tools[0].closure.as_mut().unwrap().hash = identity.clone();
+        grant["closure"] = json!(identity);
+        install(root.path(), &mut request, &grant);
+        resolve(&request, Some(&admitted), root.path())
+    };
+    let resolved = bind(sources.clone()).unwrap().unwrap();
+    let config: Value = serde_json::from_str(&resolved.args[0]).unwrap();
+    assert_eq!(config["tools"].as_array().unwrap().len(), 2);
+    assert!(!resolved.args[0].contains("shared.so"));
+    let mut reordered = sources.clone();
+    reordered.swap(1, 2);
+    assert!(bind(reordered).err().unwrap().contains("order or root"));
+    sources.pop();
+    assert!(bind(sources).is_err());
+}
+
 fn fixture(root: &Path) -> (ExecutionRequest, super::super::closure::Admitted, Value) {
     let mut wire: Value = serde_json::from_str(include_str!(
         "../../../examples/execution/harness-reference.json"
@@ -50,6 +122,7 @@ fn fixture(root: &Path) -> (ExecutionRequest, super::super::closure::Admitted, V
     );
     let signed = Closure {
         api_version: "celln.dev/closure-v1".into(),
+        sources: Vec::new(),
         toolfs: Hash::of(b"image").0,
         entrypoint: "/harness".into(),
         interpreter: false,

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -5,6 +5,7 @@ mod capabilities;
 mod cells;
 mod closure_cli;
 mod closure_policy;
+mod composition_cli;
 mod config;
 mod dispatch;
 #[cfg(all(test, target_os = "linux"))]
@@ -336,6 +337,16 @@ enum NodeCmd {
 
 #[derive(Subcommand)]
 enum ClosureCmd {
+    /// Build and sign a filesystem from exact approved source closures and member blobs.
+    Compose {
+        plan: PathBuf,
+        #[arg(long)]
+        key_file: PathBuf,
+        #[arg(long)]
+        output_dir: PathBuf,
+        #[arg(long, default_value = "/usr/sbin/mke2fs")]
+        builder: PathBuf,
+    },
     /// Hash signed closure members inside a sealed cell without executing them.
     /// Requires an operator-pinned declared request, with empty args and no egress.
     CheckMembers { request: PathBuf },
@@ -430,6 +441,12 @@ fn resolve_root(explicit: &Option<PathBuf>) -> PathBuf {
 fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
     let root = resolve_root(&cli.root);
     match &cli.cmd {
+        Cmd::Closure(ClosureCmd::Compose {
+            plan,
+            key_file,
+            output_dir,
+            builder,
+        }) => composition_cli::run(plan, key_file, output_dir, builder, &root),
         Cmd::Schema(SchemaCmd::Verify {
             schema,
             expected_hash,

--- a/crates/celln-cli/tests/closure_verify.rs
+++ b/crates/celln-cli/tests/closure_verify.rs
@@ -14,6 +14,7 @@ fn cli_verification_is_bound_read_only_and_rechecks_policy() {
     let executable = Hash::of(b"test executable").0;
     let signed = Closure {
         api_version: "celln.dev/closure-v1".into(),
+        sources: Vec::new(),
         toolfs: Hash::of(b"test toolfs").0,
         entrypoint: "/tools/test".into(),
         interpreter: false,

--- a/crates/celln-manifest/src/closure.rs
+++ b/crates/celln-manifest/src/closure.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 const DOMAIN: &[u8] = b"celln.dev/closure-v1\0";
+const COMPOSITION_DOMAIN: &[u8] = b"celln.dev/closure-v2\0";
+
+#[path = "composition.rs"]
+pub mod composition;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -18,9 +22,13 @@ pub struct Closure {
     /// Every admitted code file, keyed by canonical absolute path. Dependencies
     /// name other members; composition never consults a host library directory.
     pub members: BTreeMap<String, Member>,
+    /// v2 only: exact signed v1 inputs, runtime first. Keeping these inside the
+    /// signed message preserves source identity and withdrawal checks.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sources: Vec<composition::Source>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Member {
     pub hash: String,
@@ -77,7 +85,10 @@ fn decode<const N: usize>(value: &str) -> Result<[u8; N], String> {
 
 impl Closure {
     pub fn validate(&self) -> Result<(), String> {
-        if self.api_version != "celln.dev/closure-v1"
+        if !matches!(
+            self.api_version.as_str(),
+            "celln.dev/closure-v1" | "celln.dev/closure-v2"
+        ) || (self.api_version == "celln.dev/closure-v1" && !self.sources.is_empty())
             || !hash(&self.toolfs)
             || self.members.is_empty()
             || self.members.len() > 256
@@ -108,12 +119,26 @@ impl Closure {
         if seen.len() != self.members.len() {
             return Err("closure contains unreachable code members".into());
         }
+        if self.api_version == "celln.dev/closure-v2" {
+            let expected = composition::compose(self.sources.clone(), &Hash(self.toolfs.clone()))?;
+            if self.entrypoint != expected.entrypoint
+                || self.interpreter != expected.interpreter
+                || self.members != expected.members
+            {
+                return Err("composed closure differs from its signed source graph".into());
+            }
+        }
         Ok(())
     }
 
     fn message(&self) -> Result<Vec<u8>, String> {
         self.validate()?;
-        let mut message = DOMAIN.to_vec();
+        let mut message = if self.api_version == "celln.dev/closure-v2" {
+            COMPOSITION_DOMAIN
+        } else {
+            DOMAIN
+        }
+        .to_vec();
         message.extend(serde_json::to_vec(self).map_err(|e| e.to_string())?);
         Ok(message)
     }
@@ -134,6 +159,9 @@ impl SignedClosure {
     pub fn verify(&self, publishers: &BTreeSet<String>) -> Result<(), String> {
         if !publishers.contains(&self.publisher) {
             return Err("closure publisher is not authorized".into());
+        }
+        for source in &self.closure.sources {
+            source.parse()?.verify(publishers)?;
         }
         let key = VerifyingKey::from_bytes(&decode(&self.publisher)?)
             .map_err(|_| "invalid closure publisher key")?;
@@ -157,6 +185,7 @@ mod tests {
     fn fixture() -> Closure {
         Closure {
             api_version: "celln.dev/closure-v1".into(),
+            sources: Vec::new(),
             toolfs: Hash::of(b"filesystem").0,
             entrypoint: "/bin/program".into(),
             interpreter: false,

--- a/crates/celln-manifest/src/composition.rs
+++ b/crates/celln-manifest/src/composition.rs
@@ -1,0 +1,221 @@
+//! Deterministic signed-source graph composition; no I/O or authority defaults.
+use super::{Closure, Member, SignedClosure};
+use crate::Hash;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Source {
+    pub hash: String,
+    /// Exact original JSON bytes, not a reserialized descriptor identity.
+    pub descriptor: String,
+}
+
+impl Source {
+    pub fn parse(&self) -> Result<SignedClosure, String> {
+        if self.descriptor.len() > 262144 || Hash::of(self.descriptor.as_bytes()).0 != self.hash {
+            return Err("composition source identity or byte limit mismatch".into());
+        }
+        let signed: SignedClosure =
+            serde_json::from_str(&self.descriptor).map_err(|_| "invalid composition source")?;
+        // No recursive/nested composition: bounded provenance stays directly
+        // inspectable, and an input cannot smuggle a second authority graph.
+        if signed.closure.api_version != "celln.dev/closure-v1"
+            || !signed.closure.sources.is_empty()
+        {
+            return Err("composition requires original v1 signed sources".into());
+        }
+        signed.verify(&BTreeSet::from([signed.publisher.clone()]))?;
+        Ok(signed)
+    }
+}
+
+/// Runtime first, followed by explicitly selected tool closures. Shared members
+/// must agree in bytes AND dependencies. No relocation or host library lookup.
+/// This checks signatures, not caller authorization: the host must independently
+/// authorize every source publisher and check current revocation policy.
+pub fn compose(sources: Vec<Source>, toolfs: &Hash) -> Result<Closure, String> {
+    if sources.is_empty() || sources.len() > 17 || !super::hash(&toolfs.0) {
+        return Err("composition requires 1..17 sources and a filesystem hash".into());
+    }
+    let source_bytes = serde_json::to_vec(&sources).map_err(|_| "invalid sources")?;
+    if source_bytes.len() > 196608 {
+        return Err("composition source envelope exceeds 192 KiB".into());
+    }
+    let signed = sources
+        .iter()
+        .map(Source::parse)
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut roots = BTreeSet::new();
+    let mut identities = BTreeSet::new();
+    for (source, descriptor) in sources.iter().zip(&signed) {
+        if !roots.insert(descriptor.closure.entrypoint.clone()) || !identities.insert(&source.hash)
+        {
+            return Err("duplicate composition source or entrypoint".into());
+        }
+    }
+    let mut members: BTreeMap<String, Member> = BTreeMap::new();
+    for source in &signed {
+        for (path, member) in &source.closure.members {
+            if roots.contains(path) && path != &source.closure.entrypoint {
+                return Err("selected entrypoint collides with another source dependency".into());
+            }
+            if let Some(existing) = members.get(path) {
+                if existing != member {
+                    return Err("composition member hash or dependency collision".into());
+                }
+            } else {
+                members.insert(path.clone(), member.clone());
+                if members.len() > 256 {
+                    return Err("composed graph exceeds 256 members".into());
+                }
+            }
+        }
+    }
+    let entrypoint = signed[0].closure.entrypoint.clone();
+    for path in members.keys() {
+        let mut parent = path.as_str();
+        while let Some((prefix, _)) = parent.rsplit_once('/') {
+            if members.contains_key(prefix) {
+                return Err("composition file collides with a parent directory".into());
+            }
+            parent = prefix;
+        }
+    }
+    members
+        .get_mut(&entrypoint)
+        .unwrap()
+        .dependencies
+        .extend(signed.iter().skip(1).map(|s| s.closure.entrypoint.clone()));
+    let composed = Closure {
+        api_version: "celln.dev/closure-v2".into(),
+        toolfs: toolfs.0.clone(),
+        entrypoint,
+        interpreter: signed.iter().any(|s| s.closure.interpreter),
+        members,
+        sources,
+    };
+    if serde_json::to_vec(&composed)
+        .map_err(|_| "invalid composition")?
+        .len()
+        > 262144 - 512
+    {
+        return Err("composed descriptor exceeds signed delivery envelope".into());
+    }
+    Ok(composed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn source(path: &str, library: &[u8], seed: u8) -> Source {
+        let members = BTreeMap::from([
+            (
+                path.into(),
+                Member {
+                    hash: Hash::of(path.as_bytes()).0,
+                    dependencies: BTreeSet::from(["/lib/shared.so".into()]),
+                },
+            ),
+            (
+                "/lib/shared.so".into(),
+                Member {
+                    hash: Hash::of(library).0,
+                    dependencies: BTreeSet::new(),
+                },
+            ),
+        ]);
+        let signed = Closure {
+            api_version: "celln.dev/closure-v1".into(),
+            toolfs: Hash::of(path.as_bytes()).0,
+            entrypoint: path.into(),
+            interpreter: false,
+            members,
+            sources: vec![],
+        }
+        .sign(&[seed; 32])
+        .unwrap();
+        let descriptor = serde_json::to_string_pretty(&signed).unwrap();
+        Source {
+            hash: Hash::of(descriptor.as_bytes()).0,
+            descriptor,
+        }
+    }
+
+    #[test]
+    fn composition_preserves_sources_graph_and_independent_publishers() {
+        let sources = vec![
+            source("/harness", b"library", 1),
+            source("/tool", b"library", 2),
+        ];
+        let mut publishers: BTreeSet<_> = sources
+            .iter()
+            .map(|s| s.parse().unwrap().publisher)
+            .collect();
+        let input_publisher = sources[1].parse().unwrap().publisher;
+        let closure = compose(sources, &Hash::of(b"new filesystem")).unwrap();
+        assert_eq!(closure.members.len(), 3);
+        assert!(closure.members["/harness"].dependencies.contains("/tool"));
+        let signed = closure.sign(&[3; 32]).unwrap();
+        publishers.insert(signed.publisher.clone());
+        signed.verify(&publishers).unwrap();
+        publishers.remove(&input_publisher);
+        assert!(
+            signed.verify(&publishers).is_err(),
+            "composer signature cannot replace source approval"
+        );
+        let mut tampered = signed.clone();
+        publishers.insert(input_publisher);
+        tampered.closure.sources[0].descriptor.push(' ');
+        assert!(tampered.verify(&publishers).is_err());
+    }
+
+    #[test]
+    fn conflicting_graphs_nested_inputs_and_downgraded_taint_refuse() {
+        let runtime = source("/harness", b"library", 1);
+        assert!(compose(
+            vec![runtime.clone(), source("/tool", b"different", 2)],
+            &Hash::of(b"fs")
+        )
+        .is_err());
+        assert!(compose(vec![runtime.clone(), runtime.clone()], &Hash::of(b"fs")).is_err());
+        assert!(compose(
+            vec![runtime.clone(), source("/harness/child", b"library", 2)],
+            &Hash::of(b"fs")
+        )
+        .is_err());
+        let mut tool = source("/tool", b"library", 2).parse().unwrap().closure;
+        tool.interpreter = true;
+        let descriptor = serde_json::to_string(&tool.sign(&[2; 32]).unwrap()).unwrap();
+        let tainted = Source {
+            hash: Hash::of(descriptor.as_bytes()).0,
+            descriptor,
+        };
+        let mut composed = compose(vec![runtime.clone(), tainted], &Hash::of(b"fs")).unwrap();
+        assert!(composed.interpreter);
+        composed.interpreter = false;
+        assert!(composed.sign(&[3; 32]).is_err());
+        let signed = compose(vec![runtime], &Hash::of(b"fs"))
+            .unwrap()
+            .sign(&[3; 32])
+            .unwrap();
+        let descriptor = serde_json::to_string(&signed).unwrap();
+        assert!(Source {
+            hash: Hash::of(descriptor.as_bytes()).0,
+            descriptor
+        }
+        .parse()
+        .is_err());
+    }
+
+    #[test]
+    fn legacy_signature_encoding_remains_unchanged_and_v1_cannot_hide_sources() {
+        let original = source("/harness", b"library", 1);
+        let signed = original.parse().unwrap();
+        assert!(!serde_json::to_string(&signed).unwrap().contains("sources"));
+        let mut illegal = signed.closure;
+        illegal.sources.push(original);
+        assert!(illegal.sign(&[1; 32]).is_err());
+    }
+}

--- a/crates/celln-pilot/src/harness_proof.rs
+++ b/crates/celln-pilot/src/harness_proof.rs
@@ -98,6 +98,7 @@ fn main() -> Result<()> {
     std::fs::File::open("/dev/urandom")?.read_exact(&mut seed)?;
     let signed = Closure {
         api_version: "celln.dev/closure-v1".into(),
+        sources: Vec::new(),
         toolfs: Hash::of(&payload).0,
         entrypoint: "/harness".into(),
         interpreter: false,

--- a/crates/celln-pilot/src/json_harness_proof.rs
+++ b/crates/celln-pilot/src/json_harness_proof.rs
@@ -95,6 +95,7 @@ fn main() -> Result<()> {
         .collect();
     let signed = Closure {
         api_version: "celln.dev/closure-v1".into(),
+        sources: Vec::new(),
         toolfs: Hash::of(&payload).0,
         entrypoint: "/harness".into(),
         interpreter: false,

--- a/docs/CLOSURE_COMPOSITION.md
+++ b/docs/CLOSURE_COMPOSITION.md
@@ -1,0 +1,82 @@
+# Signed-source filesystem composition
+
+`celln closure compose` is operator-side packaging for the Harness/tool
+catalogue integration. It does not admit, distribute, prewarm or certify a
+selection, and is not yet connected to the high-level Sympozium picker.
+
+A bounded JSON plan names exact descriptor-byte identities, runtime first:
+
+```json
+{
+  "apiVersion": "celln.dev/composition-plan-v1",
+  "sources": ["blake3:<runtime descriptor>", "blake3:<tool descriptor>"],
+  "imageBytes": 33554432
+}
+```
+
+Run with a trusted Linux filesystem builder and an independently authorized
+composer key (exactly 32 raw private seed bytes):
+
+```sh
+celln --root /var/lib/celln closure compose plan.json \
+  --key-file /secure/composer.seed --output-dir /var/tmp/new-composition
+```
+
+The destination must not exist. Sources are original signed closure-v1
+descriptors in the root's `closures` store. Every member must be present by
+content hash in its `tools` store. All source publishers and the composer must
+be allowed by the current `trusted-closures.json`; revoked inputs refuse.
+No source executable runs, input filesystem is mounted, or host library is
+implicitly imported. Shared paths must agree in both bytes and dependency
+edges; selected entrypoint collisions and file/directory collisions refuse.
+`/tmp` and `/lost+found` are reserved. The combined interpreter flag cannot be
+downgraded.
+
+The resulting `toolfs.ext2` contains the union of those exact members, and
+`signed-closure.json` authenticates a closure-v2 graph retaining the exact
+signed source descriptors. Verification independently checks source publishers
+and source descriptor/filesystem revocations, as well as final image, member
+and descriptor revocations. A composer signature cannot replace source trust.
+Original v1 signature encoding remains unchanged. Nested composition is not
+accepted: source count is bounded to one runtime plus at most 16 tools, the
+combined graph to 256 members, and the signed descriptor to 256 KiB.
+
+Image size is 32–512 MiB, aligned to 2 MiB. The builder has a 45-second deadline
+and bounded output. Source bytes have an aggregate image-size-minus-8-MiB cap;
+filesystem overhead can still cause an explicit build failure. Graph
+composition is deterministic; ext2 byte reproducibility is **not claimed**.
+Policy is rechecked before publishing the descriptor, with policy changes
+refused. Failed builds may leave an explicitly named output directory for
+diagnosis, but no artifact is automatically admitted. Temporary member staging
+is removed on normal return or error.
+
+The report explicitly says `artifactReadiness: not_checked` and
+`conformance: not_checked`. Source filesystem provenance is retained, but this
+command does not prove that original source filesystems matched their member
+graphs. Sealed guest member verification, runtime/tool functional conformance,
+distribution, serving-process prewarm and request-specific grants remain
+separate mandatory checks before execution. Neither a successful build nor
+an approved catalogue record is permission to execute a composition.
+
+## Dispatch and validation
+
+The JSON Harness contract accepts v2 only when the ordered source roots match
+the runtime and every explicitly selected tool. The runtime source must include
+`/pilot-fetch`. Shared signed dependencies do not become entries in the model's
+callable tool list. The reference contract retains its static member restriction;
+interpreter closures remain unsupported by Harness dispatch. Exact host grants
+and the existing sealed execution gate still apply.
+
+Portable tests cover conflicting members/graphs, source order, omitted tools,
+publisher/source/filesystem/member withdrawal, v1 encoding compatibility, and
+an actual ext2 build. The explicit `signed_closure_on_real_kvm` test additionally
+feeds a signed dynamic closure through the compositor CLI, checks its generated
+image's members inside a sealed cell, executes the dynamic program with guest
+mutation attempts, and refuses a subsequent run after source revocation. This
+is a compositor/dynamic-execution proof, not a catalogue-backed model journey.
+
+```sh
+CELLN_TEST_BINARY=/absolute/path/to/built/celln \
+CELLN_PILOT_DIR=/absolute/path/to/static/pilot/binaries \
+  cargo test -p celln-cli signed_closure_on_real_kvm -- --ignored --nocapture
+```


### PR DESCRIPTION
Progresses sympozium-ai/sympozium#426 (M1/M3 composition), not a closure of the epic.

Implements versioned closure-v2 retaining exact signed v1 source descriptors, independent input publisher verification, and source descriptor/filesystem/member revocation. The operator CLI builds ext2 from verified member blobs without executing sources or looking up host libraries. JSON Harness dispatch binds ordered source roots to selected tools while retaining signed dependencies outside the model tool list. Legacy reference restrictions and v1 signature encoding remain intact.

Validation: make ci; all-target/all-feature Clippy with warnings denied; real ext2 build and revocation tests; JSON source-order/selection tests; explicit real-KVM signed_closure_on_real_kvm passed, including actual compositor CLI image construction, sealed guest member verification, dynamic execution/mutation attempts and subsequent source-revocation refusal.

Scope limits: not catalogue selection/grant issuance, distribution/prewarm, UI, conversations, or a composed catalogue-backed AI E2E proof. Readiness and conformance are not inferred from packaging. Interpreter Harness dispatch remains unsupported. See docs/CLOSURE_COMPOSITION.md.