### PR TITLE
feat: prepare candidate motes from operator-pinned templates

### DIFF
--- a/crates/celln-cli/src/dispatch_closure_tests.rs
+++ b/crates/celln-cli/src/dispatch_closure_tests.rs
@@ -167,6 +167,30 @@ fn signed_closure_on_real_kvm() {
     Store::open(&tools).unwrap().put(&program_bytes).unwrap();
     let kernel_hash = store.put(&std::fs::read(kernel).unwrap()).unwrap();
     let initrd_hash = store.put(&std::fs::read(&initrd).unwrap()).unwrap();
+    // Candidate verification must work before this test grants any production
+    // mote admission, and must not manufacture that admission as a side effect.
+    let candidate = work.path().join("candidate");
+    std::fs::create_dir(&candidate).unwrap();
+    let template = serde_json::to_vec(&json!({"apiVersion":"celln.dev/mote-template-v1","kernel":kernel_hash.0,"initrd":initrd_hash.0,"runtimeExecutable":program_hash.0,"runtimeEntryPoint":signed.closure.entrypoint,"composerPublisher":signed.publisher})).unwrap();
+    std::fs::write(candidate.join("template.json"), &template).unwrap();
+    std::fs::write(
+        candidate.join("signed-closure.json"),
+        serde_json::to_vec(&signed).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(candidate.join("toolfs.ext2"), &image_bytes).unwrap();
+    let candidate_report =
+        crate::mote_check::check(&candidate, &Hash::of(&template).0, &motes, &tools, &state)
+            .unwrap();
+    assert_eq!(
+        candidate_report["members"]["memberIntegrity"],
+        "verified-in-sealed-cell"
+    );
+    assert_eq!(candidate_report["members"]["toolExecution"], false);
+    assert_eq!(candidate_report["members"]["cellDissolved"], true);
+    assert_eq!(candidate_report["admitted"], false);
+    assert!(!state.join("trusted-motes.json").exists());
+    eprintln!("CANDIDATE_MEMBER_PROOF={candidate_report}");
     store.put(&image_bytes).unwrap();
     let bundle = store.put(&serde_json::to_vec(&json!({"apiVersion":"celln.dev/v1alpha1", "format":"celln.warm-closure-v1", "kernel":kernel_hash.0,"initrd":initrd_hash.0,"toolfs":image_hash.0,"invocation":{"alias":"/closure/program","toolHash":program_hash.0}})).unwrap()).unwrap();
     std::fs::write(

--- a/crates/celln-cli/src/dispatch_closure_tests.rs
+++ b/crates/celln-cli/src/dispatch_closure_tests.rs
@@ -191,6 +191,24 @@ fn signed_closure_on_real_kvm() {
     assert_eq!(candidate_report["admitted"], false);
     assert!(!state.join("trusted-motes.json").exists());
     eprintln!("CANDIDATE_MEMBER_PROOF={candidate_report}");
+    let admitted = crate::mote_admit::admit(
+        &candidate,
+        &Hash::of(&template).0,
+        candidate_report["mote"]["hash"].as_str().unwrap(),
+        &motes,
+        &tools,
+        &state,
+    )
+    .unwrap();
+    assert_eq!(admitted["admitted"], true);
+    crate::mote_admit::withdraw(candidate_report["mote"]["hash"].as_str().unwrap(), &state)
+        .unwrap();
+    let withdrawn: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(state.join("trusted-motes.json")).unwrap()).unwrap();
+    assert!(withdrawn["bundles"].as_array().unwrap().is_empty());
+    eprintln!(
+        "CANDIDATE_ADMISSION_PROOF={admitted}; exact mote withdrawn, stored artifacts retained"
+    );
     store.put(&image_bytes).unwrap();
     let bundle = store.put(&serde_json::to_vec(&json!({"apiVersion":"celln.dev/v1alpha1", "format":"celln.warm-closure-v1", "kernel":kernel_hash.0,"initrd":initrd_hash.0,"toolfs":image_hash.0,"invocation":{"alias":"/closure/program","toolHash":program_hash.0}})).unwrap()).unwrap();
     std::fs::write(

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -13,6 +13,7 @@ mod dispatch_conformance;
 mod dispatch_http;
 mod host;
 mod image;
+mod mote_admit;
 mod mote_check;
 mod mote_prepare;
 mod node;
@@ -349,6 +350,24 @@ enum NodeCmd {
 
 #[derive(Subcommand)]
 enum ClosureCmd {
+    /// Administrator approval: verify a candidate on KVM, publish bytes and admit its exact mote.
+    AdmitPrepared {
+        #[arg(long)]
+        candidate: PathBuf,
+        #[arg(long)]
+        template_hash: String,
+        #[arg(long)]
+        approve_mote: String,
+        #[arg(long)]
+        mote_store: PathBuf,
+        #[arg(long)]
+        tool_store: PathBuf,
+    },
+    /// Remove an exact mote from host admission. Does not cancel already-running cells.
+    WithdrawMote {
+        #[arg(long)]
+        mote: String,
+    },
     /// Check pinned candidate members in an isolated sealed cell before production admission.
     CheckPrepared {
         #[arg(long)]
@@ -480,6 +499,30 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
     let root = resolve_root(&cli.root);
     match &cli.cmd {
         Cmd::HarnessBinding { request } => dispatch::harness::inspect_binding(request),
+        Cmd::Closure(ClosureCmd::AdmitPrepared {
+            candidate,
+            template_hash,
+            approve_mote,
+            mote_store,
+            tool_store,
+        }) => {
+            println!(
+                "{}",
+                mote_admit::admit(
+                    candidate,
+                    template_hash,
+                    approve_mote,
+                    mote_store,
+                    tool_store,
+                    &root
+                )?
+            );
+            Ok(0)
+        }
+        Cmd::Closure(ClosureCmd::WithdrawMote { mote }) => {
+            mote_admit::withdraw(mote, &root)?;
+            Ok(0)
+        }
         Cmd::Closure(ClosureCmd::CheckPrepared {
             candidate,
             template_hash,

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -13,6 +13,7 @@ mod dispatch_conformance;
 mod dispatch_http;
 mod host;
 mod image;
+mod mote_check;
 mod mote_prepare;
 mod node;
 mod out;
@@ -348,6 +349,17 @@ enum NodeCmd {
 
 #[derive(Subcommand)]
 enum ClosureCmd {
+    /// Check pinned candidate members in an isolated sealed cell before production admission.
+    CheckPrepared {
+        #[arg(long)]
+        candidate: PathBuf,
+        #[arg(long)]
+        template_hash: String,
+        #[arg(long)]
+        mote_store: PathBuf,
+        #[arg(long)]
+        tool_store: PathBuf,
+    },
     /// Cold-path preparation from an exact operator-reviewed template. Does not admit or boot.
     PrepareMote {
         #[arg(long)]
@@ -468,6 +480,18 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
     let root = resolve_root(&cli.root);
     match &cli.cmd {
         Cmd::HarnessBinding { request } => dispatch::harness::inspect_binding(request),
+        Cmd::Closure(ClosureCmd::CheckPrepared {
+            candidate,
+            template_hash,
+            mote_store,
+            tool_store,
+        }) => {
+            println!(
+                "{}",
+                mote_check::check(candidate, template_hash, mote_store, tool_store, &root)?
+            );
+            Ok(0)
+        }
         Cmd::Closure(ClosureCmd::PrepareMote {
             template,
             template_hash,

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -13,6 +13,7 @@ mod dispatch_conformance;
 mod dispatch_http;
 mod host;
 mod image;
+mod mote_prepare;
 mod node;
 mod out;
 mod router;
@@ -347,6 +348,21 @@ enum NodeCmd {
 
 #[derive(Subcommand)]
 enum ClosureCmd {
+    /// Cold-path preparation from an exact operator-reviewed template. Does not admit or boot.
+    PrepareMote {
+        #[arg(long)]
+        template: PathBuf,
+        #[arg(long)]
+        template_hash: String,
+        #[arg(long)]
+        descriptor: PathBuf,
+        #[arg(long)]
+        toolfs: PathBuf,
+        #[arg(long)]
+        mote_store: PathBuf,
+        #[arg(long)]
+        output_dir: PathBuf,
+    },
     /// Build and sign a filesystem from exact approved source closures and member blobs.
     Compose {
         plan: PathBuf,
@@ -452,6 +468,22 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
     let root = resolve_root(&cli.root);
     match &cli.cmd {
         Cmd::HarnessBinding { request } => dispatch::harness::inspect_binding(request),
+        Cmd::Closure(ClosureCmd::PrepareMote {
+            template,
+            template_hash,
+            descriptor,
+            toolfs,
+            mote_store,
+            output_dir,
+        }) => mote_prepare::run(
+            template,
+            template_hash,
+            descriptor,
+            toolfs,
+            mote_store,
+            output_dir,
+            &root,
+        ),
         Cmd::HarnessProfileClock => dispatch::harness::inspect_clock(),
         Cmd::HarnessGrant { request, profile } => dispatch::harness::issue(request, profile, &root),
         Cmd::Closure(ClosureCmd::Compose {

--- a/crates/celln-cli/src/mote_admit.rs
+++ b/crates/celln-cli/src/mote_admit.rs
@@ -1,0 +1,246 @@
+//! Explicit administrator-only host admission. Never exposed to guest requests.
+use anyhow::{ensure, Result};
+use celln_manifest::Hash;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::{collections::BTreeSet, fs, io::Write, path::Path};
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Policy {
+    api_version: String,
+    bundles: BTreeSet<String>,
+}
+
+fn valid_hash(hash: &str) -> bool {
+    hash.strip_prefix("blake3:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    })
+}
+
+fn lock(root: &Path) -> Result<fs::File> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = root;
+        anyhow::bail!("Unsupported: durable admission requires Linux");
+    }
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::{fd::AsRawFd, unix::fs::OpenOptionsExt};
+        fs::create_dir_all(root)?;
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+            .open(root.join("mote-admission.lock"))?;
+        ensure!(
+            file.metadata()?.is_file(),
+            "regular admission lock required"
+        );
+        ensure!(
+            unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0,
+            "admission is busy; retry later"
+        );
+        Ok(file)
+    }
+}
+
+fn read_policy(root: &Path) -> Result<(Policy, Option<Vec<u8>>)> {
+    let path = root.join("trusted-motes.json");
+    if !path.try_exists()? {
+        return Ok((
+            Policy {
+                api_version: "celln.dev/v1alpha1".into(),
+                bundles: BTreeSet::new(),
+            },
+            None,
+        ));
+    }
+    let bytes = crate::closure_policy::read_bounded(&path).map_err(anyhow::Error::msg)?;
+    let policy: Policy = serde_json::from_slice(&bytes)?;
+    ensure!(
+        policy.api_version == "celln.dev/v1alpha1"
+            && policy.bundles.len() <= 1024
+            && policy.bundles.iter().all(|h| valid_hash(h)),
+        "invalid or oversized mote policy"
+    );
+    Ok((policy, Some(bytes)))
+}
+
+fn atomic_file(path: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("parent required"))?;
+    let mut file = tempfile::NamedTempFile::new_in(parent)?;
+    file.write_all(bytes)?;
+    file.as_file().sync_all()?;
+    file.persist(path).map_err(|e| e.error)?;
+    fs::File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+fn commit_policy(root: &Path, policy: &Policy, previous: &Option<Vec<u8>>) -> Result<()> {
+    ensure!(
+        &read_policy(root)?.1 == previous,
+        "mote policy changed outside admission lock"
+    );
+    ensure!(policy.bundles.len() <= 1024, "mote admission policy full");
+    atomic_file(
+        &root.join("trusted-motes.json"),
+        &serde_json::to_vec(policy)?,
+    )
+}
+
+// Publish immutable objects durably before granting authority. A corrupt
+// pre-existing object refuses; never trust Store::put's dedup result alone.
+fn publish(root: &Path, bytes: &[u8]) -> Result<Hash> {
+    let hash = Hash::of(bytes);
+    let hex = &hash.0[7..];
+    let objects = root.join("objects");
+    let parent = objects.join(&hex[..2]);
+    fs::create_dir_all(&parent)?;
+    let target = parent.join(hex);
+    let mut temp = tempfile::NamedTempFile::new_in(&parent)?;
+    temp.write_all(bytes)?;
+    temp.as_file().sync_all()?;
+    match temp.persist_noclobber(&target) {
+        Ok(_) => (),
+        Err(e) if e.error.kind() == std::io::ErrorKind::AlreadyExists => (),
+        Err(e) => return Err(e.error.into()),
+    }
+    let stored = celln_store::Store::open(root)?.get_bounded(&hash, bytes.len())?;
+    ensure!(stored == bytes, "published object mismatch");
+    fs::File::open(&target)?.sync_all()?;
+    for dir in [&parent, &objects, &root.to_path_buf()] {
+        fs::File::open(dir)?.sync_all()?;
+    }
+    Ok(hash)
+}
+
+pub fn admit(
+    candidate: &Path,
+    template_hash: &str,
+    expected_mote: &str,
+    motes: &Path,
+    tools: &Path,
+    root: &Path,
+) -> Result<Value> {
+    ensure!(
+        valid_hash(expected_mote),
+        "exact approved mote hash required"
+    );
+    let _lock = lock(root)?;
+    let (mut policy, previous) = read_policy(root)?;
+    let work = crate::agent::tempdir()?;
+    let prepared = work.path().join("prepared");
+    let report = crate::mote_prepare::prepare(
+        &candidate.join("template.json"),
+        template_hash,
+        &candidate.join("signed-closure.json"),
+        &candidate.join("toolfs.ext2"),
+        motes,
+        &prepared,
+        root,
+    )?;
+    ensure!(
+        report["mote"]["hash"] == expected_mote,
+        "candidate differs from explicit administrator approval"
+    );
+    let checked = crate::mote_check::check(&prepared, template_hash, motes, tools, root)?;
+    ensure!(
+        checked["mote"] == report["mote"]
+            && checked["closure"] == report["closure"]
+            && checked["policyHash"] == report["policyHash"],
+        "candidate or policy changed during checking"
+    );
+    for name in ["kernel", "initrd", "toolfs.ext2", "mote.json"] {
+        publish(motes, &fs::read(prepared.join(name))?)?;
+    }
+    let raw = fs::read(prepared.join("signed-closure.json"))?;
+    publish(&root.join("closures"), &raw)?;
+    let current = crate::closure_policy::verify(&raw, root).map_err(anyhow::Error::msg)?;
+    ensure!(
+        current.policy_hash.0 == report["policyHash"],
+        "closure policy changed before admission"
+    );
+    // Evidence precedes the authority commit. A record alone is never admission;
+    // readers must consult current host policy. Unused blobs are safe on failure.
+    let records = root.join("mote-admission-evidence");
+    fs::create_dir_all(&records)?;
+    atomic_file(
+        &records.join(format!("{}.json", &expected_mote[7..])),
+        &serde_json::to_vec(&checked)?,
+    )?;
+    policy.bundles.insert(expected_mote.into());
+    let manifest = crate::mote_check::read_manifest(&root.join("assay/manifest.json"))?;
+    ensure!(
+        serde_json::to_value(manifest.as_ref().map(|b| Hash::of(b).0))?
+            == checked["localManifestHash"],
+        "local manifest changed before admission"
+    );
+    commit_policy(root, &policy, &previous)?;
+    Ok(
+        json!({"mote":{"hash":expected_mote},"closure":report["closure"],"admitted":true,"executionAuthorized":false,"readiness":"not_established","scope":"explicit administrator host admission; independent run/model grants still required"}),
+    )
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    #[test]
+    fn policy_commit_preserves_other_motes_and_detects_external_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let _lock = lock(root).unwrap();
+        assert!(lock(root).is_err());
+        let (mut policy, previous) = read_policy(root).unwrap();
+        let a = Hash::of(b"a").0;
+        let b = Hash::of(b"b").0;
+        policy.bundles.extend([a.clone(), b.clone()]);
+        commit_policy(root, &policy, &previous).unwrap();
+        assert!(commit_policy(root, &policy, &previous).is_err());
+        drop(_lock);
+        withdraw(&a, root).unwrap();
+        withdraw(&a, root).unwrap();
+        assert_eq!(read_policy(root).unwrap().0.bundles, BTreeSet::from([b]));
+        fs::write(root.join("trusted-motes.json"), b"{}").unwrap();
+        assert!(withdraw(&a, root).is_err());
+        assert_eq!(fs::read(root.join("trusted-motes.json")).unwrap(), b"{}");
+    }
+    #[test]
+    fn publication_is_verified_and_corrupt_dedup_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let hash = publish(dir.path(), b"bytes").unwrap();
+        assert_eq!(publish(dir.path(), b"bytes").unwrap(), hash);
+        let hex = &hash.0[7..];
+        let path = dir.path().join("objects").join(&hex[..2]).join(hex);
+        fs::write(&path, b"corrupt").unwrap();
+        assert!(publish(dir.path(), b"bytes").is_err());
+        assert_eq!(fs::read(&path).unwrap(), b"corrupt");
+    }
+    #[test]
+    fn bad_approval_refuses_before_creating_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(admit(dir.path(), "bad", "bad", dir.path(), dir.path(), dir.path()).is_err());
+        assert!(!dir.path().join("trusted-motes.json").exists());
+    }
+}
+
+pub fn withdraw(mote: &str, root: &Path) -> Result<()> {
+    ensure!(valid_hash(mote), "exact mote hash required");
+    let _lock = lock(root)?;
+    let (mut policy, previous) = read_policy(root)?;
+    policy.bundles.remove(mote);
+    commit_policy(root, &policy, &previous)?;
+    println!(
+        "{}",
+        json!({"mote":mote,"admitted":false,"activeCellsCancelled":false})
+    );
+    Ok(())
+}

--- a/crates/celln-cli/src/mote_check.rs
+++ b/crates/celln-cli/src/mote_check.rs
@@ -5,7 +5,7 @@ use celln_store::Store;
 use serde_json::{json, Value};
 use std::{fs, io::Read, path::Path};
 
-fn read_manifest(path: &Path) -> Result<Option<Vec<u8>>> {
+pub(crate) fn read_manifest(path: &Path) -> Result<Option<Vec<u8>>> {
     let mut options = fs::OpenOptions::new();
     options.read(true);
     #[cfg(unix)]
@@ -26,31 +26,6 @@ fn read_manifest(path: &Path) -> Result<Option<Vec<u8>>> {
     file.take((8 << 20) + 1).read_to_end(&mut bytes)?;
     ensure!(bytes.len() <= 8 << 20, "local manifest exceeds check limit");
     Ok(Some(bytes))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn local_manifest_read_is_bounded_and_refuses_nonregular_inputs() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("manifest");
-        assert!(read_manifest(&path).unwrap().is_none());
-        fs::write(&path, b"{}").unwrap();
-        assert_eq!(read_manifest(&path).unwrap(), Some(b"{}".to_vec()));
-        fs::File::create(&path)
-            .unwrap()
-            .set_len((8 << 20) + 1)
-            .unwrap();
-        assert!(read_manifest(&path).is_err());
-        assert!(read_manifest(dir.path()).is_err());
-        #[cfg(unix)]
-        {
-            let link = dir.path().join("link");
-            std::os::unix::fs::symlink(&path, &link).unwrap();
-            assert!(read_manifest(&link).is_err());
-        }
-    }
 }
 
 pub fn check(
@@ -125,6 +100,31 @@ pub fn check(
         "local manifest changed during member check"
     );
     Ok(
-        json!({"apiVersion":"celln.dev/prepared-members-check-v1","template":template_hash,"mote":report["mote"],"closure":report["closure"],"policyHash":report["policyHash"],"members":members,"admitted":false,"executionAuthorized":false,"runtimeConformance":"not_checked","readiness":"not_established"}),
+        json!({"apiVersion":"celln.dev/prepared-members-check-v1","template":template_hash,"mote":report["mote"],"closure":report["closure"],"policyHash":report["policyHash"],"localManifestHash":manifest.as_ref().map(|b|Hash::of(b).0),"members":members,"admitted":false,"executionAuthorized":false,"runtimeConformance":"not_checked","readiness":"not_established"}),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn local_manifest_read_is_bounded_and_refuses_nonregular_inputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("manifest");
+        assert!(read_manifest(&path).unwrap().is_none());
+        fs::write(&path, b"{}").unwrap();
+        assert_eq!(read_manifest(&path).unwrap(), Some(b"{}".to_vec()));
+        fs::File::create(&path)
+            .unwrap()
+            .set_len((8 << 20) + 1)
+            .unwrap();
+        assert!(read_manifest(&path).is_err());
+        assert!(read_manifest(dir.path()).is_err());
+        #[cfg(unix)]
+        {
+            let link = dir.path().join("link");
+            std::os::unix::fs::symlink(&path, &link).unwrap();
+            assert!(read_manifest(&link).is_err());
+        }
+    }
 }

--- a/crates/celln-cli/src/mote_check.rs
+++ b/crates/celln-cli/src/mote_check.rs
@@ -1,0 +1,130 @@
+//! Isolated cold-path member verification; never admits to a production host.
+use anyhow::{ensure, Result};
+use celln_manifest::{closure::SignedClosure, Hash};
+use celln_store::Store;
+use serde_json::{json, Value};
+use std::{fs, io::Read, path::Path};
+
+fn read_manifest(path: &Path) -> Result<Option<Vec<u8>>> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let file = match options.open(path) {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    ensure!(
+        file.metadata()?.is_file(),
+        "regular local manifest required"
+    );
+    let mut bytes = Vec::new();
+    file.take((8 << 20) + 1).read_to_end(&mut bytes)?;
+    ensure!(bytes.len() <= 8 << 20, "local manifest exceeds check limit");
+    Ok(Some(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn local_manifest_read_is_bounded_and_refuses_nonregular_inputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("manifest");
+        assert!(read_manifest(&path).unwrap().is_none());
+        fs::write(&path, b"{}").unwrap();
+        assert_eq!(read_manifest(&path).unwrap(), Some(b"{}".to_vec()));
+        fs::File::create(&path)
+            .unwrap()
+            .set_len((8 << 20) + 1)
+            .unwrap();
+        assert!(read_manifest(&path).is_err());
+        assert!(read_manifest(dir.path()).is_err());
+        #[cfg(unix)]
+        {
+            let link = dir.path().join("link");
+            std::os::unix::fs::symlink(&path, &link).unwrap();
+            assert!(read_manifest(&link).is_err());
+        }
+    }
+}
+
+pub fn check(
+    candidate: &Path,
+    template_hash: &str,
+    mote_store: &Path,
+    tool_store: &Path,
+    root: &Path,
+) -> Result<Value> {
+    let work = crate::agent::tempdir()?;
+    let prepared = work.path().join("prepared");
+    // Regenerate from verified inputs; never trust a caller's prepared.json or
+    // mote.json to grant authority. Template hash comes from operator config.
+    let report = crate::mote_prepare::prepare(
+        &candidate.join("template.json"),
+        template_hash,
+        &candidate.join("signed-closure.json"),
+        &candidate.join("toolfs.ext2"),
+        mote_store,
+        &prepared,
+        root,
+    )?;
+    let raw = crate::closure_policy::read_bounded(&prepared.join("signed-closure.json"))
+        .map_err(anyhow::Error::msg)?;
+    let signed: SignedClosure = serde_json::from_slice(&raw)?;
+    let policy_path = root.join("trusted-closures.json");
+    let policy = crate::closure_policy::read_bounded(&policy_path).map_err(anyhow::Error::msg)?;
+    ensure!(
+        report["policyHash"] == Hash::of(&policy).0,
+        "policy changed before member check"
+    );
+    let manifest_path = root.join("assay/manifest.json");
+    let manifest = read_manifest(&manifest_path)?;
+    let stage = work.path().join("stage");
+    fs::create_dir(&stage)?;
+    fs::write(stage.join("trusted-closures.json"), &policy)?;
+    if let Some(bytes) = &manifest {
+        fs::create_dir(stage.join("assay"))?;
+        fs::write(stage.join("assay/manifest.json"), bytes)?;
+    }
+    let motes = Store::open(stage.join("motes"))?;
+    for name in ["kernel", "initrd", "toolfs.ext2", "mote.json"] {
+        motes.put(&fs::read(prepared.join(name))?)?;
+    }
+    Store::open(stage.join("closures"))?.put(&raw)?;
+    // This allowlist exists only in the owned temporary verification root. It
+    // cannot be used by the production dispatcher and is removed on return.
+    fs::write(
+        stage.join("trusted-motes.json"),
+        serde_json::to_vec(
+            &json!({"apiVersion":"celln.dev/v1alpha1","bundles":[report["mote"]["hash"]]}),
+        )?,
+    )?;
+    let request = serde_json::from_value(json!({
+        "apiVersion":"celln.dev/v1alpha1","id":"candidate-member-check","workload":{"id":"candidate-member-check","caller":"operator:admission-review"},
+        "mote":report["mote"],"tools":[{"alias":signed.closure.entrypoint,"hash":signed.closure.members[&signed.closure.entrypoint].hash,"closure":report["closure"]}],
+        "invocation":{"alias":signed.closure.entrypoint,"args":[]},
+        "capabilities":{"workspace":"none","egress":[],"timeoutMs":10000,"memoryBytes":268435456,"outputBytes":4096},
+        "execution":{"lane":"agent","requireHardwareIsolation":true}
+    }))?;
+    let members =
+        crate::dispatch::check_members(&request, &stage.join("motes"), tool_store, &stage)
+            .map_err(anyhow::Error::msg)?;
+    let current = crate::closure_policy::verify(&raw, root).map_err(anyhow::Error::msg)?;
+    ensure!(
+        current.policy_hash.0 == report["policyHash"],
+        "policy changed during member check"
+    );
+    let current_manifest = read_manifest(&manifest_path)?;
+    ensure!(
+        current_manifest == manifest,
+        "local manifest changed during member check"
+    );
+    Ok(
+        json!({"apiVersion":"celln.dev/prepared-members-check-v1","template":template_hash,"mote":report["mote"],"closure":report["closure"],"policyHash":report["policyHash"],"members":members,"admitted":false,"executionAuthorized":false,"runtimeConformance":"not_checked","readiness":"not_established"}),
+    )
+}

--- a/crates/celln-cli/src/mote_prepare.rs
+++ b/crates/celln-cli/src/mote_prepare.rs
@@ -1,0 +1,267 @@
+//! Cold-path packaging only. An exact template is an operator input, not an
+//! execution grant. No host-kernel discovery, trust-policy writes or guest boot.
+use anyhow::{ensure, Context, Result};
+use celln_manifest::Hash;
+use celln_store::Store;
+use serde::Deserialize;
+use serde_json::json;
+use std::{
+    fs,
+    io::{Read, Write},
+    path::Path,
+};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Template {
+    api_version: String,
+    kernel: String,
+    initrd: String,
+    runtime_executable: String,
+    runtime_entry_point: String,
+    composer_publisher: String,
+}
+
+fn read_regular(path: &Path, limit: usize) -> Result<Vec<u8>> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let file = options.open(path).context("opening preparation input")?;
+    ensure!(
+        file.metadata()?.is_file(),
+        "regular preparation input required"
+    );
+    let mut bytes = Vec::new();
+    file.take((limit + 1) as u64).read_to_end(&mut bytes)?;
+    ensure!(
+        !bytes.is_empty() && bytes.len() <= limit,
+        "input empty or oversized"
+    );
+    Ok(bytes)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn run(
+    template_path: &Path,
+    expected_template: &str,
+    descriptor: &Path,
+    toolfs: &Path,
+    mote_store: &Path,
+    output: &Path,
+    root: &Path,
+) -> Result<u8> {
+    let template_bytes = read_regular(template_path, 16384)?;
+    ensure!(
+        Hash::of(&template_bytes).0 == expected_template,
+        "template identity mismatch"
+    );
+    let template: Template = serde_json::from_slice(&template_bytes)?;
+    ensure!(
+        template.api_version == "celln.dev/mote-template-v1",
+        "unsupported template"
+    );
+    let raw = read_regular(descriptor, crate::closure_policy::MAX_DESCRIPTOR_BYTES)?;
+    let verified = crate::closure_policy::verify(&raw, root).map_err(anyhow::Error::msg)?;
+    let closure = &verified.signed.closure;
+    ensure!(
+        verified.signed.publisher == template.composer_publisher,
+        "template composer mismatch"
+    );
+    ensure!(
+        closure.entrypoint == template.runtime_entry_point
+            && closure
+                .members
+                .get(&closure.entrypoint)
+                .is_some_and(|m| m.hash == template.runtime_executable),
+        "template runtime mismatch"
+    );
+    let image = read_regular(toolfs, crate::image::MAX_IMAGE_BYTES as usize)?;
+    ensure!(
+        Hash::of(&image).0 == closure.toolfs,
+        "signed filesystem mismatch"
+    );
+    // Store::open may create the store directory, but never changes admission.
+    let store = Store::open(mote_store)?;
+    let kernel = store.get_bounded(&Hash(template.kernel.clone()), 64 << 20)?;
+    let initrd = store.get_bounded(&Hash(template.initrd.clone()), 64 << 20)?;
+    ensure!(
+        !kernel.is_empty() && initrd.starts_with(b"070701"),
+        "nonempty kernel and uncompressed newc initrd required"
+    );
+    let bundle = serde_json::to_vec(
+        &json!({"apiVersion":"celln.dev/v1alpha1","format":"celln.warm-closure-v1","kernel":template.kernel,"initrd":template.initrd,"toolfs":closure.toolfs,"invocation":{"alias":closure.entrypoint,"toolHash":template.runtime_executable}}),
+    )?;
+    let current = crate::closure_policy::verify(&raw, root).map_err(anyhow::Error::msg)?;
+    ensure!(
+        current.policy_hash == verified.policy_hash,
+        "policy changed during preparation"
+    );
+    // Never replace an output directory, admit a derived mote or infer trust
+    // from content addressing. Partial output remains visibly incomplete.
+    fs::create_dir(output).context("output must be a new directory")?;
+    for (name, bytes) in [
+        ("kernel", kernel.as_slice()),
+        ("initrd", initrd.as_slice()),
+        ("toolfs.ext2", image.as_slice()),
+        ("signed-closure.json", raw.as_slice()),
+        ("mote.json", bundle.as_slice()),
+        ("template.json", template_bytes.as_slice()),
+    ] {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(output.join(name))?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+    }
+    let report = json!({"apiVersion":"celln.dev/mote-preparation-v1","template":expected_template,"mote":{"hash":Hash::of(&bundle).0},"closure":{"hash":verified.identity.0},"policyHash":verified.policy_hash.0,"admitted":false,"hardwareConformance":"not_checked","readiness":"not_established","executionAuthorized":false});
+    let mut completion = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(output.join("prepared.json"))?;
+    completion.write_all(&serde_json::to_vec(&report)?)?;
+    completion.sync_all()?;
+    #[cfg(unix)]
+    fs::File::open(output)?.sync_all()?;
+    println!("{}", report);
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use celln_manifest::closure::{Closure, Member};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    #[test]
+    fn preparation_binds_inputs_and_never_admits() {
+        for mode in [
+            "valid",
+            "runtime",
+            "composer",
+            "image",
+            "revoked",
+            "missing-kernel",
+            "existing-output",
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let root = dir.path();
+            let store = Store::open(root.join("motes")).unwrap();
+            let kernel = store.put(b"reviewed test kernel bytes").unwrap();
+            let initrd = store.put(b"070701reviewed test archive bytes").unwrap();
+            let executable = Hash::of(b"runtime").0;
+            let signed = Closure {
+                api_version: "celln.dev/closure-v1".into(),
+                sources: vec![],
+                toolfs: Hash::of(b"image").0,
+                entrypoint: "/harness".into(),
+                interpreter: false,
+                members: BTreeMap::from([(
+                    "/harness".into(),
+                    Member {
+                        hash: executable.clone(),
+                        dependencies: BTreeSet::new(),
+                    },
+                )]),
+            }
+            .sign(&[42; 32])
+            .unwrap();
+            let raw = serde_json::to_vec(&signed).unwrap();
+            let mut template = json!({"apiVersion":"celln.dev/mote-template-v1","kernel":kernel.0,"initrd":initrd.0,"runtimeExecutable":executable,"runtimeEntryPoint":"/harness","composerPublisher":signed.publisher});
+            if mode == "runtime" {
+                template["runtimeExecutable"] = Hash::of(b"different").0.into();
+            }
+            if mode == "composer" {
+                template["composerPublisher"] = "different".into();
+            }
+            if mode == "missing-kernel" {
+                template["kernel"] = Hash::of(b"missing").0.into();
+            }
+            let template = serde_json::to_vec(&template).unwrap();
+            let revoked: Vec<_> = if mode == "revoked" {
+                vec![Hash::of(&raw).0]
+            } else {
+                vec![]
+            };
+            let policy = serde_json::to_vec(&json!({"apiVersion":"celln.dev/closure-policy-v1","publishers":[signed.publisher],"revoked":revoked})).unwrap();
+            fs::write(root.join("trusted-closures.json"), &policy).unwrap();
+            fs::write(root.join("trusted-motes.json"), b"operator-owned sentinel").unwrap();
+            fs::write(root.join("template"), &template).unwrap();
+            fs::write(root.join("descriptor"), &raw).unwrap();
+            fs::write(
+                root.join("image"),
+                if mode == "image" { b"other" } else { b"image" },
+            )
+            .unwrap();
+            let output = root.join("out");
+            if mode == "existing-output" {
+                fs::create_dir(&output).unwrap();
+            }
+            let result = run(
+                &root.join("template"),
+                &Hash::of(&template).0,
+                &root.join("descriptor"),
+                &root.join("image"),
+                &root.join("motes"),
+                &output,
+                root,
+            );
+            assert_eq!(result.is_ok(), mode == "valid", "{mode}: {result:?}");
+            assert_eq!(
+                fs::read(root.join("trusted-motes.json")).unwrap(),
+                b"operator-owned sentinel"
+            );
+            assert_eq!(
+                fs::read(root.join("trusted-closures.json")).unwrap(),
+                policy
+            );
+            assert!(!root.join("closures").exists());
+            if mode == "valid" {
+                let report: serde_json::Value =
+                    serde_json::from_slice(&fs::read(output.join("prepared.json")).unwrap())
+                        .unwrap();
+                assert_eq!(report["admitted"], false);
+                assert_eq!(report["executionAuthorized"], false);
+                assert_eq!(
+                    report["mote"]["hash"],
+                    Hash::of(&fs::read(output.join("mote.json")).unwrap()).0
+                );
+                assert_eq!(
+                    fs::read(output.join("kernel")).unwrap(),
+                    b"reviewed test kernel bytes"
+                );
+            } else {
+                assert!(!output.join("prepared.json").exists());
+            }
+        }
+    }
+    #[test]
+    fn bounded_regular_inputs_and_template_pin_refuse() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("template");
+        fs::write(&file, b"{}").unwrap();
+        assert!(read_regular(&file, 1).is_err());
+        assert!(read_regular(dir.path(), 100).is_err());
+        assert!(run(
+            &file,
+            "wrong",
+            &file,
+            &file,
+            dir.path(),
+            &dir.path().join("out"),
+            dir.path()
+        )
+        .is_err());
+        assert!(!dir.path().join("out").exists());
+        #[cfg(unix)]
+        {
+            let link = dir.path().join("link");
+            std::os::unix::fs::symlink(&file, &link).unwrap();
+            assert!(read_regular(&link, 100).is_err());
+        }
+    }
+}

--- a/crates/celln-cli/src/mote_prepare.rs
+++ b/crates/celln-cli/src/mote_prepare.rs
@@ -54,6 +54,29 @@ pub fn run(
     output: &Path,
     root: &Path,
 ) -> Result<u8> {
+    let report = prepare(
+        template_path,
+        expected_template,
+        descriptor,
+        toolfs,
+        mote_store,
+        output,
+        root,
+    )?;
+    println!("{}", report);
+    Ok(0)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn prepare(
+    template_path: &Path,
+    expected_template: &str,
+    descriptor: &Path,
+    toolfs: &Path,
+    mote_store: &Path,
+    output: &Path,
+    root: &Path,
+) -> Result<serde_json::Value> {
     let template_bytes = read_regular(template_path, 16384)?;
     ensure!(
         Hash::of(&template_bytes).0 == expected_template,
@@ -127,8 +150,7 @@ pub fn run(
     completion.sync_all()?;
     #[cfg(unix)]
     fs::File::open(output)?.sync_all()?;
-    println!("{}", report);
-    Ok(0)
+    Ok(report)
 }
 
 #[cfg(test)]

--- a/docs/PINNED_MOTE_PREPARATION.md
+++ b/docs/PINNED_MOTE_PREPARATION.md
@@ -55,6 +55,32 @@ rechecked after input reads, but this is an observation, not a policy lease.
 
 ## Remaining admission/distribution workflow
 
+### Verify members before production admission
+
+`celln closure check-prepared --candidate <directory> --template-hash <trusted-hash>
+--mote-store <store> --tool-store <store>` regenerates the candidate from verified
+inputs, then checks signed members with actual guest code in a sealed cell.
+The explicit template hash must still come from trusted operator configuration.
+The runtime executable must exist by hash in the tool store.
+
+The check uses an owned temporary verification root with a copy of the current
+closure policy and local manifest constraints. Only that temporary root gets a
+single-candidate allowlist; production mote policy is never changed. The request
+has no arguments, inputs, workspace or egress and requires hardware isolation.
+Current production policy and manifest are checked again after the guest exits.
+Unavailable hardware or an unsupported pilot refuses, never certifies success.
+
+The report binds the template, candidate and signed closure to a fresh sealed
+member challenge. It still says `admitted: false`: member integrity is not full
+runtime functional conformance, model authorization, capacity or serving-host
+readiness. Do not accept a user-supplied copy of this report as an admission token.
+
+The explicit real-KVM signed-closure regression exercises this path before
+creating any production mote allowlist, asserts guest verification and teardown,
+then runs the existing hostile-guest mutation and revocation tests.
+
+### Admission and distribution still required
+
 Before a production controller may use the candidate, the host admission
 service must independently revalidate template authorization, exact selected
 source closures and their current grants, verify sealed members with actual

--- a/docs/PINNED_MOTE_PREPARATION.md
+++ b/docs/PINNED_MOTE_PREPARATION.md
@@ -79,9 +79,60 @@ The explicit real-KVM signed-closure regression exercises this path before
 creating any production mote allowlist, asserts guest verification and teardown,
 then runs the existing hostile-guest mutation and revocation tests.
 
-### Admission and distribution still required
+### Administrator-assisted MLP admission
 
-Before a production controller may use the candidate, the host admission
+On the intended serving host, an administrator can now explicitly approve the
+exact reviewed candidate with:
+
+```sh
+celln --root /var/lib/celln closure admit-prepared \
+  --candidate /var/lib/celln/build/new-candidate \
+  --template-hash blake3:<trusted-template-digest> \
+  --approve-mote blake3:<reviewed-candidate-mote-digest> \
+  --mote-store /var/lib/celln/motes --tool-store /var/lib/celln/tools
+```
+
+This is an authority-changing operator command, not a tenant endpoint. Run it
+under the host service account with exclusive custody of the policy/store;
+new files are private to that account. The administrator is responsible for
+runtime/tool functional review in addition to the mandatory member check.
+Do not derive trusted template approval from a tenant's uploaded report.
+
+Admission repeats preparation and real-KVM checking. It durably publishes the
+kernel/initrd/filesystem/descriptor objects, verifies even deduplicated objects,
+records check evidence, then atomically replaces the exact-mote allowlist.
+Cooperating admission/withdrawal commands use a nonblocking Linux file lock;
+other tools must not edit this policy concurrently. Observed external edits
+refuse. All existing allowlist entries are preserved. Corrupt stored objects
+refuse rather than being overwritten. No model grant or execution is issued.
+
+Failure before the allowlist commit may leave unused immutable blobs/evidence,
+but does not authorize a new mote. A lost success acknowledgement may occur
+after the commit: inspect current host policy or repeat the exact command. A
+retry rechecks policy and hardware; it never submits execution. Evidence alone
+is not current admission. Storage must provide local Linux lock, atomic rename
+and fsync semantics; shared/distributed filesystems are not qualified here.
+
+To prevent new use of one exact mote:
+
+```sh
+celln --root /var/lib/celln closure withdraw-mote --mote blake3:<mote-digest>
+```
+
+Withdrawal atomically removes only that entry and retains artifacts/evidence.
+It is repeatable, but **does not cancel active cells**. Withdraw relevant model
+and tool approvals and cancel active AgentRuns separately; wait for terminal
+teardown. Do not call this fleet-wide live revocation.
+
+Register the admitted mote/closure pair with the Sympozium catalogue controller
+only after installation on its explicitly pinned serving host. The controller
+still performs current run/model/tool authority checks and serving-process
+prewarm. Automated distribution, production deployment qualification and the
+full borrowed-tool user journey remain separate completion gates.
+
+### Automated service/distribution follow-up
+
+Before an automated production controller may admit a new candidate, its host admission
 service must independently revalidate template authorization, exact selected
 source closures and their current grants, verify sealed members with actual
 guest attempts, and commit a revocable admission record. It must distribute

--- a/docs/PINNED_MOTE_PREPARATION.md
+++ b/docs/PINNED_MOTE_PREPARATION.md
@@ -1,0 +1,70 @@
+# Pinned mote preparation (cold path)
+
+`celln closure prepare-mote` packages a candidate mote from an exact
+operator-reviewed template and a signed closure. It replaces neither admission
+nor hardware conformance. It does not boot a guest, create a warm serving mote,
+issue model authority, or write either host trust policy.
+
+The command never selects the current host kernel or searches for an initramfs.
+Its template pins the kernel, pilot initrd, runtime executable/entrypoint and
+composition publisher. The caller must obtain the template and its expected
+BLAKE3 hash from trusted operator configuration, not from a tenant request.
+Matching a supplied hash proves byte identity, not who approved those bytes.
+
+Template format (hash values shown as placeholders):
+
+```json
+{
+  "apiVersion": "celln.dev/mote-template-v1",
+  "kernel": "blake3:<kernel digest>",
+  "initrd": "blake3:<pilot initrd digest>",
+  "runtimeExecutable": "blake3:<runtime digest>",
+  "runtimeEntryPoint": "/harness",
+  "composerPublisher": "<64 hex characters>"
+}
+```
+
+The kernel and uncompressed newc initrd must already exist in the explicit mote
+store. Hash verification is bounded to 64 MiB each. Template/descriptor/image
+inputs are bounded regular files; on Unix symlinks and FIFOs refuse. The image
+must match the signed closure's filesystem identity. The closure is checked
+against the current host publisher/revocation policy, including signed source
+closures. Its entrypoint and executable must match the exact template.
+
+```sh
+celln --root /var/lib/celln closure prepare-mote \
+  --template /etc/celln/templates/native-json.json \
+  --template-hash blake3:<trusted-template-digest> \
+  --descriptor /var/lib/celln/build/composition/signed-closure.json \
+  --toolfs /var/lib/celln/build/composition/toolfs.ext2 \
+  --mote-store /var/lib/celln/motes \
+  --output-dir /var/lib/celln/build/new-candidate
+```
+
+The output directory must not exist. Successful preparation writes kernel,
+initrd, toolfs, signed closure, exact template and mote descriptor bytes, then a
+`prepared.json` report. Existing directories and files are never overwritten.
+An error may leave a partial directory for inspection; it is not automatically
+deleted and must not be consumed as successful preparation. Consumers must
+validate the complete report and all referenced bytes; a filename is no proof.
+
+The report always says `admitted: false`, `executionAuthorized: false`,
+`hardwareConformance: not_checked`, and `readiness: not_established`.
+Content addressing alone does not grant any new mote authority. Policy is
+rechecked after input reads, but this is an observation, not a policy lease.
+
+## Remaining admission/distribution workflow
+
+Before a production controller may use the candidate, the host admission
+service must independently revalidate template authorization, exact selected
+source closures and their current grants, verify sealed members with actual
+guest attempts, and commit a revocable admission record. It must distribute
+verified bytes to the selected serving host, prewarm there, and bind serving
+identity and route without rerouting ambiguous execution. Interrupted builds,
+admission withdrawal, retries and cleanup require durable reconciliation.
+This command does not implement those service/controller steps.
+
+The public-seed `prepare_issuance_fixture` example remains explicitly test-only.
+Neither its host-kernel discovery nor its allowlist creation is reused here.
+Portable preparation tests use nonbootable byte fixtures intentionally: they
+prove packaging/refusal and unchanged policy, not any hardware guarantee.

--- a/docs/PREPARED_ADMISSION_EVIDENCE_2026-09-08.json
+++ b/docs/PREPARED_ADMISSION_EVIDENCE_2026-09-08.json
@@ -1,0 +1,17 @@
+{
+  "status": "passed",
+  "scope": "Administrator-assisted candidate admission and exact mote withdrawal using real KVM member verification, followed by existing signed-closure guest-attack/revocation regression",
+  "source": "mote_admit implementation and regression committed alongside this evidence",
+  "command": "CELLN_PILOT_DIR=<checkout>/target/validation/x86_64-unknown-linux-musl/release CELLN_TEST_BINARY=<checkout>/target/validation/debug/celln CARGO_TARGET_DIR=target/validation cargo test -p celln-cli signed_closure_on_real_kvm -- --ignored --nocapture",
+  "durationSeconds": 22.75,
+  "template": "blake3:5fac10ea071c913553586cb1db4fe1c26cb2ca3abe41870428ca6b378d2dd58a",
+  "mote": "blake3:a7de49b311ed776925b2637f6a0664f7fd9e69ac0b4144661c9f1bb5f3b33a9d",
+  "closure": "blake3:d6dfbfd3696e85ba4b71606d66d6900757b093c4c8e05f1d097c86c83be2a593",
+  "localManifestHash": "blake3:6ba9f7eb06f5fe2e174ac88a6abfb8b9e6fd5c1595c73ca764f341d53b3fc7e1",
+  "memberCount": 4,
+  "admittedThenWithdrawn": true,
+  "artifactsRetained": true,
+  "portableChecks": ["corrupt dedup refuses without overwrite", "nonblocking lock contention", "outside-policy-change refusal", "withdrawal preserves other entries and is repeatable", "invalid approval refuses before authority creation"],
+  "validation": "make ci passed after correcting a test-module placement Clippy warning",
+  "limitations": ["Local Linux filesystem semantics, not distributed storage qualification", "Withdrawal denies new admission but does not cancel running cells", "No native Harness/real-model admission-path proof yet", "No automatic distribution or production deployment qualification"]
+}

--- a/docs/PREPARED_MEMBERS_EVIDENCE_2026-09-08.json
+++ b/docs/PREPARED_MEMBERS_EVIDENCE_2026-09-08.json
@@ -1,0 +1,20 @@
+{
+  "status": "passed",
+  "scope": "Real-KVM isolated candidate sealed-member check before production admission, followed by existing signed-closure hostile-guest and revocation regression",
+  "source": "check-prepared implementation and regression committed alongside this evidence",
+  "command": "CELLN_PILOT_DIR=<checkout>/target/validation/x86_64-unknown-linux-musl/release CELLN_TEST_BINARY=<checkout>/target/validation/debug/celln CARGO_TARGET_DIR=target/validation cargo test -p celln-cli signed_closure_on_real_kvm -- --ignored --nocapture",
+  "guestBuild": "CARGO_TARGET_DIR=target/validation cargo build --release --target x86_64-unknown-linux-musl -p celln-pilot --bin celln-pilot --bin pilot-fetch",
+  "durationSeconds": 28.60,
+  "template": "blake3:6aff192b6bda0f056bd2bf439bc066148aaf94634d8aea94923dfbffabb9ec10",
+  "mote": "blake3:fef47c533499806a272a9aa6a7ba87efe42c58ab73ae2c1c5307327d31cbcaa2",
+  "closure": "blake3:6641cfa153c7bf9d5516234d2e62a015d4f0889153c0612febd5cd452272badb",
+  "challenge": "blake3:21eaa60e1a1b7a49c651f11fb1e32d8c81985fd351598dcb146df23a1ea7d3b1",
+  "requestHash": "blake3:ee49b2a0ccc65d9e05fef26e0d8f3581a40ea98464d692b9dae3f65051ea4384",
+  "memberCount": 4,
+  "memberIntegrity": "verified-in-sealed-cell",
+  "toolExecution": false,
+  "cellDissolved": true,
+  "productionMoteAllowlistAbsentAfterCheck": true,
+  "admitted": false,
+  "limitations": ["No full native Harness functional conformance or model run in candidate check", "No production admission, distribution or readiness claim", "Initial attempt skipped for missing guest-binary path; explicit rebuilt guest path rerun exercised hardware", "Subsequent bounded manifest read hardening is covered by portable checks and does not change the guest challenge path"]
+}


### PR DESCRIPTION
Advances sympozium-ai/sympozium#426 production packaging work. Adds cold-path closure prepare-mote with an exact externally trusted template hash, pinned kernel/initrd/runtime/composer identities, current signed closure/revocation verification, bounded regular artifact reads and new-output-only packaging. No host-kernel discovery, seed requirement, trust-policy writes, model grant, boot or admission. Reports admitted=false and no hardware/readiness claim. Tests cover success, exact output binding, unchanged policies, runtime/composer/image mismatch, revocation, missing kernel, existing output, size limits and symlinks. make ci and all-targets Clippy passed; actual CLI help smoke passed. Portable preparation fixtures are intentionally nonbootable and are not a hardware proof. Durable admission/revocation, conformance and serving distribution/controller automation remain required follow-ups.