### PR TITLE
feat: serving-process artifact verification and prewarm

### DIFF
--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -19,6 +19,7 @@ pub(crate) mod harness;
 mod substrate;
 pub(crate) use substrate::check_members;
 pub(crate) use substrate::launch_declared;
+pub(crate) use substrate::validate_member_request;
 #[path = "dispatch_inputs.rs"]
 pub(crate) mod inputs;
 #[cfg(target_os = "linux")]

--- a/crates/celln-cli/src/dispatch_closure_tests.rs
+++ b/crates/celln-cli/src/dispatch_closure_tests.rs
@@ -292,6 +292,7 @@ fn signed_closure_on_real_kvm() {
     composed_check.invocation.as_mut().unwrap().args.clear();
     let report = super::super::check_members(&composed_check, &motes, &tools, &state).unwrap();
     assert_eq!(report["memberIntegrity"], "verified-in-sealed-cell");
+    crate::dispatch_http::prove_prewarm_on_kvm(&composed_check, &state, &closure_hash.0);
     let (out, _) =
         super::super::launch_declared(&composed_request, &motes, &tools, &state).unwrap();
     assert!(out.succeeded(), "{out:?}");

--- a/crates/celln-cli/src/dispatch_harness_tests.rs
+++ b/crates/celln-cli/src/dispatch_harness_tests.rs
@@ -184,6 +184,7 @@ fn model_over_authenticated_dispatch(json_adapter: bool) {
     }
     assert!(request.problems().is_empty(), "{:?}", request.problems());
     let state = State {
+        prewarm: Mutex::new(None),
         token_file: PathBuf::new(),
         token: "test-token-at-least-24-bytes".into(),
         egress_policy: EgressPolicy::new(&["api.deepseek.com".into()]).unwrap(),

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -13,11 +13,15 @@ mod audit;
 mod harness_tests;
 #[path = "dispatch_journal.rs"]
 mod journal;
+#[path = "dispatch_prewarm.rs"]
+mod prewarm;
 use anyhow::{bail, Context, Result};
 use celln_spec::{
     ExecutionOutput, ExecutionPhase, ExecutionReceipt, ExecutionRequest, ResolvedExecution,
 };
 use celln_store::Store;
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) use prewarm::prove_prewarm_on_kvm;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
 use std::io::{BufRead, BufReader, Read, Write};
@@ -201,6 +205,14 @@ fn current_node(
     let mut node = crate::node::NodeEligibility::from_probe(&state.probe, 0);
     let other = crate::cells::live_count_excluding_pid(&state.root, Some(std::process::id()));
     apply_reservations(&mut node, registry, other);
+    if let Some(reservation) = *state
+        .prewarm
+        .lock()
+        .expect("prewarm reservation not poisoned")
+    {
+        node.live_cells = node.live_cells.saturating_add(1);
+        node.memory_bytes = node.memory_bytes.saturating_sub(reservation.memory_bytes);
+    }
     node
 }
 
@@ -212,6 +224,7 @@ struct State {
     root: PathBuf,
     probe: NodeProbeArgs,
     executions: Executions,
+    prewarm: Mutex<Option<Reservation>>,
 }
 
 /// Reopen the path each time: projected Secrets replace symlinks during rotation.
@@ -336,6 +349,7 @@ pub fn serve(
         root,
         probe: probe.clone(),
         executions: Arc::new(Mutex::new(HashMap::new())),
+        prewarm: Mutex::new(None),
     });
     if non_loopback {
         eprintln!(
@@ -422,6 +436,9 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
         }
     }
     match (method.as_str(), path.as_str()) {
+        ("POST", "/v1/artifacts/prewarm") => {
+            prewarm::handle(state, &mut stream, &mut reader, length)
+        }
         ("GET", "/v1/capabilities") => {
             let registry = state
                 .executions
@@ -1000,6 +1017,7 @@ mod tests {
                 egress_slots: 0,
             },
             executions: Arc::new(Mutex::new(HashMap::new())),
+            prewarm: Mutex::new(None),
         }
     }
 
