### PR TITLE
feat: request-bound host Harness grant issuer with live policy checks

### DIFF
--- a/crates/celln-cli/src/dispatch_harness.rs
+++ b/crates/celln-cli/src/dispatch_harness.rs
@@ -1,16 +1,25 @@
 //! Operator-owned grants: possessing artifact bytes is not model authority.
 use celln_manifest::Hash;
 use celln_spec::{BorrowedTool, ExecutionRequest, JsonHarnessOptions};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{
     io::{Read, Write},
     path::{Path, PathBuf},
 };
 
-#[derive(Deserialize)]
+#[path = "dispatch_harness_issuer.rs"]
+mod issuer;
+pub(crate) use issuer::inspect_binding;
+pub(crate) use issuer::issue;
+#[cfg(test)]
+pub(crate) use issuer::prove_issuance;
+
+#[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Grant {
     api_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    issuer: Option<issuer::Binding>,
     #[serde(default)]
     contract_version: Option<String>,
     #[serde(default)]
@@ -60,7 +69,18 @@ pub fn resolve(
     if bytes.len() > 65536 || Hash::of(&bytes).0 != binding.model_grant.hash {
         return Err("Harness grant revision mismatch".into());
     }
-    let grant: Grant = serde_json::from_slice(&bytes).map_err(|_| "invalid Harness grant")?;
+    resolve_bytes(request, closure, root, &bytes).map(Some)
+}
+
+fn resolve_bytes(
+    request: &ExecutionRequest,
+    closure: &super::closure::Admitted,
+    root: &Path,
+    bytes: &[u8],
+) -> Result<Resolved, String> {
+    let binding = request.harness.as_ref().ok_or("missing Harness binding")?;
+    let grant: Grant = serde_json::from_slice(bytes).map_err(|_| "invalid Harness grant")?;
+    issuer::validate(request, &grant, root)?;
     let contract_authorized = match binding.contract_version.as_str() {
         "celln.reference-functions/v1" => {
             grant.api_version == "celln.dev/harness-grant-v1"
@@ -68,7 +88,8 @@ pub fn resolve(
                 && grant.json.is_none()
         }
         "celln.json-tools/v1" => {
-            grant.api_version == "celln.dev/harness-grant-v2"
+            (grant.api_version == "celln.dev/harness-grant-v2"
+                || grant.api_version == "celln.dev/harness-grant-v3")
                 && grant.contract_version.as_deref() == Some("celln.json-tools/v1")
                 && grant.json == binding.json
         }
@@ -165,10 +186,10 @@ pub fn resolve(
         max_output_tokens: grant.max_output_tokens,
         max_total_output_tokens: grant.max_total_output_tokens,
     });
-    Ok(Some(Resolved {
+    Ok(Resolved {
         policy,
         args: vec![config],
-    }))
+    })
 }
 
 fn json_config(request: &ExecutionRequest, grant: &Grant, root: &Path) -> Result<String, String> {

--- a/crates/celln-cli/src/dispatch_harness_issuer.rs
+++ b/crates/celln-cli/src/dispatch_harness_issuer.rs
@@ -1,0 +1,212 @@
+//! Local operator issuance. This is not an upload endpoint or a tenant authority.
+use super::*;
+
+#[cfg(test)]
+#[path = "dispatch_harness_issuer_tests.rs"]
+mod tests;
+#[cfg(test)]
+pub(crate) fn prove_issuance(request: &ExecutionRequest, root: &Path) {
+    tests::prove_issuance(request, root);
+}
+
+pub(crate) fn inspect_binding(path: &Path) -> anyhow::Result<u8> {
+    let bytes = crate::closure_policy::read_bounded(path).map_err(anyhow::Error::msg)?;
+    if bytes.len() > 65536 {
+        anyhow::bail!("issuance request exceeds 64 KiB");
+    }
+    let request: ExecutionRequest = serde_json::from_slice(&bytes)?;
+    println!(
+        "{}",
+        serde_json::json!({"apiVersion":"celln.dev/harness-request-binding-v1","requestBinding":request_binding(&request).map_err(anyhow::Error::msg)?,"executionAuthorized":false})
+    );
+    Ok(0)
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct Binding {
+    profile: String,
+    policy_hash: String,
+    request_binding: String,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Profile {
+    api_version: String,
+    request_binding: String,
+    credential_file: PathBuf,
+    model: String,
+    url: String,
+    max_requests: usize,
+    max_output_tokens: u64,
+    max_total_output_tokens: u64,
+}
+
+// Normalize only the self-referential grant hash. Task, caller, execution ID,
+// persona, limits and every artifact/schema identity remain bound.
+fn request_binding(request: &ExecutionRequest) -> Result<String, String> {
+    let mut value = serde_json::to_value(request).map_err(|_| "invalid request")?;
+    if request.harness.is_none() || !request.problems().is_empty() {
+        return Err("valid Harness request required".into());
+    }
+    value["harness"]["modelGrant"]["hash"] = serde_json::json!(Hash::of(b"").0);
+    Ok(Hash::of(&serde_json::to_vec(&value).map_err(|_| "invalid request")?).0)
+}
+
+fn profile(root: &Path, name: &str) -> Result<(Profile, String), String> {
+    if name.is_empty()
+        || name.len() > 64
+        || !name
+            .bytes()
+            .all(|c| c.is_ascii_alphanumeric() || c == b'_' || c == b'-')
+    {
+        return Err("invalid operator profile name".into());
+    }
+    let bytes = crate::closure_policy::read_bounded(
+        &root
+            .join("trusted-model-profiles")
+            .join(format!("{name}.json")),
+    )?;
+    if bytes.len() > 65536 {
+        return Err("model profile exceeds 64 KiB".into());
+    }
+    let p: Profile =
+        serde_json::from_slice(&bytes).map_err(|_| "invalid operator model profile")?;
+    if p.api_version != "celln.dev/model-issuer-profile-v1"
+        || !p.credential_file.is_absolute()
+        || p.url != "https://api.deepseek.com/chat/completions"
+        || p.model.is_empty()
+        || p.model.len() > 128
+        || p.max_requests == 0
+        || p.max_requests > 6
+        || p.max_output_tokens != 512
+        || p.max_total_output_tokens < 512
+        || p.max_total_output_tokens > 3072
+    {
+        return Err("unsupported operator model profile".into());
+    }
+    Ok((p, Hash::of(&bytes).0))
+}
+
+pub(super) fn validate(
+    request: &ExecutionRequest,
+    grant: &Grant,
+    root: &Path,
+) -> Result<(), String> {
+    if grant.api_version != "celln.dev/harness-grant-v3" {
+        return if grant.issuer.is_none() {
+            Ok(())
+        } else {
+            Err("issuer binding requires grant v3".into())
+        };
+    }
+    let b = grant
+        .issuer
+        .as_ref()
+        .ok_or("issued grant missing policy binding")?;
+    let (p, hash) = profile(root, &b.profile)?;
+    if hash != b.policy_hash
+        || p.request_binding != b.request_binding
+        || request_binding(request)? != b.request_binding
+        || p.credential_file != grant.credential_file
+        || p.model != grant.model
+        || p.url != grant.url
+        || p.max_requests != grant.max_requests
+        || p.max_output_tokens != grant.max_output_tokens
+        || p.max_total_output_tokens != grant.max_total_output_tokens
+    {
+        return Err("issued grant policy withdrawn, changed or request mismatched".into());
+    }
+    Ok(())
+}
+
+fn candidate(request: &ExecutionRequest, name: &str, root: &Path) -> Result<Vec<u8>, String> {
+    let identity = request_binding(request)?;
+    let (p, policy_hash) = profile(root, name)?;
+    let h = request.harness.as_ref().ok_or("missing Harness")?;
+    if h.contract_version != "celln.json-tools/v1"
+        || h.model != p.model
+        || identity != p.request_binding
+    {
+        return Err("request is not independently approved by host model profile".into());
+    }
+    let options = h.json.as_ref().ok_or("missing JSON Harness options")?;
+    if p.max_requests < options.max_turns
+        || p.max_total_output_tokens < options.max_turns as u64 * 512
+    {
+        return Err("issuer profile cannot fund the configured turn ceiling".into());
+    }
+    let mut grant = serde_json::json!({
+        "apiVersion":"celln.dev/harness-grant-v3", "contractVersion":h.contract_version,
+        "json":h.json,"caller":request.workload.caller,"mote":request.mote.as_ref().ok_or("missing mote")?.hash,
+        "runtime":request.tools[0].hash,"closure":request.tools[0].closure.as_ref().ok_or("missing closure")?.hash,
+        "borrowedTools":h.borrowed_tools,"url":p.url,"model":p.model,"credentialFile":p.credential_file,
+        "maxRequests":p.max_requests,"maxOutputTokens":p.max_output_tokens,"maxTotalOutputTokens":p.max_total_output_tokens
+    });
+    grant["issuer"] = serde_json::to_value(Binding {
+        profile: name.into(),
+        policy_hash,
+        request_binding: identity,
+    })
+    .map_err(|_| "invalid issuer binding")?;
+    let bytes = serde_json::to_vec(&grant).map_err(|_| "invalid grant")?;
+    if bytes.len() > 65536 {
+        return Err("issued grant exceeds 64 KiB".into());
+    }
+    Ok(bytes)
+}
+
+pub(crate) fn issue(request_path: &Path, name: &str, root: &Path) -> anyhow::Result<u8> {
+    let bytes = crate::closure_policy::read_bounded(request_path).map_err(anyhow::Error::msg)?;
+    if bytes.len() > 65536 {
+        anyhow::bail!("issuance request exceeds 64 KiB");
+    }
+    let mut request: ExecutionRequest = serde_json::from_slice(&bytes)?;
+    let grant = candidate(&request, name, root).map_err(anyhow::Error::msg)?;
+    // Member verification deliberately removes execution/model authority. This
+    // CLI's cache is not the serving dispatcher's cache or a readiness lease.
+    let mut check = serde_json::to_value(&request)?;
+    check["apiVersion"] = serde_json::json!("celln.dev/v1alpha1");
+    check.as_object_mut().unwrap().remove("harness");
+    check["capabilities"]["egress"] = serde_json::json!([]);
+    let check: ExecutionRequest = serde_json::from_value(check)?;
+    let control = celln_control::Control::new(std::time::Duration::from_secs(30))?;
+    let report = control
+        .scope(|| {
+            crate::dispatch::check_members(&check, &root.join("motes"), &root.join("tools"), root)
+        })
+        .map_err(anyhow::Error::msg)?;
+    let bundle =
+        crate::dispatch::resolve_bundle(&request, &root.join("motes"), &root.join("tools"))
+            .map_err(anyhow::Error::msg)?;
+    let closure = crate::dispatch::closure::resolve(&request, &bundle, root)
+        .map_err(anyhow::Error::msg)?
+        .ok_or_else(|| anyhow::anyhow!("admitted closure required"))?;
+    resolve_bytes(&request, &closure, root, &grant).map_err(anyhow::Error::msg)?;
+    let hash = Hash::of(&grant);
+    let directory = root.join("trusted-harness");
+    std::fs::create_dir_all(&directory)?;
+    let mut temp = tempfile::NamedTempFile::new_in(&directory)?;
+    temp.write_all(&grant)?;
+    temp.as_file().sync_all()?;
+    // Recheck the independently provisioned policy immediately before publish.
+    if candidate(&request, name, root).map_err(anyhow::Error::msg)? != grant {
+        anyhow::bail!("issuer policy changed during verification");
+    }
+    let path = directory.join(format!("{}.json", hash.0.trim_start_matches("blake3:")));
+    if let Err(error) = temp.persist_noclobber(&path) {
+        if error.error.kind() != std::io::ErrorKind::AlreadyExists
+            || crate::closure_policy::read_bounded(&path).map_err(anyhow::Error::msg)? != grant
+        {
+            anyhow::bail!("cannot publish issued grant without overwriting existing data");
+        }
+    }
+    std::fs::File::open(&directory)?.sync_all()?;
+    request.harness.as_mut().unwrap().model_grant.hash = hash.0.clone();
+    println!(
+        "{}",
+        serde_json::json!({"apiVersion":"celln.dev/harness-issuance-v1","grant":hash.0,"request":request,"verification":report,"artifactReadiness":"not_checked","conformance":"not_checked","executed":false})
+    );
+    Ok(0)
+}

--- a/crates/celln-cli/src/dispatch_harness_issuer_tests.rs
+++ b/crates/celln-cli/src/dispatch_harness_issuer_tests.rs
@@ -1,0 +1,122 @@
+use super::*;
+use serde_json::json;
+
+pub(super) fn prove_issuance(request: &ExecutionRequest, root: &Path) {
+    let profile = setup(root, request);
+    let bytes = candidate(request, "reviewed", root).unwrap();
+    let hash = Hash::of(&bytes);
+    let path = root.join("issuer-request.json");
+    std::fs::write(&path, serde_json::to_vec(request).unwrap()).unwrap();
+    for _ in 0..2 {
+        assert_eq!(issue(&path, "reviewed", root).unwrap(), 0);
+    }
+    let issued = root
+        .join("trusted-harness")
+        .join(format!("{}.json", hash.0.trim_start_matches("blake3:")));
+    assert_eq!(std::fs::read(&issued).unwrap(), bytes);
+    let mut bound = request.clone();
+    bound.harness.as_mut().unwrap().model_grant.hash = hash.0.clone();
+    let bundle =
+        crate::dispatch::resolve_bundle(&bound, &root.join("motes"), &root.join("tools")).unwrap();
+    let closure = crate::dispatch::closure::resolve(&bound, &bundle, root).unwrap();
+    assert!(resolve(&bound, closure.as_ref(), root).unwrap().is_some());
+    std::fs::remove_file(profile).unwrap();
+    assert!(resolve(&bound, closure.as_ref(), root).is_err());
+    assert!(issue(&path, "reviewed", root).is_err());
+    assert_eq!(std::fs::read(issued).unwrap(), bytes);
+    eprintln!("PASS real-KVM issuer: two checks, idempotent publication, v3 resolution and policy withdrawal refusal; modelCalls=0; grant={}", hash.0);
+}
+
+fn setup(root: &Path, request: &ExecutionRequest) -> PathBuf {
+    let directory = root.join("trusted-model-profiles");
+    std::fs::create_dir_all(&directory).unwrap();
+    let path = directory.join("reviewed.json");
+    std::fs::write(&path, serde_json::to_vec(&json!({
+        "apiVersion":"celln.dev/model-issuer-profile-v1", "requestBinding":request_binding(request).unwrap(),
+        "model":request.harness.as_ref().unwrap().model,"url":"https://api.deepseek.com/chat/completions",
+        "credentialFile":"/never-read-test-credential","maxRequests":3,"maxOutputTokens":512,"maxTotalOutputTokens":1536
+    })).unwrap()).unwrap();
+    path
+}
+
+#[test]
+fn issued_grants_pin_full_request_and_live_profile_without_reading_credentials() {
+    let root = tempfile::tempdir().unwrap();
+    let (mut request, closure, _) = super::super::json_tests::fixture(root.path());
+    let path = setup(root.path(), &request);
+    let bytes = candidate(&request, "reviewed", root.path()).unwrap();
+    let before = request_binding(&request).unwrap();
+    request.harness.as_mut().unwrap().model_grant.hash = Hash::of(&bytes).0;
+    assert_eq!(request_binding(&request).unwrap(), before);
+    let resolved = resolve_bytes(&request, &closure, root.path(), &bytes).unwrap();
+    assert!(!resolved.args[0].contains("never-read-test-credential"));
+    for field in ["task", "persona", "id", "caller", "timeout", "tools"] {
+        let mut changed = serde_json::to_value(&request).unwrap();
+        match field {
+            "task" => changed["harness"]["task"] = json!("different task"),
+            "persona" => changed["harness"]["json"]["system"] = json!("different persona"),
+            "id" => changed["id"] = json!("new-attempt"),
+            "caller" => changed["workload"]["caller"] = json!("other-caller"),
+            "timeout" => changed["capabilities"]["timeoutMs"] = json!(1000),
+            "tools" => {
+                changed["harness"]["borrowedTools"][0]["description"] =
+                    json!("different tool description")
+            }
+            _ => unreachable!(),
+        }
+        let changed: ExecutionRequest = serde_json::from_value(changed).unwrap();
+        assert!(
+            resolve_bytes(&changed, &closure, root.path(), &bytes).is_err(),
+            "{field}"
+        );
+    }
+    let original = std::fs::read(&path).unwrap();
+    let mut altered = original.clone();
+    altered.push(b' ');
+    std::fs::write(&path, altered).unwrap();
+    assert!(resolve_bytes(&request, &closure, root.path(), &bytes).is_err());
+    std::fs::write(&path, original).unwrap();
+    std::fs::remove_file(&path).unwrap();
+    assert!(resolve_bytes(&request, &closure, root.path(), &bytes).is_err());
+    assert!(candidate(&request, "reviewed", root.path()).is_err());
+}
+
+#[test]
+fn profile_paths_and_issuer_downgrades_refuse() {
+    let root = tempfile::tempdir().unwrap();
+    let (request, closure, _) = super::super::json_tests::fixture(root.path());
+    setup(root.path(), &request);
+    for name in ["", "../reviewed", "/reviewed", "with.dot"] {
+        assert!(candidate(&request, name, root.path()).is_err());
+    }
+    let bytes = candidate(&request, "reviewed", root.path()).unwrap();
+    let mut grant: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    grant["apiVersion"] = json!("celln.dev/harness-grant-v2");
+    assert!(resolve_bytes(
+        &request,
+        &closure,
+        root.path(),
+        &serde_json::to_vec(&grant).unwrap()
+    )
+    .is_err());
+    grant["apiVersion"] = json!("celln.dev/harness-grant-v3");
+    grant.as_object_mut().unwrap().remove("issuer");
+    assert!(resolve_bytes(
+        &request,
+        &closure,
+        root.path(),
+        &serde_json::to_vec(&grant).unwrap()
+    )
+    .is_err());
+}
+
+#[test]
+fn missing_hardware_or_artifacts_never_publishes_a_grant() {
+    let root = tempfile::tempdir().unwrap();
+    let (request, _, _) = super::super::json_tests::fixture(root.path());
+    setup(root.path(), &request);
+    let path = root.path().join("request.json");
+    std::fs::write(&path, serde_json::to_vec(&request).unwrap()).unwrap();
+    assert!(issue(&path, "reviewed", root.path()).is_err());
+    assert!(!root.path().join("trusted-harness").exists());
+}

--- a/crates/celln-cli/src/dispatch_harness_json_tests.rs
+++ b/crates/celln-cli/src/dispatch_harness_json_tests.rs
@@ -78,7 +78,7 @@ fn composed_json_sources_bind_exact_selected_roots_and_keep_dependencies_out_of_
     assert!(bind(sources).is_err());
 }
 
-fn fixture(root: &Path) -> (ExecutionRequest, super::super::closure::Admitted, Value) {
+pub(super) fn fixture(root: &Path) -> (ExecutionRequest, super::super::closure::Admitted, Value) {
     let mut wire: Value = serde_json::from_str(include_str!(
         "../../../examples/execution/harness-reference.json"
     ))

--- a/crates/celln-cli/src/dispatch_harness_tests.rs
+++ b/crates/celln-cli/src/dispatch_harness_tests.rs
@@ -80,24 +80,34 @@ fn controller_hook(
 #[test]
 #[ignore = "billable: requires CELLN_HARNESS_PACKAGE, CELLN_MODEL_TOKEN_FILE and real KVM"]
 fn harness_model_over_authenticated_dispatch() {
-    model_over_authenticated_dispatch(false);
+    model_over_authenticated_dispatch(false, false);
 }
 
 #[test]
 #[ignore = "billable: requires JSON CELLN_HARNESS_PACKAGE, CELLN_MODEL_TOKEN_FILE and real KVM"]
 fn json_harness_model_over_authenticated_dispatch() {
-    model_over_authenticated_dispatch(true);
+    model_over_authenticated_dispatch(true, false);
 }
 
-fn model_over_authenticated_dispatch(json_adapter: bool) {
+#[test]
+#[ignore = "requires real KVM and a native JSON Harness package; no model calls"]
+fn json_harness_grant_issuance_on_real_kvm() {
+    model_over_authenticated_dispatch(true, true);
+}
+
+fn model_over_authenticated_dispatch(json_adapter: bool, issuance_only: bool) {
     let _lock = crate::dispatch::warm::PROOF_LOCK.lock().unwrap();
     let package = PathBuf::from(
         std::env::var_os("CELLN_HARNESS_PACKAGE")
             .expect("set package directory from celln-harness-proof --package-only"),
     );
-    let token = PathBuf::from(
-        std::env::var_os("CELLN_MODEL_TOKEN_FILE").expect("set private host credential file"),
-    );
+    let token = if issuance_only {
+        PathBuf::from("/never-read-issuance-proof-credential")
+    } else {
+        PathBuf::from(
+            std::env::var_os("CELLN_MODEL_TOKEN_FILE").expect("set private host credential file"),
+        )
+    };
     assert!(
         Path::new("/dev/kvm").exists(),
         "explicit hardware proof requires KVM"
@@ -183,6 +193,10 @@ fn model_over_authenticated_dispatch(json_adapter: bool) {
         binding.task = "Call uppercase with text celln, wait for its result, then call length with the uppercase result. Wait for both tool results. Finally answer exactly: CELLN has length 5".into();
     }
     assert!(request.problems().is_empty(), "{:?}", request.problems());
+    if issuance_only {
+        crate::dispatch::harness::prove_issuance(&request, root);
+        return;
+    }
     let state = State {
         prewarm: Mutex::new(None),
         token_file: PathBuf::new(),

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -66,6 +66,14 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
+    /// Inspect a request binding for operator review; grants no authority.
+    HarnessBinding { request: PathBuf },
+    /// Issue a request-bound model grant from an independently provisioned host profile.
+    HarnessGrant {
+        request: PathBuf,
+        #[arg(long)]
+        profile: String,
+    },
     /// Authenticate and admit precomposed dependency closures.
     #[command(subcommand)]
     Closure(ClosureCmd),
@@ -441,6 +449,8 @@ fn resolve_root(explicit: &Option<PathBuf>) -> PathBuf {
 fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
     let root = resolve_root(&cli.root);
     match &cli.cmd {
+        Cmd::HarnessBinding { request } => dispatch::harness::inspect_binding(request),
+        Cmd::HarnessGrant { request, profile } => dispatch::harness::issue(request, profile, &root),
         Cmd::Closure(ClosureCmd::Compose {
             plan,
             key_file,

--- a/docs/HARNESS_GRANT_ISSUANCE.md
+++ b/docs/HARNESS_GRANT_ISSUANCE.md
@@ -1,0 +1,72 @@
+# Request-bound host Harness grants
+
+`celln harness-grant REQUEST --profile NAME` is a local operator command, not
+an authenticated tenant upload API. It issues a JSON Harness grant only when
+the operator has independently provisioned
+`ROOT/trusted-model-profiles/NAME.json` approving the exact request binding.
+The profile directory, grant directory and credential mapping must be writable
+only by trusted operators. Artifact-store access must not grant access to them.
+
+`celln harness-binding REQUEST` prints the binding for review, granting no
+authority. It parses a bounded declared request and hashes its normalized JSON
+with only `harness.modelGrant.hash` replaced by the BLAKE3 hash of empty bytes.
+Thus task, persona, caller, execution ID, time/resource limits and all selected
+artifact/schema identities are covered without a circular grant hash. This is
+a versioned serialization contract, not the hash of the original HTTP bytes.
+
+The independently reviewed host profile has this shape:
+
+```json
+{
+  "apiVersion": "celln.dev/model-issuer-profile-v1",
+  "requestBinding": "blake3:<reviewed binding>",
+  "credentialFile": "/operator-owned/provider-token",
+  "model": "deepseek-chat",
+  "url": "https://api.deepseek.com/chat/completions",
+  "maxRequests": 3,
+  "maxOutputTokens": 512,
+  "maxTotalOutputTokens": 1536
+}
+```
+
+Do not create this profile merely because an untrusted request asks for it.
+The operator must approve the complete request, including identity, behavior
+and spending authority, through an independent trust path. The issuer does not
+read credential contents or call a provider. It accepts profile names containing
+1–64 ASCII letters/digits/underscores/hyphens, not arbitrary input paths.
+
+Issuance runs challenge-bound member verification in a sealed cell without
+executing the Harness/tools, resolves the admitted closure and schemas, and
+validates the full existing JSON broker contract. In particular, each configured
+turn requires a reserved 512 output tokens. It rechecks the profile before
+atomically publishing a private, content-addressed `harness-grant-v3` file with
+no overwrite. Repeating the identical issuance accepts only identical existing
+bytes. The output includes a request with the issued grant hash, but no host
+credential path or contents.
+
+V3 binds the exact profile revision and normalized request. Every grant
+resolution rereads the profile; deletion, any byte change or request substitution
+refuses. This prevents an old grant file bypassing profile withdrawal at a new
+resolution. It is not a fleet-wide active-cell withdrawal claim. Existing
+manually provisioned v1/v2 grants keep their prior compatibility contract and
+do not acquire this new guarantee.
+
+## Scope and proof
+
+This process's member-check cache is not the serving dispatcher's cache.
+Issuance does not advertise readiness, prove functional adapter conformance,
+distribute artifacts, execute the Harness, or implement Sympozium's authenticated
+policy-to-host provisioning bridge. Those gates remain required.
+
+Portable tests cover exact request binding, self-hash normalization, path
+refusal, profile revision/withdrawal, issuer downgrade refusal and no publication
+when hardware/artifacts are unavailable. The explicit ignored
+`json_harness_grant_issuance_on_real_kvm` test uses `CELLN_HARNESS_PACKAGE` from
+the native JSON proof package, calls issuance twice, checks idempotent bytes,
+resolves the issued v3 grant, and removes the profile to prove refusal. It uses
+a nonexistent credential path and makes no model calls. Require its explicit
+`PASS real-KVM issuer` output; portable tests alone are not a hardware proof.
+
+The [2026-09-07 recorded run](evidence/harness-grant-issuer-2026-09-07.json)
+passed that explicit hardware test, along with portable `make ci` and
+all-target/all-feature Clippy. It proves local issuance and resolution only.

--- a/docs/evidence/harness-grant-issuer-2026-09-07.json
+++ b/docs/evidence/harness-grant-issuer-2026-09-07.json
@@ -1,0 +1,225 @@
+{
+  "status": "passed",
+  "date": "2026-09-07",
+  "scope": "local operator issuance + real KVM member verification + dispatcher grant resolution; not model execution or controller integration",
+  "modelCalls": 0,
+  "credentialContentsRead": false,
+  "idempotentPublication": true,
+  "profileWithdrawalRefused": true,
+  "observations": [
+    {
+      "apiVersion": "celln.dev/harness-issuance-v1",
+      "artifactReadiness": "not_checked",
+      "conformance": "not_checked",
+      "executed": false,
+      "grant": "blake3:1745d06dd1725a4cc9c3cadac675cdd9347592be76c0cc2265ddd72ddcf9e6cf",
+      "request": {
+        "apiVersion": "celln.dev/v1alpha3",
+        "capabilities": {
+          "egress": [
+            "https://api.deepseek.com"
+          ],
+          "memoryBytes": 268435456,
+          "outputBytes": 65536,
+          "timeoutMs": 180000,
+          "workspace": "none"
+        },
+        "execution": {
+          "lane": "agent",
+          "requireHardwareIsolation": true
+        },
+        "forge": null,
+        "harness": {
+          "borrowedTools": [
+            {
+              "description": "Uppercase text",
+              "hash": "blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c",
+              "jsonStdio": {
+                "abi": "celln.json-stdio/v1",
+                "inputBytes": 1024,
+                "inputSchema": "blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6",
+                "outputBytes": 1024,
+                "outputSchema": "blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6",
+                "timeoutMs": 1000
+              },
+              "name": "uppercase",
+              "path": "/uppercase"
+            },
+            {
+              "description": "Measure text length",
+              "hash": "blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245",
+              "jsonStdio": {
+                "abi": "celln.json-stdio/v1",
+                "inputBytes": 1024,
+                "inputSchema": "blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6",
+                "outputBytes": 1024,
+                "outputSchema": "blake3:334d8ed405e3789cc513dc297a2137ee175e9f2b91743deb1e73e15517cf72d5",
+                "timeoutMs": 1000
+              },
+              "name": "length",
+              "path": "/length"
+            }
+          ],
+          "contractVersion": "celln.json-tools/v1",
+          "json": {
+            "maxCalls": 2,
+            "maxTurns": 3,
+            "system": "Use the explicitly lent tools."
+          },
+          "model": "deepseek-chat",
+          "modelGrant": {
+            "hash": "blake3:1745d06dd1725a4cc9c3cadac675cdd9347592be76c0cc2265ddd72ddcf9e6cf"
+          },
+          "task": "Call uppercase with text celln, wait for its result, then call length with the uppercase result. Wait for both tool results. Finally answer exactly: CELLN has length 5"
+        },
+        "id": "harness-dispatch-proof",
+        "inputs": [],
+        "invocation": {
+          "alias": "/harness",
+          "args": []
+        },
+        "mote": {
+          "hash": "blake3:69dd16ead0088c22dbd6cc36f7d7bec88a46bdb9386ba99e369985cd0659f29b"
+        },
+        "tools": [
+          {
+            "alias": "/harness",
+            "closure": {
+              "hash": "blake3:a8862c2652dc4a460c6e16bc111de2616f0afad036db7c3baf1209afac2b9d82"
+            },
+            "hash": "blake3:e0b47f4d4473dabec0a759f5915bf7b85f3c146a08d504ab6104f9b95ff8fa47"
+          }
+        ],
+        "workload": {
+          "caller": "test:controller",
+          "id": "test-run"
+        }
+      },
+      "verification": {
+        "apiVersion": "celln.dev/sealed-members-verification-v1",
+        "artifactReadiness": "not_checked",
+        "cellDissolved": true,
+        "challenge": "blake3:5756e43d538e418dc9ceacaffc21712af600c2028b03139b95de9c048ff59bd8",
+        "closure": "blake3:a8862c2652dc4a460c6e16bc111de2616f0afad036db7c3baf1209afac2b9d82",
+        "conformance": "not_checked",
+        "initrd": "blake3:30cd3684ea388042986cab121c7cd70da40fbef2e0f5832c9e4857d5d65991a5",
+        "kernel": "blake3:e8e05482b24c4d9019ff7298f42f6f2730fcf656cbcb429ec44150ceac0e4ca8",
+        "memberCount": 4,
+        "memberIntegrity": "verified-in-sealed-cell",
+        "mote": "blake3:69dd16ead0088c22dbd6cc36f7d7bec88a46bdb9386ba99e369985cd0659f29b",
+        "publisher": "197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61",
+        "requestHash": "blake3:bbd9ef879ff094b4f3568a8b850b237373ef03967599afd44a310076825c72c8",
+        "scope": "sealed-member-identities-only",
+        "toolExecution": false,
+        "toolfs": "blake3:68d46fb9468200a3455b75472c104a47a67223694e285db3893e38c100cece47"
+      }
+    },
+    {
+      "apiVersion": "celln.dev/harness-issuance-v1",
+      "artifactReadiness": "not_checked",
+      "conformance": "not_checked",
+      "executed": false,
+      "grant": "blake3:1745d06dd1725a4cc9c3cadac675cdd9347592be76c0cc2265ddd72ddcf9e6cf",
+      "request": {
+        "apiVersion": "celln.dev/v1alpha3",
+        "capabilities": {
+          "egress": [
+            "https://api.deepseek.com"
+          ],
+          "memoryBytes": 268435456,
+          "outputBytes": 65536,
+          "timeoutMs": 180000,
+          "workspace": "none"
+        },
+        "execution": {
+          "lane": "agent",
+          "requireHardwareIsolation": true
+        },
+        "forge": null,
+        "harness": {
+          "borrowedTools": [
+            {
+              "description": "Uppercase text",
+              "hash": "blake3:2696e782ed2d35ec85cb07057b27a4ed1068862edb5ce8b40510d87e8dd58d0c",
+              "jsonStdio": {
+                "abi": "celln.json-stdio/v1",
+                "inputBytes": 1024,
+                "inputSchema": "blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6",
+                "outputBytes": 1024,
+                "outputSchema": "blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6",
+                "timeoutMs": 1000
+              },
+              "name": "uppercase",
+              "path": "/uppercase"
+            },
+            {
+              "description": "Measure text length",
+              "hash": "blake3:8da2133cbe208448e3aa8fe6b8e91d6cd6b66ae3bc93fb81e18916f6488bd245",
+              "jsonStdio": {
+                "abi": "celln.json-stdio/v1",
+                "inputBytes": 1024,
+                "inputSchema": "blake3:0dfab6d82264eae8236cdfe7e66e7dd9d99f7afe6fe80cc01ddaef3791e54ab6",
+                "outputBytes": 1024,
+                "outputSchema": "blake3:334d8ed405e3789cc513dc297a2137ee175e9f2b91743deb1e73e15517cf72d5",
+                "timeoutMs": 1000
+              },
+              "name": "length",
+              "path": "/length"
+            }
+          ],
+          "contractVersion": "celln.json-tools/v1",
+          "json": {
+            "maxCalls": 2,
+            "maxTurns": 3,
+            "system": "Use the explicitly lent tools."
+          },
+          "model": "deepseek-chat",
+          "modelGrant": {
+            "hash": "blake3:1745d06dd1725a4cc9c3cadac675cdd9347592be76c0cc2265ddd72ddcf9e6cf"
+          },
+          "task": "Call uppercase with text celln, wait for its result, then call length with the uppercase result. Wait for both tool results. Finally answer exactly: CELLN has length 5"
+        },
+        "id": "harness-dispatch-proof",
+        "inputs": [],
+        "invocation": {
+          "alias": "/harness",
+          "args": []
+        },
+        "mote": {
+          "hash": "blake3:69dd16ead0088c22dbd6cc36f7d7bec88a46bdb9386ba99e369985cd0659f29b"
+        },
+        "tools": [
+          {
+            "alias": "/harness",
+            "closure": {
+              "hash": "blake3:a8862c2652dc4a460c6e16bc111de2616f0afad036db7c3baf1209afac2b9d82"
+            },
+            "hash": "blake3:e0b47f4d4473dabec0a759f5915bf7b85f3c146a08d504ab6104f9b95ff8fa47"
+          }
+        ],
+        "workload": {
+          "caller": "test:controller",
+          "id": "test-run"
+        }
+      },
+      "verification": {
+        "apiVersion": "celln.dev/sealed-members-verification-v1",
+        "artifactReadiness": "not_checked",
+        "cellDissolved": true,
+        "challenge": "blake3:025af3db559db1e29f7dbab098c5fdc8f47dc2f51b39d85bb6574558752c4187",
+        "closure": "blake3:a8862c2652dc4a460c6e16bc111de2616f0afad036db7c3baf1209afac2b9d82",
+        "conformance": "not_checked",
+        "initrd": "blake3:30cd3684ea388042986cab121c7cd70da40fbef2e0f5832c9e4857d5d65991a5",
+        "kernel": "blake3:e8e05482b24c4d9019ff7298f42f6f2730fcf656cbcb429ec44150ceac0e4ca8",
+        "memberCount": 4,
+        "memberIntegrity": "verified-in-sealed-cell",
+        "mote": "blake3:69dd16ead0088c22dbd6cc36f7d7bec88a46bdb9386ba99e369985cd0659f29b",
+        "publisher": "197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61",
+        "requestHash": "blake3:06066f284223fc316674db656881552340fd2b0938ed02d2c356aa1611bad2c1",
+        "scope": "sealed-member-identities-only",
+        "toolExecution": false,
+        "toolfs": "blake3:68d46fb9468200a3455b75472c104a47a67223694e285db3893e38c100cece47"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Part of sympozium-ai/sympozium#426, paired with control-plane policy resolution in sympozium-ai/sympozium#442.

Adds local operator harness-binding and harness-grant commands. Independent host profiles approve a normalized exact request binding (excluding only the circular model-grant hash), credential mapping and bounded model policy. Issuance verifies sealed guest members and the admitted JSON/schema/broker contract before atomic no-overwrite publication. V3 resolution rereads the exact issuing profile and refuses withdrawal, replacement or task/identity/authority substitution. Existing manually provisioned v1/v2 grants retain their prior contract.

Validation: make ci, workspace all-target/all-feature Clippy, and explicit real-KVM issuance test passed. The hardware test issues twice, checks identical publication, resolves the v3 grant, removes the profile and proves refusal while the grant file remains. No credentials read or model calls; evidence committed under docs/evidence/harness-grant-issuer-2026-09-07.json.

Scope: local operator issuance only. No tenant upload endpoint, no serving-process readiness assertion, no functional Harness/model E2E, no fleet active-withdrawal claim. Sympozium authenticated policy-to-host provisioning and catalogue-backed execution remain open.