### PR TITLE
feat: enforce boot-bound model profile admission expiry

### DIFF
--- a/crates/celln-cli/src/dispatch_harness.rs
+++ b/crates/celln-cli/src/dispatch_harness.rs
@@ -10,6 +10,7 @@ use std::{
 #[path = "dispatch_harness_issuer.rs"]
 mod issuer;
 pub(crate) use issuer::inspect_binding;
+pub(crate) use issuer::inspect_clock;
 pub(crate) use issuer::issue;
 #[cfg(test)]
 pub(crate) use issuer::prove_issuance;

--- a/crates/celln-cli/src/dispatch_harness_expiry.rs
+++ b/crates/celln-cli/src/dispatch_harness_expiry.rs
@@ -1,0 +1,172 @@
+//! Admission expiry, not renewal or active-cell revocation. Linux boot identity
+//! and CLOCK_BOOTTIME avoid wall-clock rollback and invalidate prior-boot files.
+use serde::{Deserialize, Serialize};
+
+const MAX_LIFETIME_MS: u64 = 300_000;
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct Expiry {
+    boot_id: String,
+    issued_at_boottime_ms: u64,
+    expires_at_boottime_ms: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Clock {
+    boot_id: String,
+    boottime_ms: u64,
+}
+
+impl Expiry {
+    pub(super) fn validate_current(&self) -> Result<(), String> {
+        self.validate(&host_clock()?)
+    }
+
+    fn validate(&self, clock: &Clock) -> Result<(), String> {
+        let lifetime = self
+            .expires_at_boottime_ms
+            .checked_sub(self.issued_at_boottime_ms);
+        if !valid_boot_id(&self.boot_id)
+            || self.boot_id != clock.boot_id
+            || !matches!(lifetime, Some(1..=MAX_LIFETIME_MS))
+            || self.issued_at_boottime_ms > clock.boottime_ms
+            || clock.boottime_ms >= self.expires_at_boottime_ms
+        {
+            return Err("operator model profile expired or invalid for this host boot".into());
+        }
+        Ok(())
+    }
+}
+
+fn valid_boot_id(id: &str) -> bool {
+    id.len() == 36
+        && id.bytes().enumerate().all(|(i, c)| {
+            if [8, 13, 18, 23].contains(&i) {
+                c == b'-'
+            } else {
+                c.is_ascii_digit() || (b'a'..=b'f').contains(&c)
+            }
+        })
+}
+
+#[cfg(target_os = "linux")]
+fn host_clock() -> Result<Clock, String> {
+    use std::io::Read;
+    let mut boot_id = String::new();
+    std::fs::File::open("/proc/sys/kernel/random/boot_id")
+        .and_then(|f| f.take(128).read_to_string(&mut boot_id))
+        .map_err(|_| "host boot identity unavailable")?;
+    let boot_id = boot_id.trim().to_owned();
+    if !valid_boot_id(&boot_id) {
+        return Err("invalid host boot identity".into());
+    }
+    let mut time = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: points to initialized writable storage of the required type.
+    if unsafe { libc::clock_gettime(libc::CLOCK_BOOTTIME, &mut time) } != 0
+        || time.tv_sec < 0
+        || !(0..1_000_000_000).contains(&time.tv_nsec)
+    {
+        return Err("host boot clock unavailable".into());
+    }
+    let boottime_ms = (time.tv_sec as u64)
+        .checked_mul(1000)
+        .and_then(|ms| ms.checked_add(time.tv_nsec as u64 / 1_000_000))
+        .ok_or("host boot clock overflow")?;
+    Ok(Clock {
+        boot_id,
+        boottime_ms,
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn host_clock() -> Result<Clock, String> {
+    Err(
+        "Unsupported: expiring model profiles require Linux boot identity and CLOCK_BOOTTIME"
+            .into(),
+    )
+}
+
+pub(crate) fn inspect_clock() -> anyhow::Result<u8> {
+    let clock = host_clock().map_err(anyhow::Error::msg)?;
+    println!(
+        "{}",
+        serde_json::json!({
+            "apiVersion": "celln.dev/model-profile-clock-v1",
+            "bootId": clock.boot_id, "boottimeMs": clock.boottime_ms,
+            "maxLifetimeMs": MAX_LIFETIME_MS, "executionAuthorized": false
+        })
+    );
+    Ok(0)
+}
+
+#[cfg(test)]
+pub(super) fn test_expiry(lifetime_ms: u64) -> Expiry {
+    let clock = host_clock().unwrap();
+    Expiry {
+        boot_id: clock.boot_id,
+        issued_at_boottime_ms: clock.boottime_ms,
+        expires_at_boottime_ms: clock.boottime_ms + lifetime_ms,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expiry_is_bounded_exclusive_and_boot_specific() {
+        let id = "01234567-89ab-cdef-0123-456789abcdef";
+        let mut expiry = Expiry {
+            boot_id: id.into(),
+            issued_at_boottime_ms: 100,
+            expires_at_boottime_ms: 200,
+        };
+        for (now, valid) in [
+            (99, false),
+            (100, true),
+            (199, true),
+            (200, false),
+            (u64::MAX, false),
+        ] {
+            assert_eq!(
+                expiry
+                    .validate(&Clock {
+                        boot_id: id.into(),
+                        boottime_ms: now
+                    })
+                    .is_ok(),
+                valid
+            );
+        }
+        assert!(expiry
+            .validate(&Clock {
+                boot_id: "other-boot".into(),
+                boottime_ms: 150
+            })
+            .is_err());
+        for end in [0, 100, 300_101, u64::MAX] {
+            expiry.expires_at_boottime_ms = end;
+            assert!(expiry
+                .validate(&Clock {
+                    boot_id: id.into(),
+                    boottime_ms: 100
+                })
+                .is_err());
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn reads_real_boot_clock_without_wall_time() {
+        let first = host_clock().unwrap();
+        let second = host_clock().unwrap();
+        assert!(valid_boot_id(&first.boot_id));
+        assert_eq!(first.boot_id, second.boot_id);
+        assert!(second.boottime_ms >= first.boottime_ms);
+    }
+}

--- a/crates/celln-cli/src/dispatch_harness_issuer.rs
+++ b/crates/celln-cli/src/dispatch_harness_issuer.rs
@@ -1,6 +1,10 @@
 //! Local operator issuance. This is not an upload endpoint or a tenant authority.
 use super::*;
 
+#[path = "dispatch_harness_expiry.rs"]
+mod expiry;
+pub(crate) use expiry::inspect_clock;
+
 #[cfg(test)]
 #[path = "dispatch_harness_issuer_tests.rs"]
 mod tests;
@@ -34,6 +38,8 @@ pub(super) struct Binding {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Profile {
     api_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    expiry: Option<expiry::Expiry>,
     request_binding: String,
     credential_file: PathBuf,
     model: String,
@@ -73,8 +79,12 @@ fn profile(root: &Path, name: &str) -> Result<(Profile, String), String> {
     }
     let p: Profile =
         serde_json::from_slice(&bytes).map_err(|_| "invalid operator model profile")?;
-    if p.api_version != "celln.dev/model-issuer-profile-v1"
-        || !p.credential_file.is_absolute()
+    match (p.api_version.as_str(), &p.expiry) {
+        ("celln.dev/model-issuer-profile-v1", None) => {}
+        ("celln.dev/model-issuer-profile-v2", Some(expiry)) => expiry.validate_current()?,
+        _ => return Err("unsupported operator model profile expiry contract".into()),
+    }
+    if !p.credential_file.is_absolute()
         || p.url != "https://api.deepseek.com/chat/completions"
         || p.model.is_empty()
         || p.model.len() > 128

--- a/crates/celln-cli/src/dispatch_harness_issuer_tests.rs
+++ b/crates/celln-cli/src/dispatch_harness_issuer_tests.rs
@@ -3,6 +3,7 @@ use serde_json::json;
 
 pub(super) fn prove_issuance(request: &ExecutionRequest, root: &Path) {
     let profile = setup(root, request);
+    set_expiry(&profile, 300_000);
     let bytes = candidate(request, "reviewed", root).unwrap();
     let hash = Hash::of(&bytes);
     let path = root.join("issuer-request.json");
@@ -24,7 +25,44 @@ pub(super) fn prove_issuance(request: &ExecutionRequest, root: &Path) {
     assert!(resolve(&bound, closure.as_ref(), root).is_err());
     assert!(issue(&path, "reviewed", root).is_err());
     assert_eq!(std::fs::read(issued).unwrap(), bytes);
-    eprintln!("PASS real-KVM issuer: two checks, idempotent publication, v3 resolution and policy withdrawal refusal; modelCalls=0; grant={}", hash.0);
+    eprintln!("PASS real-KVM issuer: boot-bound expiring profile, two checks, idempotent publication, v3 resolution and policy withdrawal refusal; modelCalls=0; grant={}", hash.0);
+}
+
+fn set_expiry(path: &Path, lifetime_ms: u64) {
+    let mut profile: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+    profile["apiVersion"] = json!("celln.dev/model-issuer-profile-v2");
+    profile["expiry"] = serde_json::to_value(expiry::test_expiry(lifetime_ms)).unwrap();
+    std::fs::write(path, serde_json::to_vec(&profile).unwrap()).unwrap();
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn unchanged_profile_expires_without_a_reconciler_and_cannot_downgrade() {
+    let root = tempfile::tempdir().unwrap();
+    let (request, closure, _) = super::super::json_tests::fixture(root.path());
+    let path = setup(root.path(), &request);
+    set_expiry(&path, 500);
+    let original = std::fs::read(&path).unwrap();
+    let bytes = candidate(&request, "reviewed", root.path()).unwrap();
+    assert!(resolve_bytes(&request, &closure, root.path(), &bytes).is_ok());
+    let mut altered: serde_json::Value = serde_json::from_slice(&original).unwrap();
+    altered["apiVersion"] = json!("celln.dev/model-issuer-profile-v1");
+    std::fs::write(&path, serde_json::to_vec(&altered).unwrap()).unwrap();
+    assert!(candidate(&request, "reviewed", root.path()).is_err());
+    altered["apiVersion"] = json!("celln.dev/model-issuer-profile-v2");
+    altered.as_object_mut().unwrap().remove("expiry");
+    std::fs::write(&path, serde_json::to_vec(&altered).unwrap()).unwrap();
+    assert!(candidate(&request, "reviewed", root.path()).is_err());
+    std::fs::write(&path, &original).unwrap();
+    // No profile mutation, cleanup worker or API call causes this refusal.
+    std::thread::sleep(std::time::Duration::from_millis(510));
+    assert!(resolve_bytes(&request, &closure, root.path(), &bytes)
+        .err()
+        .unwrap()
+        .contains("expired"));
+    assert!(candidate(&request, "reviewed", root.path()).is_err());
+    assert_eq!(std::fs::read(path).unwrap(), original);
 }
 
 fn setup(root: &Path, request: &ExecutionRequest) -> PathBuf {

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -68,6 +68,8 @@ struct Cli {
 enum Cmd {
     /// Inspect a request binding for operator review; grants no authority.
     HarnessBinding { request: PathBuf },
+    /// Inspect this host's boot clock for bounded model-profile expiry (no authority).
+    HarnessProfileClock,
     /// Issue a request-bound model grant from an independently provisioned host profile.
     HarnessGrant {
         request: PathBuf,
@@ -450,6 +452,7 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
     let root = resolve_root(&cli.root);
     match &cli.cmd {
         Cmd::HarnessBinding { request } => dispatch::harness::inspect_binding(request),
+        Cmd::HarnessProfileClock => dispatch::harness::inspect_clock(),
         Cmd::HarnessGrant { request, profile } => dispatch::harness::issue(request, profile, &root),
         Cmd::Closure(ClosureCmd::Compose {
             plan,

--- a/docs/HARNESS_GRANT_ISSUANCE.md
+++ b/docs/HARNESS_GRANT_ISSUANCE.md
@@ -51,6 +51,47 @@ resolution. It is not a fleet-wide active-cell withdrawal claim. Existing
 manually provisioned v1/v2 grants keep their prior compatibility contract and
 do not acquire this new guarantee.
 
+## Expiring profiles for unattended provisioning
+
+`celln.dev/model-issuer-profile-v2` keeps the fields above and **requires** an
+`expiry` object. Obtain this host's clock with `celln harness-profile-clock`:
+the versioned report contains `bootId`, `boottimeMs`, and `maxLifetimeMs` (300000).
+It reads no credentials and grants no authority. The operator may copy the boot
+identity and observed time into this additional profile field:
+
+```json
+{
+  "bootId": "<this host's reported Linux boot UUID>",
+  "issuedAtBoottimeMs": 1234000,
+  "expiresAtBoottimeMs": 1354000
+}
+```
+
+These are elapsed boot milliseconds, **not Unix timestamps**. The numbers above
+are illustrative; use the actual host report and an independently approved
+lifetime of at most five minutes. Linux `CLOCK_BOOTTIME` includes suspend time
+and does not follow wall-clock adjustments. The boot UUID must match; profiles
+from a previous boot refuse. Other operating systems return `Unsupported`.
+This trusts the host kernel/clock and operator configuration, not tenant time.
+
+Future issuance times, expired profiles (including equality at the deadline),
+zero/reversed/overlong windows and missing expiry refuse. V1 cannot carry expiry;
+v2 cannot omit it. Earlier Celln versions reject v2 rather than ignore expiry.
+Every issuance policy check and v3 grant resolution enforces this window,
+including the serving path's recheck after warm preparation. The profile may
+remain on disk after a reconciler crashes, but its authority at a new check does
+not remain valid indefinitely. Profile removal can still withdraw it earlier.
+
+Expiry is an **admission gate**, not live cancellation: an execution already
+admitted remains bounded by its existing execution deadline and budgets. It
+does not prove active-cell or fleet-wide withdrawal. There is no lease renewal;
+editing the expiry changes the pinned profile hash and invalidates old grants.
+New authority requires independent reapproval and issuance, with the same
+execution ownership/replay rules; expiry never authorizes replay. Unattended
+Sympozium provisioning must require v2 and startup reconciliation before claiming
+this protection. Legacy v1 profiles retain explicit-operator compatibility and
+do not gain expiry automatically.
+
 ## Scope and proof
 
 This process's member-check cache is not the serving dispatcher's cache.

--- a/docs/evidence/model-profile-expiry-2026-09-07.json
+++ b/docs/evidence/model-profile-expiry-2026-09-07.json
@@ -1,0 +1,35 @@
+{
+  "date": "2026-09-07",
+  "scope": "host-enforced new-issuance and grant-resolution expiry",
+  "profileVersion": "celln.dev/model-issuer-profile-v2",
+  "grantVersion": "celln.dev/harness-grant-v3",
+  "clock": "Linux boot UUID plus CLOCK_BOOTTIME; no wall time",
+  "maxLifetimeMs": 300000,
+  "portableChecks": {
+    "makeCi": "passed",
+    "clippyAllTargetsAllFeaturesDenyWarnings": "passed",
+    "issuerTests": "6 passed; none skipped in the targeted Linux run",
+    "expiryCases": [
+      "future issuance, exact expiry boundary and expired profile refused",
+      "zero, reversed, overlong and overflowing lifetime refused",
+      "different boot identity refused (injected clock; no actual host reboot)",
+      "actual Linux boot clock read succeeds",
+      "unchanged profile bytes expire without a reconciler",
+      "version downgrade or omitted v2 expiry refused"
+    ]
+  },
+  "realKVM": {
+    "test": "json_harness_grant_issuance_on_real_kvm --ignored --nocapture",
+    "result": "passed",
+    "sequence": "boot-bound expiring profile -> sealed member verification twice -> identical v3 grant -> resolution -> profile removal -> refusal",
+    "grant": "blake3:f34fe836947e4943eab20d21480964442c75310792c915851b6e772f792a72a2",
+    "modelCalls": 0
+  },
+  "notProven": [
+    "live cancellation at expiry or fleet-wide revocation",
+    "actual host reboot, suspend or clock-adjustment qualification",
+    "autonomous Sympozium provisioning requiring expiring profiles",
+    "lease renewal or replay authorization",
+    "UI/YAML or conversational end-to-end acceptance"
+  ]
+}


### PR DESCRIPTION
Part of sympozium-ai/sympozium#426; complements approval reconciliation in sympozium-ai/sympozium#445.

Adds model-issuer-profile-v2 with a required boot-bound expiry window of at most five minutes. Linux boot UUID and CLOCK_BOOTTIME avoid wall-clock rollback and invalidate prior-boot profiles; unsupported platforms refuse. The local harness-profile-clock command reports the host clock without credentials or execution authority. V1 explicit-operator profiles remain compatible; earlier Celln versions reject v2 rather than ignore expiry.

Every issuance policy check and v3 grant resolution validates expiry, including the existing serving-path recheck after warm preparation. No renewal or implicit replay. This is an admission gate, not active-cell cancellation; existing execution deadlines/budgets still govern already admitted cells. Sympozium unattended provisioning must require v2 before claiming this protection.

Validation: make ci, all-target/all-feature Clippy with warnings denied, six targeted issuer tests, and explicit real-KVM issuance under an expiring profile passed. A separate test leaves profile bytes unchanged and proves refusal after elapsed expiry without any reconciler. Boundary/boot mismatch tests use injected clock values; no host reboot or suspend was performed. No model calls. Evidence and compatibility limits are committed.