@@ -1511,6 +1529,7 @@ mod tests {
                 egress_slots: 0,
             },
             executions: Arc::new(Mutex::new(HashMap::new())),
+            prewarm: Mutex::new(None),
         };
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();

--- a/crates/celln-cli/src/dispatch_prewarm.rs
+++ b/crates/celln-cli/src/dispatch_prewarm.rs
@@ -1,0 +1,142 @@
+//! Authenticated serving-process member verification and warm-cache observation.
+use super::*;
+
+#[cfg(test)]
+#[path = "dispatch_prewarm_tests.rs"]
+mod tests;
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) fn prove_prewarm_on_kvm(request: &ExecutionRequest, root: &Path, source: &str) {
+    tests::prove_prewarm_on_kvm(request, root, source);
+}
+
+struct Lease<'a>(&'a State);
+impl Drop for Lease<'_> {
+    fn drop(&mut self) {
+        *self
+            .0
+            .prewarm
+            .lock()
+            .expect("prewarm reservation not poisoned") = None;
+    }
+}
+
+pub(super) fn handle(
+    state: &State,
+    stream: &mut TcpStream,
+    reader: &mut impl Read,
+    length: usize,
+) -> Result<()> {
+    if length > 65536 {
+        return reply(
+            stream,
+            413,
+            &serde_json::json!({"error":"prewarm request exceeds 64 KiB"}),
+        );
+    }
+    let mut bytes = vec![0; length];
+    reader.read_exact(&mut bytes)?;
+    let request: ExecutionRequest = match serde_json::from_slice(&bytes) {
+        Ok(r) => r,
+        Err(_) => {
+            return reply(
+                stream,
+                400,
+                &serde_json::json!({"error":"invalid prewarm request"}),
+            )
+        }
+    };
+    if let Err(reason) = crate::dispatch::validate_member_request(&request) {
+        return reply(stream, 422, &serde_json::json!({"error":reason}));
+    }
+    // Same lock/order as execution admission: a member-check cell cannot
+    // overcommit an execution admitted concurrently. Only one preparation is
+    // retained/in progress here; no unbounded result or retry-ID registry.
+    let registry = state
+        .executions
+        .lock()
+        .expect("dispatcher registry not poisoned");
+    if state
+        .prewarm
+        .lock()
+        .expect("prewarm reservation not poisoned")
+        .is_some()
+    {
+        return reply(
+            stream,
+            503,
+            &serde_json::json!({"error":"prewarm already in progress"}),
+        );
+    }
+    let node = current_node(state, &registry);
+    if let crate::node::Admission::Refused { reason, .. } = crate::node::admit(&request, &node) {
+        let status = if reason == crate::node::RefusalCode::AtCapacity {
+            503
+        } else {
+            422
+        };
+        return reply(
+            stream,
+            status,
+            &serde_json::json!({"error":"prewarm admission refused","reason":reason}),
+        );
+    }
+    *state
+        .prewarm
+        .lock()
+        .expect("prewarm reservation not poisoned") = Some(Reservation::for_request(&request));
+    let _lease = Lease(state);
+    drop(registry);
+    let control = celln_control::Control::new(Duration::from_millis(
+        request.capabilities.timeout_ms.min(30000),
+    ))?;
+    let report = control.scope(|| {
+        crate::dispatch::check_members(
+            &request,
+            &state.probe.mote_store,
+            &state.probe.tool_store,
+            &state.root,
+        )
+    });
+    let report = match report {
+        Ok(report) => report,
+        Err(reason) => {
+            return reply(
+                stream,
+                422,
+                &serde_json::json!({"error":"sealed prewarm verification refused","reason":reason}),
+            )
+        }
+    };
+    #[cfg(target_os = "linux")]
+    let warm = crate::dispatch::warm::availability().is_some_and(|entries| {
+        entries.iter().any(|entry| {
+            entry.mote.as_deref() == request.mote.as_ref().map(|m| m.hash.as_str())
+                && entry.guest_memory_bytes == request.capabilities.memory_bytes
+        })
+    });
+    #[cfg(not(target_os = "linux"))]
+    let warm = false;
+    if !warm {
+        return reply(
+            stream,
+            503,
+            &serde_json::json!({"error":"verified template no longer observable in serving cache"}),
+        );
+    }
+    // An opaque process-incarnation observation, not an authentication token.
+    static EPOCH: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    let epoch = EPOCH.get_or_init(|| {
+        celln_manifest::Hash::of(
+            format!("{}:{:?}", std::process::id(), std::time::SystemTime::now()).as_bytes(),
+        )
+        .0
+    });
+    reply(
+        stream,
+        200,
+        &serde_json::json!({"apiVersion":"celln.dev/artifact-prewarm-v1","node":state.probe.node_name,
+        "processEpoch":epoch,"requestHash":celln_manifest::Hash::of(&bytes).0,"verification":report,
+        "warmState":"present-at-observation","validity":"observation-only","executionAuthorized":false,
+        "conformance":"not_checked","artifactReadiness":"not_checked"}),
+    )
+}

--- a/crates/celln-cli/src/dispatch_prewarm_tests.rs
+++ b/crates/celln-cli/src/dispatch_prewarm_tests.rs
@@ -1,0 +1,148 @@
+use super::*;
+
+#[cfg(target_os = "linux")]
+pub(super) fn prove_prewarm_on_kvm(request: &ExecutionRequest, root: &Path, source: &str) {
+    use std::sync::atomic::Ordering;
+    let state = state(root);
+    let bytes = serde_json::to_vec(request).unwrap();
+    crate::dispatch::warm::evict();
+    let before = crate::dispatch::warm::PREPARATIONS.load(Ordering::SeqCst);
+    let mut observations = Vec::new();
+    for _ in 0..2 {
+        let response = http(&state, &bytes, &state.token, bytes.len());
+        assert!(response.starts_with("HTTP/1.1 200"), "{response}");
+        let report: serde_json::Value =
+            serde_json::from_str(response.split_once("\r\n\r\n").unwrap().1).unwrap();
+        assert_eq!(report["apiVersion"], "celln.dev/artifact-prewarm-v1");
+        assert_eq!(report["requestHash"], celln_manifest::Hash::of(&bytes).0);
+        assert_eq!(
+            report["verification"]["closure"],
+            request.tools[0].closure.as_ref().unwrap().hash
+        );
+        assert_eq!(
+            report["verification"]["memberIntegrity"],
+            "verified-in-sealed-cell"
+        );
+        assert_eq!(report["verification"]["toolExecution"], false);
+        assert_eq!(report["verification"]["cellDissolved"], true);
+        assert_eq!(report["warmState"], "present-at-observation");
+        assert_eq!(report["executionAuthorized"], false);
+        assert_eq!(report["artifactReadiness"], "not_checked");
+        assert!(state.prewarm.lock().unwrap().is_none());
+        assert!(state.executions.lock().unwrap().is_empty());
+        assert_eq!(
+            crate::dispatch::warm::PREPARATIONS.load(Ordering::SeqCst),
+            before + 1
+        );
+        observations.push(report);
+    }
+    assert_eq!(
+        observations[0]["processEpoch"],
+        observations[1]["processEpoch"]
+    );
+    assert_ne!(
+        observations[0]["verification"]["challenge"],
+        observations[1]["verification"]["challenge"]
+    );
+    let policy_path = root.join("trusted-closures.json");
+    let original = std::fs::read(&policy_path).unwrap();
+    let mut policy: serde_json::Value = serde_json::from_slice(&original).unwrap();
+    policy["revoked"] = serde_json::json!([source]);
+    std::fs::write(&policy_path, serde_json::to_vec(&policy).unwrap()).unwrap();
+    let denied = http(&state, &bytes, &state.token, bytes.len());
+    std::fs::write(&policy_path, original).unwrap();
+    assert!(denied.starts_with("HTTP/1.1 422"), "{denied}");
+    assert!(denied.contains("revoked"), "{denied}");
+    assert!(!denied.contains("present-at-observation"));
+    assert!(state.prewarm.lock().unwrap().is_none());
+    let node = current_node(&state, &HashMap::new());
+    assert_eq!((node.live_cells, node.memory_bytes), (0, 268435456));
+    let evidence_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(format!("../../target/prewarm-proof-{}", std::process::id()));
+    std::fs::create_dir(&evidence_dir).unwrap();
+    std::fs::write(evidence_dir.join("evidence.json"),serde_json::to_vec_pretty(&serde_json::json!({
+        "status":"passed","scope":"authenticated TCP dispatcher handler + real KVM, not router/controller readiness",
+        "observations":observations,"sourceRevocationRefused":true,"preparations":1,"checks":2,"capacityReleased":true,
+        "modelCalls":0,"toolExecution":false
+    })).unwrap()).unwrap();
+    eprintln!("PASS real-KVM prewarm endpoint: {}", evidence_dir.display());
+}
+fn state(root: &Path) -> State {
+    State {
+        token_file: PathBuf::new(),
+        token: "public-prewarm-test-token-24bytes".into(),
+        egress_policy: EgressPolicy::new(&[]).unwrap(),
+        root: root.into(),
+        probe: NodeProbeArgs {
+            node_name: "test".into(),
+            mote_store: root.join("motes"),
+            tool_store: root.join("tools"),
+            max_cells: 2,
+            memory_bytes: 268435456,
+            egress_slots: 0,
+        },
+        executions: Arc::new(Mutex::new(HashMap::new())),
+        prewarm: Mutex::new(None),
+    }
+}
+fn request() -> serde_json::Value {
+    let h = celln_manifest::Hash::of(b"fixture").0;
+    serde_json::json!({"apiVersion":"celln.dev/v1alpha1","id":"prewarm","workload":{"id":"test","caller":"operator"},
+            "mote":{"hash":h},"tools":[{"alias":"/harness","hash":h,"closure":{"hash":h}}],"invocation":{"alias":"/harness","args":[]},
+            "capabilities":{"workspace":"none","timeoutMs":10000,"memoryBytes":268435456,"outputBytes":4096},
+            "execution":{"lane":"agent","requireHardwareIsolation":true}})
+}
+fn http(state: &State, body: &[u8], token: &str, length: usize) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+    client
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    let (server, _) = listener.accept().unwrap();
+    write!(client,"POST /v1/artifacts/prewarm HTTP/1.1\r\nAuthorization: Bearer {token}\r\nContent-Length: {length}\r\n\r\n").unwrap();
+    client.write_all(body).unwrap();
+    super::super::handle(server, state).unwrap();
+    let mut out = String::new();
+    client.read_to_string(&mut out).unwrap();
+    out
+}
+#[test]
+fn prewarm_http_refuses_unauthenticated_oversized_and_executable_requests() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = state(dir.path());
+    assert!(http(&state, b"{}", "wrong", 2).starts_with("HTTP/1.1 401"));
+    assert!(http(&state, b"", &state.token, 65537).starts_with("HTTP/1.1 413"));
+    let mut r = request();
+    r["invocation"]["args"] = serde_json::json!(["execute-me"]);
+    let bytes = serde_json::to_vec(&r).unwrap();
+    assert!(http(&state, &bytes, &state.token, bytes.len()).starts_with("HTTP/1.1 422"));
+    assert!(state.prewarm.lock().unwrap().is_none());
+    assert!(state.executions.lock().unwrap().is_empty());
+}
+#[test]
+fn prewarm_reservation_reduces_capacity_and_drop_releases_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = state(dir.path());
+    *state.prewarm.lock().unwrap() = Some(Reservation {
+        memory_bytes: 268435456,
+        egress_slots: 0,
+    });
+    let lease = Lease(&state);
+    let node = current_node(&state, &HashMap::new());
+    assert_eq!((node.live_cells, node.memory_bytes), (1, 0));
+    let bytes = serde_json::to_vec(&request()).unwrap();
+    assert!(http(&state, &bytes, &state.token, bytes.len()).starts_with("HTTP/1.1 503"));
+    drop(lease);
+    let node = current_node(&state, &HashMap::new());
+    assert_eq!((node.live_cells, node.memory_bytes), (0, 268435456));
+}
+#[test]
+fn unavailable_artifacts_or_hardware_never_claim_warmth_and_release_capacity() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = state(dir.path());
+    let bytes = serde_json::to_vec(&request()).unwrap();
+    let response = http(&state, &bytes, &state.token, bytes.len());
+    assert!(response.starts_with("HTTP/1.1 422"), "{response}");
+    assert!(!response.contains("present-at-observation"));
+    assert!(state.prewarm.lock().unwrap().is_none());
+}

--- a/crates/celln-cli/src/dispatch_substrate.rs
+++ b/crates/celln-cli/src/dispatch_substrate.rs
@@ -192,6 +192,11 @@ pub(crate) fn check_members(
     tool_root: &Path,
     state_root: &Path,
 ) -> Result<serde_json::Value, String> {
+    validate_member_request(request)?;
+    check_members_validated(request, mote_root, tool_root, state_root)
+}
+
+pub(crate) fn validate_member_request(request: &ExecutionRequest) -> Result<(), String> {
     if !request.problems().is_empty()
         || request.harness.is_some()
         || request.forge.is_some()
@@ -205,7 +210,15 @@ pub(crate) fn check_members(
     {
         return Err("member check requires a valid closure request with no args, inputs, workspace, forge, harness or egress".into());
     }
-    super::check_supported_authority(request)?;
+    super::check_supported_authority(request)
+}
+
+fn check_members_validated(
+    request: &ExecutionRequest,
+    mote_root: &Path,
+    tool_root: &Path,
+    state_root: &Path,
+) -> Result<serde_json::Value, String> {
     authorize(request, state_root)?;
     let resolved = super::resolve_bundle(request, mote_root, tool_root)?;
     let closure = super::closure::resolve(request, &resolved, state_root)?

--- a/crates/celln-cli/src/dispatch_warm.rs
+++ b/crates/celln-cli/src/dispatch_warm.rs
@@ -24,12 +24,12 @@ pub(crate) fn availability() -> Option<Vec<Availability>> {
 }
 static CACHE: OnceLock<Mutex<Cached>> = OnceLock::new();
 #[cfg(test)]
-pub(super) fn evict() {
+pub(crate) fn evict() {
     *CACHE.get_or_init(|| Mutex::new(None)).lock().unwrap() = None;
     warden::vmm::kvm::collect_unused_tools();
 }
 #[cfg(test)]
-pub(super) static PREPARATIONS: std::sync::atomic::AtomicUsize =
+pub(crate) static PREPARATIONS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 #[cfg(test)]
 pub(crate) static PROOF_LOCK: Mutex<()> = Mutex::new(());

--- a/docs/DISPATCHER_PREWARM.md
+++ b/docs/DISPATCHER_PREWARM.md
@@ -1,0 +1,63 @@
+# Serving-process artifact verification and prewarming
+
+`POST /v1/artifacts/prewarm` uses the dispatcher's bearer authentication and
+accepts a bounded (64 KiB) existing declared `ExecutionRequest`. It must name
+an operator-admitted mote and signed closure, with empty invocation arguments,
+no Harness/forge payload, no inputs, no workspace and no egress. This endpoint
+does not execute the selected Harness or borrowed tools.
+
+The serving process runs the existing challenge-bound sealed guest member
+verification and observes its own warm cache afterward. Policy is checked by
+that verifier before and after guest verification. A successful response uses
+`celln.dev/artifact-prewarm-v1`, includes the exact HTTP request-byte hash,
+node identity, an opaque process-incarnation identifier, and the sealed-member
+verification report. It says `warmState: present-at-observation` only if the
+selected mote/memory configuration is observable in that process's cache.
+
+Preparation reserves one cell and the declared guest RAM under the same
+admission lock as executions. Other requests see that reservation in node
+capacity; only one prewarm operation is admitted at a time. The reservation
+is released on success, refusal or unwinding. The existing retained warm-mote
+RAM is separate from active reservations; this is not a whole-process RSS cap.
+A control deadline bounds preparation to at most 30 seconds, and the member
+check's guest run has its existing maximum 10-second timeout.
+
+This is an **observation, not a lease or an execution authorization**. Cache
+eviction, process restart and policy withdrawal can invalidate it immediately.
+It is deliberately not persisted or returned as global positive readiness.
+Responses retain `artifactReadiness: not_checked`, `conformance: not_checked`
+and `executionAuthorized: false`. Runtime/tool functional conformance, model
+grants, controller selection resolution, distribution and fresh execution-time
+authorization are still required. A CLI verifier running in another process
+cannot supply this serving-process observation.
+
+Malformed requests return 400; oversized requests 413; unsupported authority,
+missing hardware/artifacts or failed sealed-member verification 422; capacity
+shortfall, concurrent preparation or an unobservable/evicted template 503.
+The endpoint is not routed through the execution journal and does not create
+an execution ID or retry tombstone: it has no lent-tool side effects to replay.
+
+Portable HTTP tests cover authentication, body bounds, executable-argument
+refusal, capacity visibility, concurrent-preparation refusal and reservation
+release. The explicit `signed_closure_on_real_kvm` hardware test also calls the
+authenticated TCP handler twice against a freshly emptied serving-process
+cache, checks exactly one preparation and distinct verification challenges,
+then revokes a signed input source and checks refusal and released capacity.
+The [recorded run](evidence/dispatcher-prewarm-2026-09-07.json) passed on
+2026-09-07 alongside the dynamic-closure guest attack/revocation suite, portable
+`make ci`, and all-target/all-feature Clippy. No model calls were made.
+
+This proves the dispatcher handler and real guest verification, not deployed
+router/controller integration or the complete selection-specific readiness
+path. The hardware proof can be reproduced with a built `celln` binary and
+static pilot binaries:
+
+```sh
+CELLN_TEST_BINARY=/absolute/path/to/celln \
+CELLN_PILOT_DIR=/absolute/path/to/static/pilot/binaries \
+cargo test -p celln-cli signed_closure_on_real_kvm -- --ignored --nocapture
+```
+
+Check for the explicit `PASS real-KVM prewarm endpoint` line; a hardware/toolchain
+skip is not evidence of verification. Each run writes observations beneath
+`target/prewarm-proof-<pid>/evidence.json`.

--- a/docs/evidence/dispatcher-prewarm-2026-09-07.json
+++ b/docs/evidence/dispatcher-prewarm-2026-09-07.json
@@ -1,0 +1,70 @@
+{
+  "capacityReleased": true,
+  "checks": 2,
+  "modelCalls": 0,
+  "observations": [
+    {
+      "apiVersion": "celln.dev/artifact-prewarm-v1",
+      "artifactReadiness": "not_checked",
+      "conformance": "not_checked",
+      "executionAuthorized": false,
+      "node": "test",
+      "processEpoch": "blake3:261838a79b4e1f9e900f46a686906858afbab2e0c70f7183addb78a7e0627d75",
+      "requestHash": "blake3:3d87e0179bb0dbe17869827a3a6536c298af3eb99a2fa4e6a76be60ab9538bae",
+      "validity": "observation-only",
+      "verification": {
+        "apiVersion": "celln.dev/sealed-members-verification-v1",
+        "artifactReadiness": "not_checked",
+        "cellDissolved": true,
+        "challenge": "blake3:8c442711b940fbdebe51d0af5382a0d643f01994b5eba440ef2125381f435765",
+        "closure": "blake3:34b15ce2e538cfbbd3ad52d05a895eed30f66fe5df6be00fb82f549c97408806",
+        "conformance": "not_checked",
+        "initrd": "blake3:37c85b3486c1752e6a61d70fe7403306ff265baa59b8c93a68d0de6f9468dce7",
+        "kernel": "blake3:e8e05482b24c4d9019ff7298f42f6f2730fcf656cbcb429ec44150ceac0e4ca8",
+        "memberCount": 4,
+        "memberIntegrity": "verified-in-sealed-cell",
+        "mote": "blake3:ff5110586a895ea7f4e32c27bc430a87b1e2bfbc46971c8a6759d51f64956e7c",
+        "publisher": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+        "requestHash": "blake3:2f00445512b79c156fa9994e198178d4591ce9497f870f171633fbe515686623",
+        "scope": "sealed-member-identities-only",
+        "toolExecution": false,
+        "toolfs": "blake3:c6e23d59578334855e485d0824960c5b08d909d0fde19688673653904fc6b7b6"
+      },
+      "warmState": "present-at-observation"
+    },
+    {
+      "apiVersion": "celln.dev/artifact-prewarm-v1",
+      "artifactReadiness": "not_checked",
+      "conformance": "not_checked",
+      "executionAuthorized": false,
+      "node": "test",
+      "processEpoch": "blake3:261838a79b4e1f9e900f46a686906858afbab2e0c70f7183addb78a7e0627d75",
+      "requestHash": "blake3:3d87e0179bb0dbe17869827a3a6536c298af3eb99a2fa4e6a76be60ab9538bae",
+      "validity": "observation-only",
+      "verification": {
+        "apiVersion": "celln.dev/sealed-members-verification-v1",
+        "artifactReadiness": "not_checked",
+        "cellDissolved": true,
+        "challenge": "blake3:939562789fa1950f8a2ebdfa80710753446277cafd80bd21bb06303c0a0db951",
+        "closure": "blake3:34b15ce2e538cfbbd3ad52d05a895eed30f66fe5df6be00fb82f549c97408806",
+        "conformance": "not_checked",
+        "initrd": "blake3:37c85b3486c1752e6a61d70fe7403306ff265baa59b8c93a68d0de6f9468dce7",
+        "kernel": "blake3:e8e05482b24c4d9019ff7298f42f6f2730fcf656cbcb429ec44150ceac0e4ca8",
+        "memberCount": 4,
+        "memberIntegrity": "verified-in-sealed-cell",
+        "mote": "blake3:ff5110586a895ea7f4e32c27bc430a87b1e2bfbc46971c8a6759d51f64956e7c",
+        "publisher": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+        "requestHash": "blake3:478b987d8a1bf52e1093dfc3dd3814ea33498c64c9ad8b58d18d1fbc68867741",
+        "scope": "sealed-member-identities-only",
+        "toolExecution": false,
+        "toolfs": "blake3:c6e23d59578334855e485d0824960c5b08d909d0fde19688673653904fc6b7b6"
+      },
+      "warmState": "present-at-observation"
+    }
+  ],
+  "preparations": 1,
+  "scope": "authenticated TCP dispatcher handler + real KVM, not router/controller readiness",
+  "sourceRevocationRefused": true,
+  "status": "passed",
+  "toolExecution": false
+}


### PR DESCRIPTION
## Purpose
Next prerequisite for sympozium-ai/sympozium#426: authenticated selection-specific artifact verification in the process that retains the warm mote.

## Changes
- Add bounded POST /v1/artifacts/prewarm using existing dispatcher authentication and declared requests with no executable arguments, Harness payload, workspace, inputs or egress.
- Reuse challenge-bound sealed guest member verification and before/after policy checks.
- Reserve a cell and declared RAM under the execution admission lock; release on every exit. Return only process-scoped cache observations, never execution authorization or positive readiness.
- Document the contract and commit real-KVM observations.

## Validation
- make ci passed.
- Workspace all-target/all-feature Clippy with warnings denied passed.
- Explicit signed_closure_on_real_kvm passed without skipping: two authenticated TCP handler checks, one preparation, fresh challenges, signed-source revocation refusal, capacity release; existing dynamic closure guest attacks and revocation also passed.
- No model calls or cluster changes.

## Scope
Not router/controller integration, functional Harness conformance, distribution, trusted model grant issuance, or complete catalogue-backed readiness. The epic remains open.