### PR TITLE
feat: native persistent parent and disposable starter-tool cells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,12 +192,14 @@ version = "0.5.7"
 dependencies = [
  "anyhow",
  "celln-assay",
+ "celln-control",
  "celln-manifest",
  "celln-store",
  "celln-warden",
  "libc",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
 ]
 
@@ -205,6 +207,7 @@ dependencies = [
 name = "celln-spec"
 version = "0.5.7"
 dependencies = [
+ "celln-manifest",
  "serde",
  "serde_json",
  "thiserror",
@@ -227,6 +230,7 @@ version = "0.5.7"
 dependencies = [
  "celln-control",
  "celln-manifest",
+ "celln-store",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",

--- a/crates/celln-cli/src/dispatch.rs
+++ b/crates/celln-cli/src/dispatch.rs
@@ -19,6 +19,8 @@ pub(crate) mod harness;
 mod substrate;
 pub(crate) use substrate::check_members;
 pub(crate) use substrate::launch_declared;
+#[cfg(target_os = "linux")]
+pub(crate) use substrate::parent_create;
 pub(crate) use substrate::validate_member_request;
 #[path = "dispatch_inputs.rs"]
 pub(crate) mod inputs;
@@ -512,8 +514,21 @@ fn validate_executed_tool(outcome: &mut LaunchOutcome, expected: &str) {
 fn run_cell(
     request: &ExecutionRequest,
     alias: &str,
+    cell: warden::vmm::boot::LinuxCell,
+    state_root: &Path,
+) -> Result<LaunchOutcome, String> {
+    run_cell_with_broker(request, alias, cell, state_root, None)
+}
+
+/// Internal explicit broker path for an independently admitted native worker.
+/// An explicit policy must not be replaced by the legacy direct-exec GET policy.
+#[cfg(target_os = "linux")]
+fn run_cell_with_broker(
+    request: &ExecutionRequest,
+    alias: &str,
     mut cell: warden::vmm::boot::LinuxCell,
     state_root: &Path,
+    broker: Option<warden::egress::HttpPolicy>,
 ) -> Result<LaunchOutcome, String> {
     cell.set_timeout(std::time::Duration::from_millis(
         request.capabilities.timeout_ms.max(1),
@@ -532,7 +547,9 @@ fn run_cell(
         .map(|record| record.id.clone())
         .unwrap_or_default();
 
-    if request.harness.is_none() && !request.capabilities.egress.is_empty() {
+    if let Some(policy) = broker {
+        cell.enable_http_fetch(policy);
+    } else if request.harness.is_none() && !request.capabilities.egress.is_empty() {
         let hosts: Vec<String> = request
             .capabilities
             .egress

--- a/crates/celln-cli/src/dispatch_harness_tests.rs
+++ b/crates/celln-cli/src/dispatch_harness_tests.rs
@@ -198,6 +198,7 @@ fn model_over_authenticated_dispatch(json_adapter: bool, issuance_only: bool) {
         return;
     }
     let state = State {
+        parents: warden::parent_registry::ParentRegistry::new(1024, 268435456).unwrap(),
         prewarm: Mutex::new(None),
         token_file: PathBuf::new(),
         token: "test-token-at-least-24-bytes".into(),

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -13,6 +13,10 @@ mod audit;
 mod harness_tests;
 #[path = "dispatch_journal.rs"]
 mod journal;
+#[path = "dispatch_parents.rs"]
+mod parents;
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) use parents::prove_parent_http;
 #[path = "dispatch_prewarm.rs"]
 mod prewarm;
 use anyhow::{bail, Context, Result};
@@ -71,10 +75,11 @@ pub(crate) fn read_bounded_line(reader: &mut impl BufRead, cap: usize) -> Result
 /// Read and discard headers, enforcing a cap on both line length and count.
 /// Returns the parsed `Content-Length`, and the raw `Authorization` header
 /// value if the caller wants it.
-fn read_headers(reader: &mut impl BufRead) -> Result<(usize, Option<String>)> {
+fn read_headers(reader: &mut impl BufRead) -> Result<(usize, Option<String>, bool)> {
     let mut length = 0usize;
     let mut authorization = None;
     let mut count = 0usize;
+    let mut respond_async = false;
     loop {
         let header = read_bounded_line(reader, MAX_HEADER_LINE)?;
         let header = header.trim_end();
@@ -82,6 +87,11 @@ fn read_headers(reader: &mut impl BufRead) -> Result<(usize, Option<String>)> {
             break;
         }
         count += 1;
+        if let Some((name, value)) = header.split_once(':') {
+            if name.eq_ignore_ascii_case("Prefer") && value.trim() == "respond-async" {
+                respond_async = true;
+            }
+        }
         if count > MAX_HEADER_COUNT {
             bail!("too many headers (max {MAX_HEADER_COUNT})");
         }
@@ -92,7 +102,7 @@ fn read_headers(reader: &mut impl BufRead) -> Result<(usize, Option<String>)> {
             length = value.parse().context("invalid Content-Length")?;
         }
     }
-    Ok((length, authorization))
+    Ok((length, authorization, respond_async))
 }
 
 /// A registry entry with terminal cache age. Admission sweeps expired terminal
@@ -213,10 +223,33 @@ fn current_node(
         node.live_cells = node.live_cells.saturating_add(1);
         node.memory_bytes = node.memory_bytes.saturating_sub(reservation.memory_bytes);
     }
+    match state.parents.reserved_capacity() {
+        Ok(reserved) => {
+            // Reserve the parent plus its single possible active child, even
+            // between turns. Bytes include retained motes as declared at owner
+            // admission, not merely the currently executing guest's memory.
+            node.live_cells = node
+                .live_cells
+                .saturating_add(reserved.owners.saturating_mul(2));
+            node.memory_bytes = node.memory_bytes.saturating_sub(reserved.memory_bytes);
+            if reserved.owners != 0 {
+                // Parent registry does not yet carry exact broker-slot charges.
+                // Do not advertise spare egress until creation admission binds
+                // those charges and shares this node's admission lock.
+                node.egress_slots = 0;
+            }
+        }
+        Err(_) => {
+            node.live_cells = node.max_cells;
+            node.memory_bytes = 0;
+            node.egress_slots = 0;
+        }
+    }
     node
 }
 
 struct State {
+    parents: warden::parent_registry::ParentRegistry,
     token_file: PathBuf,
     #[cfg(test)]
     token: String,
@@ -342,6 +375,8 @@ pub fn serve(
     let listener = TcpListener::bind(listen_address)
         .with_context(|| format!("binding dispatcher {listen_address}"))?;
     let state = Arc::new(State {
+        parents: warden::parent_registry::ParentRegistry::new(1024, probe.memory_bytes.max(1))
+            .map_err(anyhow::Error::msg)?,
         token_file: token_file.to_owned(),
         #[cfg(test)]
         token: String::new(),
@@ -351,6 +386,21 @@ pub fn serve(
         executions: Arc::new(Mutex::new(HashMap::new())),
         prewarm: Mutex::new(None),
     });
+    // Expired/failed owners must release capacity even without another HTTP
+    // request. Weak ownership lets this maintenance thread exit with the server.
+    let maintenance = Arc::downgrade(&state);
+    thread::Builder::new()
+        .name("celln-parent-reaper".into())
+        .spawn(move || loop {
+            thread::sleep(Duration::from_millis(100));
+            let Some(state) = maintenance.upgrade() else {
+                break;
+            };
+            if let Err(error) = state.parents.reap_finished() {
+                eprintln!("parent owner reconciliation failed: {error}");
+            }
+        })
+        .context("starting parent owner reconciliation")?;
     if non_loopback {
         eprintln!(
             "WARNING: dispatcher is exposed on a non-loopback address and provides no TLS; a TLS-terminating reverse proxy is required"
@@ -412,7 +462,21 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
         .unwrap_or_default()
         .to_owned();
     let method = method.to_owned();
-    let (length, authorization) = read_headers(&mut reader)?;
+    let (length, authorization, respond_async) = read_headers(&mut reader)?;
+    if path == "/v1/parents" || path.starts_with("/v1/parents/") {
+        return parents::handle(
+            state,
+            &mut stream,
+            &mut reader,
+            &method,
+            &path,
+            parents::RequestMetadata {
+                length,
+                bearer: authorization.as_deref(),
+                respond_async,
+            },
+        );
+    }
     let is_public_health_check = method == "GET" && path == "/v1/health";
     if !is_public_health_check {
         let token = match state.credential() {
@@ -1002,8 +1066,9 @@ mod tests {
     use super::*;
     use std::io::Cursor;
 
-    fn lifecycle_state(root: &Path) -> State {
+    pub(super) fn lifecycle_state(root: &Path) -> State {
         State {
+            parents: warden::parent_registry::ParentRegistry::new(1024, 268435456).unwrap(),
             token_file: PathBuf::new(),
             token: "test-token-at-least-24-bytes".into(),
             egress_policy: EgressPolicy::new(&[]).unwrap(),
@@ -1019,6 +1084,54 @@ mod tests {
             executions: Arc::new(Mutex::new(HashMap::new())),
             prewarm: Mutex::new(None),
         }
+    }
+
+    #[test]
+    fn parent_capacity_is_visible_to_existing_node_admission_until_join() {
+        let root = tempfile::tempdir().unwrap();
+        let mut state = lifecycle_state(root.path());
+        state.probe.max_cells = 4;
+        state.probe.egress_slots = 2;
+        let id = celln_manifest::Hash::of(b"capacity-parent");
+        let (entered, ready) = std::sync::mpsc::sync_channel(1);
+        let (release, wait) = std::sync::mpsc::sync_channel(1);
+        state
+            .parents
+            .spawn_admitted(
+                "tenant",
+                &id,
+                Duration::from_secs(10),
+                128 << 20,
+                move || {
+                    Ok(move |_: &[u8]| {
+                        entered.send(()).unwrap();
+                        wait.recv().unwrap();
+                        Ok(vec![1])
+                    })
+                },
+            )
+            .unwrap();
+        let registry = HashMap::new();
+        let node = current_node(&state, &registry);
+        assert_eq!(node.live_cells, 2);
+        assert_eq!(node.memory_bytes, 128 << 20);
+        assert_eq!(node.egress_slots, 0);
+        let response = state.parents.submit("tenant", &id, b"work").unwrap();
+        ready.recv_timeout(Duration::from_secs(2)).unwrap();
+        state.parents.cancel("tenant", &id).unwrap();
+        assert_eq!(current_node(&state, &registry).memory_bytes, 128 << 20);
+        release.send(()).unwrap();
+        assert!(response
+            .recv_timeout(Duration::from_secs(2))
+            .unwrap()
+            .is_err());
+        // Even a finished owner remains charged until its resources are joined.
+        assert_eq!(current_node(&state, &registry).live_cells, 2);
+        state.parents.stop("tenant", &id).unwrap();
+        let node = current_node(&state, &registry);
+        assert_eq!(node.live_cells, 0);
+        assert_eq!(node.memory_bytes, 256 << 20);
+        assert_eq!(node.egress_slots, 2);
     }
 
     #[test]
@@ -1516,6 +1629,7 @@ mod tests {
         let work = tempfile::tempdir().unwrap();
         let root = work.path().join("unused");
         let state = State {
+            parents: warden::parent_registry::ParentRegistry::new(1024, 268435456).unwrap(),
             token_file: PathBuf::new(),
             token: "test-token-at-least-24-bytes".into(),
             egress_policy: EgressPolicy::new(&[]).unwrap(),
@@ -1683,7 +1797,9 @@ mod tests {
         let mut cursor = Cursor::new(
             b"Content-Length: 42\r\nAuthorization: Bearer secret-token\r\n\r\n".to_vec(),
         );
-        let (length, authorization) = read_headers(&mut cursor).expect("parses headers");
+        let (length, authorization, respond_async) =
+            read_headers(&mut cursor).expect("parses headers");
+        assert!(!respond_async);
         assert_eq!(length, 42);
         assert_eq!(authorization.as_deref(), Some("secret-token"));
     }

--- a/crates/celln-cli/src/dispatch_parent_create.rs
+++ b/crates/celln-cli/src/dispatch_parent_create.rs
@@ -1,0 +1,520 @@
+//! Operator-owned launch selection. HTTP supplies only a content hash; it may
+//! not upload runtime policy or choose paths in the operator namespace.
+use super::*;
+use celln_manifest::Hash;
+use std::{
+    io::{Read, Write},
+    path::PathBuf,
+    time::Duration,
+};
+
+#[derive(Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Profile {
+    api_version: String,
+    parent: ExecutionRequest,
+    worker: ExecutionRequest,
+    template: pilot::json_harness::Config,
+    model_profile: Hash,
+    permit: Hash,
+    binding: warden::parent_permit::Binding,
+    /// Operator's logical host-memory reservation, including retained motes,
+    /// both VMs, artifact buffers and overhead. Not a physical RSS guarantee.
+    reserved_memory_bytes: u64,
+}
+
+pub(crate) struct Admission {
+    profile: Profile,
+    template: pilot::turn_worker::Template,
+    root: PathBuf,
+}
+
+pub(crate) type Handler = Box<dyn FnMut(&[u8]) -> Result<Vec<u8>, String>>;
+
+pub(crate) fn admit(root: &Path, hash: &Hash, principal: &str) -> Result<Admission, String> {
+    if !hash.0.strip_prefix("blake3:").is_some_and(|s| {
+        s.len() == 64
+            && s.bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    }) {
+        return Err("invalid launch profile hash".into());
+    }
+    let mut bytes = Vec::new();
+    std::fs::File::open(
+        root.join("trusted-parent-launches")
+            .join(format!("{}.json", &hash.0[7..])),
+    )
+    .map_err(|_| "parent launch profile unavailable")?
+    .take(65537)
+    .read_to_end(&mut bytes)
+    .map_err(|_| "parent launch profile unreadable")?;
+    if bytes.len() > 65536 || Hash::of(&bytes) != *hash {
+        return Err("parent launch profile integrity mismatch".into());
+    }
+    validate(root, &bytes, principal)
+}
+
+fn validate(root: &Path, bytes: &[u8], principal: &str) -> Result<Admission, String> {
+    if bytes.len() > 65536 {
+        return Err("parent launch profile exceeds size limit".into());
+    }
+    let profile: Profile =
+        serde_json::from_slice(bytes).map_err(|_| "invalid parent launch profile")?;
+    if profile.api_version != "celln.parent-launch/v1" {
+        return Err("unsupported parent launch profile".into());
+    }
+    warden::parent_permit::authorize(root, &profile.permit, &profile.binding, principal)
+        .map_err(|e| e.to_string())?;
+    validate_policy(root, profile)
+}
+
+fn validate_policy(root: &Path, profile: Profile) -> Result<Admission, String> {
+    validate_parent_request(&profile.parent, &profile.binding)?;
+    let template =
+        pilot::turn_worker::Template::new(profile.template.clone()).map_err(|e| e.to_string())?;
+    // No model secret is read here. Independent broker policy and caller binding
+    // are checked before durable claim, node reservation or warm preparation.
+    parent_model::ChildBrokers::new(
+        root,
+        profile.model_profile.clone(),
+        profile.binding.clone(),
+        &profile.worker,
+        &template,
+    )?;
+    // Necessary floor only, not sufficient sizing: include two retained motes
+    // and two live guest allocations. Operator must add artifacts/host overhead.
+    let floor = profile
+        .binding
+        .parent_memory_bytes
+        .checked_add(profile.binding.child_memory_bytes)
+        .and_then(|bytes| bytes.checked_mul(2))
+        .ok_or("parent reservation overflow")?;
+    if profile.reserved_memory_bytes <= floor {
+        return Err("parent reservation must include warm motes and host overhead".into());
+    }
+    Ok(Admission {
+        profile,
+        template,
+        root: root.into(),
+    })
+}
+
+/// Publish independently authorized, operator-local launch policy. This is not
+/// an HTTP upload interface and does not claim an incarnation or prepare a VM.
+/// The protected directory must already exist. Exact retries are recoverable;
+/// a corrupt existing record is never replaced. Startup rechecks live authority.
+pub(crate) fn publish(root: &Path, bytes: &[u8], principal: &str) -> Result<Hash, String> {
+    if !root.is_absolute() {
+        return Err("parent launch root must be absolute".into());
+    }
+    validate(root, bytes, principal)?;
+    let directory = root.join("trusted-parent-launches");
+    let hash = Hash::of(bytes);
+    let destination = directory.join(format!("{}.json", &hash.0[7..]));
+    let mut temporary = tempfile::NamedTempFile::new_in(&directory)
+        .map_err(|e| format!("parent launch staging failed: {e}"))?;
+    temporary.write_all(bytes).map_err(|e| e.to_string())?;
+    temporary.as_file().sync_all().map_err(|e| e.to_string())?;
+    match temporary.persist_noclobber(&destination) {
+        Ok(_) => (),
+        Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let mut existing = Vec::new();
+            std::fs::File::open(&destination)
+                .map_err(|e| e.to_string())?
+                .take(65537)
+                .read_to_end(&mut existing)
+                .map_err(|e| e.to_string())?;
+            if existing != bytes {
+                return Err("existing parent launch profile differs".into());
+            }
+        }
+        Err(error) => return Err(error.error.to_string()),
+    }
+    std::fs::File::open(&directory)
+        .and_then(|file| file.sync_all())
+        .map_err(|e| e.to_string())?;
+    // Expiry or revocation during publication must not produce an approval.
+    // Keep the durable record on failure; publication never renews authority.
+    admit(root, &hash, principal)?;
+    Ok(hash)
+}
+
+/// Trusted local input, never a tenant-supplied execution request. The caller
+/// must independently authorize the complete Kubernetes intent and selection.
+#[derive(Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ProvisionPlan {
+    api_version: String,
+    scope: String,
+    run_uid: String,
+    #[serde(rename = "intentSHA256")]
+    intent_sha256: String,
+    admission_window_ms: u64,
+    parent: ExecutionRequest,
+    worker: ExecutionRequest,
+    template: pilot::json_harness::Config,
+    model_profile: Hash,
+    reserved_memory_bytes: u64,
+    max_turns: usize,
+    turn_model_requests: u64,
+    turn_output_tokens: u64,
+    total_model_requests: u64,
+    total_output_tokens: u64,
+}
+
+pub(crate) fn provision_file(root: &Path, path: &Path, principal: &str) -> anyhow::Result<u8> {
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)?
+        .take(65537)
+        .read_to_end(&mut bytes)?;
+    let (profile, incarnation) = provision(root, &bytes, principal).map_err(anyhow::Error::msg)?;
+    println!(
+        "{}",
+        serde_json::json!({"apiVersion":"celln.parent-provisioned/v1", "launchProfile":profile, "incarnation":incarnation})
+    );
+    Ok(0)
+}
+
+fn provision(root: &Path, bytes: &[u8], principal: &str) -> Result<(Hash, Hash), String> {
+    if bytes.len() > 65536 || !root.is_absolute() {
+        return Err("bounded local parent plan and absolute root required".into());
+    }
+    let plan: ProvisionPlan =
+        serde_json::from_slice(bytes).map_err(|_| "invalid parent provision plan")?;
+    if plan.api_version != "celln.parent-provision-plan/v1"
+        || !plan
+            .intent_sha256
+            .strip_prefix("sha256:")
+            .is_some_and(|value| {
+                value.len() == 64
+                    && value
+                        .bytes()
+                        .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+            })
+        || plan.parent.workload.caller != principal
+        || plan.worker.workload.caller != principal
+    {
+        return Err("parent provision version, intent or principal mismatch".into());
+    }
+    // Bind the entire typed plan, including logical reservation and model
+    // policy, as well as the upstream SHA256 intent. No cross-language JSON
+    // canonicalization is required: the upstream digest is an opaque identity.
+    let intent = Hash::of(
+        &serde_json::to_vec(&("celln.parent-provision-intent/v1", &plan))
+            .map_err(|e| e.to_string())?,
+    );
+    let incarnation = warden::parent_permit::run_incarnation(&plan.scope, &plan.run_uid)
+        .map_err(|e| e.to_string())?;
+    let template =
+        pilot::turn_worker::Template::new(plan.template.clone()).map_err(|e| e.to_string())?;
+    let binding = warden::parent_permit::Binding {
+        principal: principal.into(),
+        incarnation: incarnation.clone(),
+        parent_configuration: plan
+            .parent
+            .configuration_binding(celln_spec::ConfigurationRole::Parent)?,
+        worker_configuration: parent_model::worker_binding(
+            &plan.worker,
+            &template,
+            &plan.model_profile,
+        )?,
+        parent_memory_bytes: plan.parent.capabilities.memory_bytes,
+        child_memory_bytes: plan.worker.capabilities.memory_bytes,
+        lifetime_ms: plan.parent.capabilities.timeout_ms,
+        turn_timeout_ms: plan.worker.capabilities.timeout_ms,
+        max_turns: plan.max_turns,
+        turn_model_requests: plan.turn_model_requests,
+        turn_output_tokens: plan.turn_output_tokens,
+        total_model_requests: plan.total_model_requests,
+        total_output_tokens: plan.total_output_tokens,
+    };
+    let profile = Profile {
+        api_version: "celln.parent-launch/v1".into(),
+        parent: plan.parent,
+        worker: plan.worker,
+        template: plan.template,
+        model_profile: plan.model_profile,
+        permit: Hash::of(b"not-yet-issued"),
+        binding: binding.clone(),
+        reserved_memory_bytes: plan.reserved_memory_bytes,
+    };
+    // Reject policy mistakes before consuming the durable issuance identity.
+    let mut admission = validate_policy(root, profile)?;
+    if serde_json::to_vec(&admission.profile)
+        .map_err(|e| e.to_string())?
+        .len()
+        > 65536
+    {
+        return Err("resulting parent launch profile exceeds size limit".into());
+    }
+    for directory in [
+        "parent-issuance",
+        "trusted-parent-permits",
+        "trusted-parent-launches",
+    ] {
+        if !root.join(directory).is_dir() {
+            return Err("pre-existing protected parent publication directories required".into());
+        }
+    }
+    let permit = warden::parent_permit::issue_for_run(
+        root,
+        &plan.scope,
+        &plan.run_uid,
+        &intent,
+        binding,
+        Duration::from_millis(plan.admission_window_ms),
+    )
+    .map_err(|e| e.to_string())?;
+    admission.profile.permit = permit.publish(root).map_err(|e| e.to_string())?;
+    let bytes = serde_json::to_vec(&admission.profile).map_err(|e| e.to_string())?;
+    let launch = publish(root, &bytes, principal)?;
+    Ok((launch, incarnation))
+}
+
+impl Admission {
+    pub(crate) fn incarnation(&self) -> &Hash {
+        &self.profile.binding.incarnation
+    }
+    pub(crate) fn lifetime(&self) -> Duration {
+        Duration::from_millis(self.profile.binding.lifetime_ms)
+    }
+    pub(crate) fn reserved_memory_bytes(&self) -> u64 {
+        self.profile.reserved_memory_bytes
+    }
+
+    /// Claim on the serving thread before any runtime preparation or creation.
+    /// Failure after this point burns the incarnation, including capacity races.
+    pub(crate) fn claim(
+        self,
+        principal: &str,
+    ) -> Result<
+        impl FnOnce(
+                std::sync::Arc<warden::parent_child_control::ChildControlSlot>,
+            ) -> Result<Handler, String>
+            + Send,
+        String,
+    > {
+        let claim = warden::parent_permit::claim(
+            &self.root,
+            &self.profile.permit,
+            &self.profile.binding,
+            principal,
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(move |children| {
+            let profile = self.profile;
+            let motes = self.root.join("motes");
+            let tools = self.root.join("tools");
+            let parent = prepare_parent(
+                &profile.parent,
+                &motes,
+                &tools,
+                &self.root,
+                &profile.permit,
+                &profile.binding,
+                &profile.binding.principal,
+            )?;
+            let worker = parent_worker::prepare_worker(
+                &profile.worker,
+                self.template,
+                profile.model_profile,
+                &profile.binding,
+                &motes,
+                &tools,
+                &self.root,
+            )?;
+            let mut session = parent.into_claimed_session(worker, Some(claim), Some(children))?;
+            Ok(
+                Box::new(move |bytes: &[u8]| session.submit(bytes).map_err(|e| e.to_string()))
+                    as Handler,
+            )
+        })
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod publication_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn fixture() -> (tempfile::TempDir, Vec<u8>) {
+        let root = tempfile::tempdir().unwrap();
+        let request = super::super::parent_tests::request();
+        let mut binding = super::super::parent_tests::binding(&request);
+        binding.turn_model_requests = 1;
+        binding.turn_output_tokens = 512;
+        binding.total_model_requests = 2;
+        binding.total_output_tokens = 1024;
+        let template = pilot::turn_worker::Template::new(
+            serde_json::from_value(json!({
+                "contract":"celln.json-tools/v1", "task":"", "system":"host persona",
+                "url":"https://api.deepseek.com/chat/completions", "model":"deepseek-chat",
+                "tools":[], "max_turns":1, "max_calls":0
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let model = serde_json::to_vec(&json!({
+            "apiVersion":"celln.parent-model-profile/v1", "principal":binding.principal,
+            "requestBinding":request.configuration_binding(celln_spec::ConfigurationRole::Worker).unwrap(),
+            "templateBinding":template.binding(), "credentialFile":root.path().join("absent-secret"),
+            "url":template.policy().url, "model":template.policy().model,
+            "maxRequests":1, "maxOutputTokens":512, "maxTotalOutputTokens":512
+        })).unwrap();
+        let model_hash = Hash::of(&model);
+        for directory in [
+            "trusted-parent-models",
+            "trusted-parent-permits",
+            "trusted-parent-launches",
+        ] {
+            std::fs::create_dir(root.path().join(directory)).unwrap();
+        }
+        std::fs::write(
+            root.path()
+                .join("trusted-parent-models")
+                .join(format!("{}.json", &model_hash.0[7..])),
+            model,
+        )
+        .unwrap();
+        binding.worker_configuration =
+            parent_model::worker_binding(&request, &template, &model_hash).unwrap();
+        let permit = warden::parent_permit::Permit::issue(binding.clone(), Duration::from_secs(60))
+            .unwrap()
+            .publish(root.path())
+            .unwrap();
+        let bytes = serde_json::to_vec(&json!({
+            "apiVersion":"celln.parent-launch/v1", "parent":request, "worker":request,
+            "template":template.policy(), "modelProfile":model_hash, "permit":permit,
+            "binding":binding, "reservedMemoryBytes":2 * (binding.parent_memory_bytes + binding.child_memory_bytes) + 1
+        })).unwrap();
+        (root, bytes)
+    }
+
+    #[test]
+    fn provision_plan_recovers_exact_launch_and_refuses_changed_intent() {
+        let (root, bytes) = fixture();
+        std::fs::create_dir(root.path().join("parent-issuance")).unwrap();
+        let profile: Profile = serde_json::from_slice(&bytes).unwrap();
+        let mut plan = ProvisionPlan {
+            api_version: "celln.parent-provision-plan/v1".into(),
+            scope: "test-cluster".into(),
+            run_uid: "immutable-run-uid".into(),
+            intent_sha256: format!("sha256:{}", "a".repeat(64)),
+            admission_window_ms: 60000,
+            parent: profile.parent,
+            worker: profile.worker,
+            template: profile.template,
+            model_profile: profile.model_profile,
+            reserved_memory_bytes: profile.reserved_memory_bytes,
+            max_turns: 2,
+            turn_model_requests: 1,
+            turn_output_tokens: 512,
+            total_model_requests: 2,
+            total_output_tokens: 1024,
+        };
+        let encode = |plan: &ProvisionPlan| serde_json::to_vec(plan).unwrap();
+        assert!(serde_json::to_value(&plan)
+            .unwrap()
+            .get("intentSHA256")
+            .is_some());
+        let first = provision(root.path(), &encode(&plan), "test:parent").unwrap();
+        assert_eq!(
+            provision(
+                root.path(),
+                &serde_json::to_vec_pretty(&plan).unwrap(),
+                "test:parent"
+            )
+            .unwrap(),
+            first
+        );
+        assert_eq!(
+            first.1,
+            warden::parent_permit::run_incarnation("test-cluster", "immutable-run-uid").unwrap()
+        );
+        assert_eq!(
+            provision(root.path(), &encode(&plan), "test:parent").unwrap(),
+            first
+        );
+        assert!(admit(root.path(), &first.0, "test:parent").is_ok());
+        plan.intent_sha256 = format!("sha256:{}", "b".repeat(64));
+        assert!(provision(root.path(), &encode(&plan), "test:parent").is_err());
+        plan.intent_sha256 = format!("sha256:{}", "a".repeat(64));
+        plan.reserved_memory_bytes += 1;
+        assert!(provision(root.path(), &encode(&plan), "test:parent").is_err());
+        plan.reserved_memory_bytes -= 1;
+        assert!(provision(root.path(), &encode(&plan), "another-tenant").is_err());
+        plan.run_uid = "second-run-uid".into();
+        let second = provision(root.path(), &encode(&plan), "test:parent").unwrap();
+        assert_ne!(first, second);
+        assert_eq!(
+            std::fs::read_dir(root.path().join("parent-issuance"))
+                .unwrap()
+                .count(),
+            2
+        );
+        assert!(!root.path().join("parent-journal").exists());
+    }
+
+    #[test]
+    fn launch_publication_is_durable_repeatable_and_never_claims() {
+        use std::os::unix::fs::PermissionsExt;
+        let (root, bytes) = fixture();
+        let hash = publish(root.path(), &bytes, "test:parent").unwrap();
+        assert_eq!(hash, Hash::of(&bytes));
+        assert_eq!(publish(root.path(), &bytes, "test:parent").unwrap(), hash);
+        let path = root
+            .path()
+            .join("trusted-parent-launches")
+            .join(format!("{}.json", &hash.0[7..]));
+        assert_eq!(std::fs::read(&path).unwrap(), bytes);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert!(!root.path().join("parent-journal").exists());
+        assert!(!root.path().join("absent-secret").exists());
+        std::fs::write(&path, b"corrupt").unwrap();
+        assert!(publish(root.path(), &bytes, "test:parent").is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), b"corrupt");
+        assert_eq!(
+            std::fs::read_dir(root.path().join("trusted-parent-launches"))
+                .unwrap()
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn launch_publication_refuses_invalid_or_unbound_policy_before_writes() {
+        let (root, bytes) = fixture();
+        assert!(publish(Path::new("relative"), &bytes, "test:parent").is_err());
+        assert!(publish(root.path(), &bytes, "other-tenant").is_err());
+        assert!(publish(root.path(), &vec![b' '; 65537], "test:parent").is_err());
+        for (pointer, value) in [
+            ("/reservedMemoryBytes", json!(1)),
+            ("/template/system", json!("unapproved persona")),
+            ("/binding/maxTurns", json!(3)),
+            ("/worker/workload/caller", json!("other-tenant")),
+            ("/parent/capabilities/workspace", json!("read-only")),
+        ] {
+            let mut changed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            *changed.pointer_mut(pointer).unwrap() = value;
+            assert!(
+                publish(
+                    root.path(),
+                    &serde_json::to_vec(&changed).unwrap(),
+                    "test:parent"
+                )
+                .is_err(),
+                "{pointer}"
+            );
+        }
+        assert_eq!(
+            std::fs::read_dir(root.path().join("trusted-parent-launches"))
+                .unwrap()
+                .count(),
+            0
+        );
+        assert!(!root.path().join("parent-journal").exists());
+    }
+}

--- a/crates/celln-cli/src/dispatch_parent_launcher_tests.rs
+++ b/crates/celln-cli/src/dispatch_parent_launcher_tests.rs
@@ -1,0 +1,259 @@
+use super::*;
+use celln_manifest::{
+    closure::{Closure, Member},
+    Hash,
+};
+use celln_store::Store;
+use serde_json::json;
+
+pub(super) fn binding(request: &ExecutionRequest) -> warden::parent_permit::Binding {
+    warden::parent_permit::Binding {
+        principal: request.workload.caller.clone(),
+        incarnation: Hash::of(b"launcher-test"),
+        parent_configuration: request
+            .configuration_binding(celln_spec::ConfigurationRole::Parent)
+            .unwrap(),
+        worker_configuration: Hash::of(b"separately-admitted-worker"),
+        parent_memory_bytes: request.capabilities.memory_bytes,
+        child_memory_bytes: 268435456,
+        lifetime_ms: request.capabilities.timeout_ms,
+        turn_timeout_ms: 1000,
+        max_turns: 2,
+        turn_model_requests: 0,
+        turn_output_tokens: 0,
+        total_model_requests: 0,
+        total_output_tokens: 0,
+    }
+}
+
+pub(super) fn request() -> ExecutionRequest {
+    serde_json::from_value(json!({"apiVersion":"celln.dev/v1alpha1","id":"parent-launcher",
+        "workload":{"id":"parent-launcher","caller":"test:parent"},
+        "mote":{"hash":Hash::of(b"mote").0},
+        "tools":[{"alias":"/parent","hash":Hash::of(b"parent").0,"closure":{"hash":Hash::of(b"closure").0}}],
+        "invocation":{"alias":"/parent","args":[]},
+        "capabilities":{"workspace":"none","timeoutMs":30000,"memoryBytes":268435456,"outputBytes":8192},
+        "execution":{"lane":"agent","requireHardwareIsolation":true}})).unwrap()
+}
+
+#[test]
+fn parent_contract_refuses_ambient_authority_even_with_matching_fingerprint() {
+    let request = request();
+    assert!(validate_parent_request(&request, &binding(&request)).is_ok());
+    for (path, value) in [
+        ("/capabilities/workspace", json!("read-only")),
+        ("/capabilities/egress", json!(["https://api.deepseek.com"])),
+        ("/execution/lane", json!("tool")),
+        ("/execution/requireHardwareIsolation", json!(false)),
+        ("/invocation/args", json!(["unexpected"])),
+    ] {
+        let mut changed = serde_json::to_value(&request).unwrap();
+        *changed.pointer_mut(path).unwrap() = value;
+        let changed: ExecutionRequest = serde_json::from_value(changed).unwrap();
+        assert!(
+            validate_parent_request(&changed, &binding(&changed)).is_err(),
+            "{path}"
+        );
+    }
+    let root = tempfile::tempdir().unwrap();
+    assert!(prepare_parent(
+        &request,
+        root.path(),
+        root.path(),
+        root.path(),
+        &Hash::of(b"missing"),
+        &binding(&request),
+        "test:parent"
+    )
+    .is_err());
+}
+
+#[test]
+#[ignore = "requires real KVM, kernel, static native parent/Pilot and initramfs tools"]
+fn declared_parent_launcher_on_real_kvm() {
+    let _proof = crate::dispatch::warm::PROOF_LOCK.lock().unwrap();
+    if !Path::new("/dev/kvm").exists() {
+        eprintln!("SKIP: no KVM");
+        return;
+    }
+    let Some(kernel) = warden::vmm::boot::BootConfig::host_kernel() else {
+        eprintln!("SKIP: no kernel");
+        return;
+    };
+    for tool in ["gcc", "cpio", "mke2fs"] {
+        if std::process::Command::new("sh")
+            .args(["-c", "command -v \"$1\"", "check", tool])
+            .output()
+            .map_or(true, |output| !output.status.success())
+        {
+            eprintln!("SKIP: missing {tool}");
+            return;
+        }
+    }
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let pilot_dir = std::env::var_os("CELLN_PILOT_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| repo.join("target/x86_64-unknown-linux-musl/release"));
+    if !pilot_dir.join("celln-harness-parent").exists() {
+        eprintln!("SKIP: native parent not built");
+        return;
+    }
+    let work = tempfile::tempdir().unwrap();
+    let Some(runtime) = crate::dispatch::tests::test_runtime_root(work.path()) else {
+        return;
+    };
+    let rootfs = work.path().join("rootfs");
+    std::fs::create_dir(&rootfs).unwrap();
+    std::fs::create_dir(rootfs.join("tmp")).unwrap();
+    let program = std::fs::read(pilot_dir.join("celln-harness-parent")).unwrap();
+    let program_hash = Hash::of(&program);
+    std::fs::copy(
+        pilot_dir.join("celln-harness-parent"),
+        rootfs.join("parent"),
+    )
+    .unwrap();
+    let image = work.path().join("toolfs.ext2");
+    let output = std::process::Command::new("mke2fs")
+        .args(["-q", "-t", "ext2", "-b", "4096", "-F", "-d"])
+        .arg(&rootfs)
+        .arg(&image)
+        .arg("8192")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let image = std::fs::read(image).unwrap();
+    let signed = Closure {
+        api_version: "celln.dev/closure-v1".into(),
+        sources: vec![],
+        toolfs: Hash::of(&image).0,
+        entrypoint: "/parent".into(),
+        interpreter: false,
+        members: std::collections::BTreeMap::from([(
+            "/parent".into(),
+            Member {
+                hash: program_hash.0.clone(),
+                dependencies: Default::default(),
+            },
+        )]),
+    }
+    .sign(&[29; 32])
+    .unwrap();
+    let state = work.path().join("state");
+    let closure = Store::open(state.join("closures"))
+        .unwrap()
+        .put(&serde_json::to_vec(&signed).unwrap())
+        .unwrap();
+    std::fs::write(state.join("trusted-closures.json"), json!({"apiVersion":"celln.dev/closure-policy-v1","publishers":[signed.publisher],"revoked":[]}).to_string()).unwrap();
+    let mut assay = assay::Assayer::open(state.join("assay")).unwrap();
+    assay
+        .admit_verified_authored("/parent", &program, false, celln_manifest::Author::Host)
+        .unwrap();
+    let initrd = work.path().join("initrd");
+    crate::agent::sh_env(
+        &runtime,
+        "scripts/mkinitramfs.sh",
+        &[initrd.display().to_string()],
+        &[
+            (
+                "CELLN_MANIFEST",
+                state.join("assay/manifest.json").display().to_string(),
+            ),
+            (
+                "CELLN_PILOT_DIR",
+                runtime.join("pilot").display().to_string(),
+            ),
+        ],
+    )
+    .unwrap();
+    let motes = Store::open(state.join("motes")).unwrap();
+    Store::open(state.join("tools"))
+        .unwrap()
+        .put(&program)
+        .unwrap();
+    let kernel = motes.put(&std::fs::read(kernel).unwrap()).unwrap();
+    let initrd = motes.put(&std::fs::read(initrd).unwrap()).unwrap();
+    let toolfs = motes.put(&image).unwrap();
+    let mote = motes.put(&serde_json::to_vec(&json!({"apiVersion":"celln.dev/v1alpha1","format":"celln.warm-closure-v1",
+        "kernel":kernel.0,"initrd":initrd.0,"toolfs":toolfs.0,"invocation":{"alias":"/parent","toolHash":program_hash.0}})).unwrap()).unwrap();
+    std::fs::write(
+        state.join("trusted-motes.json"),
+        json!({"apiVersion":"celln.dev/v1alpha1","bundles":[mote.0]}).to_string(),
+    )
+    .unwrap();
+    let mut request = request();
+    request.mote.as_mut().unwrap().hash = mote.0;
+    request.tools[0].hash = program_hash.0;
+    request.tools[0].closure.as_mut().unwrap().hash = closure.0;
+    let binding = binding(&request);
+    let clock = warden::parent_permit::host_clock().unwrap();
+    let permit = warden::parent_permit::Permit {
+        api_version: warden::parent_permit::VERSION.into(),
+        binding: binding.clone(),
+        boot_id: clock.boot_id,
+        issued_at_boottime_ms: clock.boottime_ms,
+        expires_at_boottime_ms: clock.boottime_ms + 60000,
+    };
+    let permit = serde_json::to_vec(&permit).unwrap();
+    let permit_hash = Hash::of(&permit);
+    std::fs::create_dir(state.join("trusted-parent-permits")).unwrap();
+    let permit_path = state
+        .join("trusted-parent-permits")
+        .join(format!("{}.json", &permit_hash.0[7..]));
+    std::fs::write(&permit_path, &permit).unwrap();
+    let prepare = || {
+        prepare_parent(
+            &request,
+            &state.join("motes"),
+            &state.join("tools"),
+            &state,
+            &permit_hash,
+            &binding,
+            "test:parent",
+        )
+        .unwrap()
+    };
+    let revoked = prepare();
+    std::fs::remove_file(&permit_path).unwrap();
+    assert!(revoked.launch().is_err());
+    std::fs::write(&permit_path, &permit).unwrap();
+    let mut parent = prepare().launch().unwrap();
+    let mut exchange = |input: serde_json::Value| {
+        parent
+            .cell
+            .deliver_parent_message(&serde_json::to_vec(&input).unwrap())
+            .unwrap();
+        let report = parent.cell.run().unwrap();
+        assert_eq!(
+            report.end,
+            warden::vmm::boot::BootEnd::Parked,
+            "{}",
+            report.tail(30)
+        );
+        assert!(!report.console.contains("Linux version"));
+        serde_json::from_slice::<serde_json::Value>(
+            &parent.cell.take_parent_response().unwrap().unwrap(),
+        )
+        .unwrap()
+    };
+    let spawn = exchange(
+        json!({"kind":"turn","apiVersion":pilot::parent_harness::VERSION,"turnId":"one","message":"remember violet"}),
+    );
+    assert_eq!(spawn["kind"], "spawn");
+    let completed = exchange(
+        json!({"kind":"result","apiVersion":pilot::parent_harness::VERSION,"turnId":"one","succeeded":true,"answer":"remembered"}),
+    );
+    assert_eq!(completed["kind"], "completed");
+    let next = exchange(
+        json!({"kind":"turn","apiVersion":pilot::parent_harness::VERSION,"turnId":"two","message":"what value?"}),
+    );
+    let task: serde_json::Value =
+        serde_json::from_str(next["request"]["task"].as_str().unwrap()).unwrap();
+    assert_eq!(task["history"][0]["user"], "remember violet");
+    assert!(prepare().launch().is_err());
+    drop(parent);
+    eprintln!("PASS: signed declared parent, permit revocation before fork, retained guest context, incarnation replay refused");
+}

--- a/crates/celln-cli/src/dispatch_parent_model.rs
+++ b/crates/celln-cli/src/dispatch_parent_model.rs
@@ -1,0 +1,421 @@
+//! Host-only model authority for a fixed native worker. Unlike a one-shot
+//! Harness grant, this profile authorizes fresh child-local brokers under one
+//! admitted parent ledger; it never authorizes resetting that ledger.
+use celln_manifest::Hash;
+use celln_spec::{ConfigurationRole, ExecutionRequest};
+use pilot::turn_worker::Template;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeSet,
+    io::Read,
+    path::{Path, PathBuf},
+};
+use warden::{parent_lease::ReservedTurn, parent_permit::Binding};
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Profile {
+    api_version: String,
+    principal: String,
+    request_binding: Hash,
+    template_binding: Hash,
+    credential_file: PathBuf,
+    url: String,
+    model: String,
+    max_requests: u64,
+    max_output_tokens: u64,
+    max_total_output_tokens: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    workspace: Option<WorkspaceProfile>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    fetch: Option<FetchProfile>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FetchProfile {
+    allow_hosts: Vec<String>,
+    max_requests: usize,
+    max_response_bytes: usize,
+    timeout_ms: u64,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct WorkspaceProfile {
+    read: bool,
+    write: bool,
+    max_operations: usize,
+    max_files: usize,
+    max_file_bytes: usize,
+    max_total_bytes: usize,
+}
+
+pub(super) fn worker_binding(
+    request: &ExecutionRequest,
+    template: &Template,
+    profile: &Hash,
+) -> Result<Hash, String> {
+    let request = request.configuration_binding(ConfigurationRole::Worker)?;
+    Ok(Hash::of(
+        &serde_json::to_vec(&(
+            "celln.native-worker-admission/v1",
+            request,
+            template.binding(),
+            profile,
+        ))
+        .map_err(|_| "invalid worker binding")?,
+    ))
+}
+
+pub(super) struct ChildBrokers {
+    root: PathBuf,
+    profile: Hash,
+    binding: Binding,
+    request: Hash,
+    template: Hash,
+    url: String,
+    model: String,
+    requests: u64,
+    claimed: BTreeSet<String>,
+    workspace: Option<warden::workspace_broker::Owner>,
+}
+
+impl ChildBrokers {
+    /// Construct once in the live owner after validating the parent permit and
+    /// independently admitting the worker closure. This does not read the key.
+    pub(super) fn new(
+        root: &Path,
+        profile: Hash,
+        binding: Binding,
+        request: &ExecutionRequest,
+        template: &Template,
+    ) -> Result<Self, String> {
+        if worker_binding(request, template, &profile)? != binding.worker_configuration
+            || request.workload.caller != binding.principal
+        {
+            return Err("worker model authority is not bound to parent permit".into());
+        }
+        let mut issuer = Self {
+            root: root.into(),
+            profile,
+            binding,
+            request: request.configuration_binding(ConfigurationRole::Worker)?,
+            template: template.binding().clone(),
+            url: template.policy().url.clone(),
+            model: template.policy().model.clone(),
+            requests: template.policy().max_turns as u64,
+            claimed: BTreeSet::new(),
+            workspace: None,
+        };
+        let admitted = issuer.read_profile()?;
+        if admitted.fetch.is_some()
+            && !template
+                .policy()
+                .tools
+                .iter()
+                .any(|t| t.name == "https-fetch")
+        {
+            return Err("fetch profile lacks explicitly selected starter tool".into());
+        }
+        if let Some(workspace) = admitted.workspace {
+            // The entire profile is content-hash pinned to the parent permit.
+            // Tool selection still requires independent upstream admission.
+            let has_tool = |name: &str| template.policy().tools.iter().any(|t| t.name == name);
+            if workspace.read != has_tool("workspace-read")
+                || workspace.write != has_tool("workspace-write")
+                || (!workspace.read && !workspace.write)
+                || !(1..=64).contains(&workspace.max_operations)
+            {
+                return Err("workspace profile does not match selected starter tools".into());
+            }
+            issuer.workspace = Some(warden::workspace_broker::Owner::new(
+                issuer.binding.incarnation.clone(),
+                celln_store::workspace::Limits {
+                    files: workspace.max_files,
+                    file_bytes: workspace.max_file_bytes,
+                    total_bytes: workspace.max_total_bytes,
+                },
+            )?);
+        }
+        Ok(issuer)
+    }
+
+    fn read_profile(&self) -> Result<Profile, String> {
+        let hash = self
+            .profile
+            .0
+            .strip_prefix("blake3:")
+            .filter(|s| {
+                s.len() == 64
+                    && s.bytes()
+                        .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+            })
+            .ok_or("invalid parent model profile hash")?;
+        let mut bytes = Vec::new();
+        std::fs::File::open(
+            self.root
+                .join("trusted-parent-models")
+                .join(format!("{hash}.json")),
+        )
+        .and_then(|f| f.take(65537).read_to_end(&mut bytes))
+        .map_err(|_| "parent model profile unavailable")?;
+        if bytes.len() > 65536 || Hash::of(&bytes) != self.profile {
+            return Err("parent model profile revision mismatch".into());
+        }
+        let profile: Profile =
+            serde_json::from_slice(&bytes).map_err(|_| "invalid parent model profile")?;
+        if profile.api_version != "celln.parent-model-profile/v1"
+            || profile.principal != self.binding.principal
+            || profile.request_binding != self.request
+            || profile.template_binding != self.template
+            || profile.url != self.url
+            || profile.model != self.model
+            || profile.url != "https://api.deepseek.com/chat/completions"
+            || !profile.credential_file.is_absolute()
+            || profile.max_output_tokens != 512
+            || profile.max_requests != self.requests
+            || !(1..=6).contains(&profile.max_requests)
+            || profile.max_requests > self.binding.turn_model_requests
+            || profile.max_total_output_tokens < profile.max_requests * 512
+            || profile.max_total_output_tokens > self.binding.turn_output_tokens
+        {
+            return Err("parent model profile policy mismatch".into());
+        }
+        if let Some(fetch) = &profile.fetch {
+            if !(1..=16).contains(&fetch.max_requests)
+                || !(1..=65536).contains(&fetch.max_response_bytes)
+                || !(1..=30000).contains(&fetch.timeout_ms)
+                || fetch.allow_hosts.is_empty()
+                || fetch.allow_hosts.len() > 16
+                || fetch.allow_hosts.iter().any(|host| {
+                    host.len() > 253
+                        || !host.contains('.')
+                        || host.split('.').any(|label| {
+                            label.is_empty()
+                                || label.len() > 63
+                                || label.starts_with('-')
+                                || label.ends_with('-')
+                                || !label.bytes().all(|b| {
+                                    b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-'
+                                })
+                        })
+                })
+            {
+                return Err("invalid bounded HTTPS starter profile".into());
+            }
+        }
+        Ok(profile)
+    }
+
+    /// One broker per reserved child. No refund/retry on profile failure. The
+    /// ParentLease/ParentJournal remain responsible for aggregate budgets and
+    /// durable pre-spawn reservation; this in-memory set is not restart recovery.
+    pub(super) fn for_turn(
+        &mut self,
+        turn: &ReservedTurn,
+    ) -> Result<warden::egress::HttpPolicy, String> {
+        let expected = Hash::of(
+            &serde_json::to_vec(&(&self.binding.incarnation.0, &turn.request.turn_id))
+                .map_err(|_| "invalid child binding")?,
+        );
+        if turn.parent != self.binding.incarnation
+            || turn.child != expected
+            || self.claimed.len() >= self.binding.max_turns
+            || turn.limits.model_requests > self.binding.turn_model_requests
+            || turn.limits.output_tokens > self.binding.turn_output_tokens
+            || turn.limits.memory_bytes > self.binding.child_memory_bytes
+            || turn.limits.timeout.is_zero()
+            || turn.limits.timeout > std::time::Duration::from_millis(self.binding.turn_timeout_ms)
+        {
+            return Err("child model reservation mismatch".into());
+        }
+        if !self.claimed.insert(turn.child.0.clone()) {
+            return Err("child broker already claimed".into());
+        }
+        let profile = self.read_profile()?;
+        if profile.max_requests > turn.limits.model_requests
+            || profile.max_total_output_tokens > turn.limits.output_tokens
+        {
+            return Err("model profile exceeds child reservation".into());
+        }
+        let mut policy = warden::egress::HttpPolicy::new(vec!["api.deepseek.com".into()]);
+        policy.timeout = turn.limits.timeout.min(std::time::Duration::from_secs(45));
+        policy.max_requests = profile.max_requests as usize;
+        let get = match profile.fetch {
+            Some(fetch) => warden::egress::GetGrant {
+                allow_hosts: fetch.allow_hosts,
+                max_requests: fetch.max_requests,
+                max_response_bytes: fetch.max_response_bytes,
+                timeout: std::time::Duration::from_millis(fetch.timeout_ms)
+                    .min(turn.limits.timeout),
+            },
+            None => warden::egress::GetGrant {
+                allow_hosts: vec![],
+                max_requests: 0,
+                max_response_bytes: 0,
+                timeout: std::time::Duration::from_secs(1),
+            },
+        };
+        policy.allow_hosts.extend(get.allow_hosts.iter().cloned());
+        policy.get = Some(get);
+        policy.json_posts.push(warden::egress::JsonPostGrant {
+            url: profile.url,
+            model: profile.model,
+            bearer_token_file: profile.credential_file,
+            max_output_tokens: 512,
+            max_total_output_tokens: profile.max_total_output_tokens,
+        });
+        Ok(policy)
+    }
+
+    pub(super) fn workspace_for_turn(
+        &mut self,
+        turn: &ReservedTurn,
+        policy: &mut warden::egress::HttpPolicy,
+    ) -> Result<Option<warden::workspace_broker::Lease>, String> {
+        if !self.claimed.contains(&turn.child.0) {
+            return Err("workspace requires an admitted child broker".into());
+        }
+        let Some(profile) = self.read_profile()?.workspace else {
+            return Ok(None);
+        };
+        let control = celln_control::current().ok_or("workspace requires live child control")?;
+        let (lease, grant) = self
+            .workspace
+            .as_mut()
+            .ok_or("workspace owner unavailable")?
+            .begin(
+                turn,
+                profile.read,
+                profile.write,
+                profile.max_operations,
+                control,
+            )?;
+        policy.workspace = Some(grant);
+        Ok(Some(lease))
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    fn fixture() -> (
+        tempfile::TempDir,
+        ChildBrokers,
+        warden::parent_lease::ParentLease,
+        PathBuf,
+    ) {
+        let root = tempfile::tempdir().unwrap();
+        let request = super::super::parent_tests::request();
+        let mut binding = super::super::parent_tests::binding(&request);
+        binding.turn_model_requests = 1;
+        binding.turn_output_tokens = 512;
+        binding.total_model_requests = 2;
+        binding.total_output_tokens = 1024;
+        let template = Template::new(
+            serde_json::from_value(serde_json::json!({
+                "contract":"celln.json-tools/v1","task":"","system":"host persona",
+                "url":"https://api.deepseek.com/chat/completions","model":"deepseek-chat",
+                "tools":[],"max_turns":1,"max_calls":0
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let profile = Profile {
+            api_version: "celln.parent-model-profile/v1".into(),
+            principal: binding.principal.clone(),
+            request_binding: request
+                .configuration_binding(ConfigurationRole::Worker)
+                .unwrap(),
+            template_binding: template.binding().clone(),
+            credential_file: root.path().join("must-not-be-opened"),
+            url: template.policy().url.clone(),
+            model: template.policy().model.clone(),
+            max_requests: 1,
+            max_output_tokens: 512,
+            max_total_output_tokens: 512,
+            workspace: None,
+            fetch: None,
+        };
+        let bytes = serde_json::to_vec(&profile).unwrap();
+        let hash = Hash::of(&bytes);
+        binding.worker_configuration = worker_binding(&request, &template, &hash).unwrap();
+        std::fs::create_dir(root.path().join("trusted-parent-models")).unwrap();
+        let path = root
+            .path()
+            .join("trusted-parent-models")
+            .join(format!("{}.json", &hash.0[7..]));
+        std::fs::write(&path, &bytes).unwrap();
+        let issuer =
+            ChildBrokers::new(root.path(), hash, binding.clone(), &request, &template).unwrap();
+        let mut wrong = binding.clone();
+        wrong.worker_configuration = Hash::of(b"wrong");
+        assert!(ChildBrokers::new(
+            root.path(),
+            issuer.profile.clone(),
+            wrong,
+            &request,
+            &template
+        )
+        .is_err());
+        let lease = warden::parent_lease::ParentLease::new(
+            binding.incarnation,
+            std::time::Duration::from_secs(30),
+            warden::parent_lease::TurnLimits {
+                memory_bytes: binding.child_memory_bytes,
+                timeout: std::time::Duration::from_millis(binding.turn_timeout_ms),
+                model_requests: 1,
+                output_tokens: 512,
+            },
+            2,
+            2,
+            1024,
+        )
+        .unwrap();
+        (root, issuer, lease, path)
+    }
+    fn reserve(lease: &mut warden::parent_lease::ParentLease, id: &str) -> ReservedTurn {
+        lease.reserve(&serde_json::to_vec(&serde_json::json!({"apiVersion":warden::parent_protocol::VERSION,"turnId":id,"task":"input"})).unwrap()).unwrap()
+    }
+    #[test]
+    fn child_local_brokers_are_bounded_one_use_and_do_not_read_credentials() {
+        let (_root, mut issuer, mut lease, _path) = fixture();
+        for id in ["one", "two"] {
+            let turn = reserve(&mut lease, id);
+            let policy = issuer.for_turn(&turn).unwrap();
+            assert_eq!(policy.max_requests, 1);
+            assert_eq!(policy.json_posts[0].max_total_output_tokens, 512);
+            assert!(!policy.json_posts[0].bearer_token_file.exists());
+            assert!(issuer.for_turn(&turn).is_err());
+            lease.confirm_child_destroyed(&turn.child).unwrap();
+        }
+        assert_eq!(issuer.claimed.len(), 2);
+    }
+    #[test]
+    fn live_profile_revocation_consumes_claim_without_retry_or_refund() {
+        let (_root, mut issuer, mut lease, path) = fixture();
+        let turn = reserve(&mut lease, "one");
+        let bytes = std::fs::read(&path).unwrap();
+        std::fs::remove_file(&path).unwrap();
+        assert!(issuer.for_turn(&turn).is_err());
+        std::fs::write(&path, bytes).unwrap();
+        assert!(issuer
+            .for_turn(&turn)
+            .unwrap_err()
+            .contains("already claimed"));
+    }
+    #[test]
+    fn changed_child_identity_and_widened_limits_are_refused() {
+        let (_root, mut issuer, mut lease, _path) = fixture();
+        let mut turn = reserve(&mut lease, "one");
+        let child = turn.child.clone();
+        turn.child = Hash::of(b"forged");
+        assert!(issuer.for_turn(&turn).is_err());
+        turn.child = child;
+        turn.limits.model_requests = 2;
+        assert!(issuer.for_turn(&turn).is_err());
+        turn.limits.model_requests = 1;
+        assert!(issuer.for_turn(&turn).is_ok());
+    }
+}

--- a/crates/celln-cli/src/dispatch_parent_pair_tests.rs
+++ b/crates/celln-cli/src/dispatch_parent_pair_tests.rs
@@ -1,0 +1,476 @@
+use super::*;
+use celln_manifest::{
+    closure::{Closure, Member},
+    Hash,
+};
+use celln_store::Store;
+use serde_json::json;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+};
+
+#[path = "../../celln-pilot/src/proof_credential.rs"]
+mod credential;
+
+#[path = "dispatch_starter_live_tests.rs"]
+mod starter;
+
+fn bundle(
+    state: &Path,
+    runtime: &Path,
+    kernel: &Path,
+    name: &str,
+    programs: &[(&str, PathBuf)],
+) -> ExecutionRequest {
+    let rootfs = state.join(format!("{name}-rootfs"));
+    std::fs::create_dir_all(rootfs.join("tmp")).unwrap();
+    let mut members = BTreeMap::new();
+    for (path, source) in programs {
+        let bytes = std::fs::read(source).unwrap();
+        std::fs::copy(source, rootfs.join(path.trim_start_matches('/'))).unwrap();
+        members.insert(
+            path.to_string(),
+            Member {
+                hash: Hash::of(&bytes).0,
+                dependencies: BTreeSet::new(),
+            },
+        );
+    }
+    members.get_mut(programs[0].0).unwrap().dependencies = programs
+        .iter()
+        .skip(1)
+        .map(|(path, _)| path.to_string())
+        .collect();
+    let program = std::fs::read(&programs[0].1).unwrap();
+    let program_hash = Hash::of(&program);
+    let image = state.join(format!("{name}.ext2"));
+    let result = std::process::Command::new("mke2fs")
+        .args(["-q", "-t", "ext2", "-b", "4096", "-F", "-d"])
+        .arg(&rootfs)
+        .arg(&image)
+        .arg("8192")
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let image = std::fs::read(image).unwrap();
+    let signed = Closure {
+        api_version: "celln.dev/closure-v1".into(),
+        sources: vec![],
+        toolfs: Hash::of(&image).0,
+        entrypoint: programs[0].0.into(),
+        interpreter: false,
+        members,
+    }
+    .sign(&[31; 32])
+    .unwrap();
+    let closure = Store::open(state.join("closures"))
+        .unwrap()
+        .put(&serde_json::to_vec(&signed).unwrap())
+        .unwrap();
+    std::fs::write(state.join("trusted-closures.json"),json!({"apiVersion":"celln.dev/closure-policy-v1","publishers":[signed.publisher],"revoked":[]}).to_string()).unwrap();
+    let assay_root = state.join(format!("{name}-assay"));
+    assay::Assayer::open(&assay_root)
+        .unwrap()
+        .admit_verified_authored(programs[0].0, &program, false, celln_manifest::Author::Host)
+        .unwrap();
+    let initrd = state.join(format!("{name}.cpio"));
+    crate::agent::sh_env(
+        runtime,
+        "scripts/mkinitramfs.sh",
+        &[initrd.display().to_string()],
+        &[
+            (
+                "CELLN_MANIFEST",
+                assay_root.join("manifest.json").display().to_string(),
+            ),
+            (
+                "CELLN_PILOT_DIR",
+                runtime.join("pilot").display().to_string(),
+            ),
+        ],
+    )
+    .unwrap();
+    let motes = Store::open(state.join("motes")).unwrap();
+    Store::open(state.join("tools"))
+        .unwrap()
+        .put(&program)
+        .unwrap();
+    let kernel = motes.put(&std::fs::read(kernel).unwrap()).unwrap();
+    let initrd = motes.put(&std::fs::read(initrd).unwrap()).unwrap();
+    let toolfs = motes.put(&image).unwrap();
+    let mote=motes.put(&serde_json::to_vec(&json!({"apiVersion":"celln.dev/v1alpha1","format":"celln.warm-closure-v1",
+        "kernel":kernel.0,"initrd":initrd.0,"toolfs":toolfs.0,"invocation":{"alias":programs[0].0,"toolHash":program_hash.0}})).unwrap()).unwrap();
+    let mut request = super::parent_tests::request();
+    request.id = name.into();
+    request.workload.id = name.into();
+    request.mote.as_mut().unwrap().hash = mote.0;
+    request.tools[0].hash = program_hash.0;
+    request.tools[0].alias = programs[0].0.into();
+    request.tools[0].closure.as_mut().unwrap().hash = closure.0;
+    request.invocation.as_mut().unwrap().alias = programs[0].0.into();
+    request
+}
+
+#[test]
+#[ignore = "explicit billable DeepSeek/KVM proof; requires CELLN_PARENT_MODEL_KEY_FROM_ZSHRC"]
+fn declared_parent_worker_pair_real_model() {
+    prove_pair(false, false);
+}
+
+#[test]
+#[ignore = "explicit billable DeepSeek/KVM borrowed-tool proof"]
+fn declared_parent_worker_pair_borrowed_tool() {
+    prove_pair(true, false);
+}
+
+#[test]
+#[ignore = "explicit billable DeepSeek/KVM child cancellation proof"]
+fn declared_parent_worker_pair_cancelled_model() {
+    prove_pair(true, true);
+}
+
+fn prove_pair(borrowed: bool, cancel: bool) {
+    if cancel {
+        assert!(std::env::var_os("CELLN_PARENT_INTEROP_BINARY").is_none());
+    }
+    let Some(key_path) = std::env::var_os("CELLN_PARENT_MODEL_KEY_FROM_ZSHRC") else {
+        eprintln!("SKIP: explicit model key source required");
+        return;
+    };
+    let _proof = crate::dispatch::warm::PROOF_LOCK.lock().unwrap();
+    if !Path::new("/dev/kvm").exists() {
+        eprintln!("SKIP: no KVM");
+        return;
+    }
+    let Some(kernel) = warden::vmm::boot::BootConfig::host_kernel() else {
+        eprintln!("SKIP: no kernel");
+        return;
+    };
+    for tool in ["gcc", "cpio", "mke2fs", "rustc"] {
+        if std::process::Command::new("sh")
+            .args(["-c", "command -v \"$1\"", "check", tool])
+            .output()
+            .map_or(true, |output| !output.status.success())
+        {
+            eprintln!("SKIP: missing {tool}");
+            return;
+        }
+    }
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let binaries = std::env::var_os("CELLN_PILOT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repo.join("target/x86_64-unknown-linux-musl/release"));
+    for name in [
+        "celln-harness-parent",
+        "celln-harness-turn",
+        "celln-pilot",
+        "pilot-fetch",
+    ] {
+        if !binaries.join(name).exists() {
+            eprintln!("SKIP: missing {name}");
+            return;
+        }
+    }
+    let work = repo.join(format!(
+        "target/declared-parent-pair-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir(&work).unwrap();
+    let runtime = crate::dispatch::tests::test_runtime_root(&work).unwrap();
+    let key = credential::from_zshrc(Path::new(&key_path)).unwrap();
+    let mut parent_request = bundle(
+        &work,
+        &runtime,
+        &kernel,
+        "parent",
+        &[("/parent", binaries.join("celln-harness-parent"))],
+    );
+    let mut programs = vec![
+        ("/worker", binaries.join("celln-harness-turn")),
+        ("/pilot-fetch", binaries.join("pilot-fetch")),
+    ];
+    if borrowed {
+        assert!(std::process::Command::new("rustc")
+            .args([
+                "--edition=2021",
+                "-O",
+                "--target",
+                "x86_64-unknown-linux-musl",
+                "--cfg",
+                "uppercase_tool"
+            ])
+            .arg(repo.join("crates/celln-pilot/tests/fixtures/json_tool.rs"))
+            .arg("-o")
+            .arg(work.join("uppercase"))
+            .status()
+            .unwrap()
+            .success());
+        programs.push(("/uppercase", work.join("uppercase")));
+    }
+    let mut worker_request = bundle(&work, &runtime, &kernel, "worker", &programs);
+    parent_request.capabilities.timeout_ms = 180000;
+    worker_request.capabilities.timeout_ms = 60000;
+    std::fs::write(work.join("trusted-motes.json"),json!({"apiVersion":"celln.dev/v1alpha1","bundles":[parent_request.mote.as_ref().unwrap().hash,worker_request.mote.as_ref().unwrap().hash]}).to_string()).unwrap();
+    let mut config = json!({"contract":"celln.json-tools/v1","task":"",
+        "system":"Answer briefly. Remember values supplied in conversation.","url":"https://api.deepseek.com/chat/completions",
+        "model":"deepseek-chat","tools":[],"max_turns":1,"max_calls":0});
+    if borrowed {
+        let schema = r#"{"type":"object","properties":{"text":{"type":"string","minLength":1,"maxLength":64}},"required":["text"],"additionalProperties":false}"#;
+        config["system"] = json!("Use the supplied conversation history, including earlier user messages. When the user requests a tool, call it on this turn even if a previous answer is available. Return only the tool result text.");
+        config["tools"] = json!([{"name":"uppercase","path":"/uppercase","hash":Hash::of(&std::fs::read(work.join("uppercase")).unwrap()).0,
+            "description":"Uppercase text","input_schema":{"bytes":schema,"hash":Hash::of(schema.as_bytes()).0},
+            "output_schema":{"bytes":schema,"hash":Hash::of(schema.as_bytes()).0},"input_bytes":1024,"output_bytes":256,"timeout_ms":1000}]);
+        config["max_turns"] = json!(3);
+        config["max_calls"] = json!(1);
+        config["require_tool_call"] = json!(true);
+    }
+    if borrowed && std::env::var_os("CELLN_PARENT_INTEROP_BINARY").is_some() {
+        // Export public catalogue metadata for the exact fixture artifacts.
+        // This is neither a host permit nor a claim of OCI compatibility.
+        let tool_request = bundle(
+            &work,
+            &runtime,
+            &kernel,
+            "uppercase-tool",
+            &[("/uppercase", work.join("uppercase"))],
+        );
+        let policy: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(work.join("trusted-closures.json")).unwrap())
+                .unwrap();
+        let publisher = &policy["publishers"][0];
+        let catalogue = json!({
+            "systemPrompt": config["system"],
+            "tool": {
+                "revision":"v1", "description":"Uppercase text", "supportOwner":"isolated-hardware-proof", "publisherKey":publisher,
+                "executable":{"hash":tool_request.tools[0].hash}, "closure":tool_request.tools[0].closure,
+                "entryPoint":"/uppercase", "invocationABI":"celln.json-stdio/v1",
+                "argumentsSchema":{"hash":config["tools"][0]["input_schema"]["hash"]},
+                "resultSchema":{"hash":config["tools"][0]["output_schema"]["hash"]},
+                "platform":"linux/amd64", "lane":"tool",
+                "limits":{"timeoutMillis":1000,"memoryBytes":268435456,"argumentBytes":1024,"outputBytes":256,"workspace":"none","effects":"none"}
+            },
+            "worker": {
+                "revision":"v1", "contractVersion":"celln.json-tools/v1", "publisherKey":publisher,
+                "executable":{"hash":worker_request.tools[0].hash}, "closure":worker_request.tools[0].closure,
+                "mote":worker_request.mote, "entryPoint":"/worker", "platform":"linux/amd64", "lane":"agent", "lifecycle":"disposable-one-shot",
+                "json":{"maxTurns":3,"maxCalls":1},
+                "limits":{"timeoutMillis":60000,"memoryBytes":268435456,"taskBytes":2048,"outputBytes":65536,"workspace":"none"}
+            }
+        });
+        std::fs::write(
+            work.join("interop-catalogue.json"),
+            serde_json::to_vec(&catalogue).unwrap(),
+        )
+        .unwrap();
+    }
+    let template =
+        pilot::turn_worker::Template::new(serde_json::from_value(config).unwrap()).unwrap();
+    let mut binding = super::parent_tests::binding(&parent_request);
+    binding.incarnation = Hash::of(work.as_os_str().as_encoded_bytes());
+    binding.turn_timeout_ms = 60000;
+    binding.turn_model_requests = if borrowed { 3 } else { 1 };
+    binding.turn_output_tokens = binding.turn_model_requests * 512;
+    binding.max_turns = if cancel { 3 } else { 2 };
+    binding.total_model_requests = binding.max_turns as u64 * binding.turn_model_requests;
+    binding.total_output_tokens = binding.max_turns as u64 * binding.turn_output_tokens;
+    let profile = json!({"apiVersion":"celln.parent-model-profile/v1","principal":binding.principal,
+        "requestBinding":worker_request.configuration_binding(celln_spec::ConfigurationRole::Worker).unwrap(),
+        "templateBinding":template.binding(),"credentialFile":key.path,"url":template.policy().url,"model":template.policy().model,
+        "maxRequests":binding.turn_model_requests,"maxOutputTokens":512,"maxTotalOutputTokens":binding.turn_output_tokens});
+    let profile = serde_json::to_vec(&profile).unwrap();
+    let profile_hash = Hash::of(&profile);
+    std::fs::create_dir(work.join("trusted-parent-models")).unwrap();
+    std::fs::write(
+        work.join("trusted-parent-models")
+            .join(format!("{}.json", &profile_hash.0[7..])),
+        profile,
+    )
+    .unwrap();
+    binding.worker_configuration =
+        super::parent_model::worker_binding(&worker_request, &template, &profile_hash).unwrap();
+    let automatic = std::env::var_os("CELLN_INTEROP_PROVISION_BINARY").is_some();
+    let reuse = std::env::var("CELLN_INTEROP_REUSE_TEMPLATE").as_deref() == Ok("true");
+    if reuse {
+        assert!(automatic);
+    }
+    if automatic {
+        assert!(std::env::var_os("CELLN_PARENT_INTEROP_BINARY").is_some());
+        for directory in [
+            "parent-issuance",
+            "trusted-parent-permits",
+            "trusted-parent-launches",
+        ] {
+            std::fs::create_dir(work.join(directory)).unwrap();
+        }
+        std::fs::write(work.join("interop-native-template.json"), serde_json::to_vec(&json!({
+            "admissionWindowMs":120000, "parent":parent_request, "worker":worker_request,
+            "template":template.policy(), "modelProfile":profile_hash,
+            "reservedMemoryBytes":2 * (binding.parent_memory_bytes + binding.child_memory_bytes) + (256u64 << 20),
+            "maxTurns":binding.max_turns, "turnModelRequests":binding.turn_model_requests,
+            "turnOutputTokens":binding.turn_output_tokens, "totalModelRequests":binding.total_model_requests,
+            "totalOutputTokens":binding.total_output_tokens
+        })).unwrap()).unwrap();
+    }
+    let launch_hash = if automatic {
+        Hash::of(b"not-pre-issued")
+    } else {
+        let permit = warden::parent_permit::Permit::issue(
+            binding.clone(),
+            std::time::Duration::from_secs(120),
+        )
+        .unwrap();
+        std::fs::create_dir(work.join("trusted-parent-permits")).unwrap();
+        let permit_hash = permit.publish(&work).unwrap();
+        let launch = serde_json::to_vec(&json!({"apiVersion":"celln.parent-launch/v1",
+        "parent":parent_request,"worker":worker_request,"template":template.policy(),
+        "modelProfile":profile_hash,"permit":permit_hash,"binding":binding,
+        "reservedMemoryBytes":2 * (binding.parent_memory_bytes + binding.child_memory_bytes) + (256u64 << 20)
+    })).unwrap();
+        std::fs::create_dir(work.join("trusted-parent-launches")).unwrap();
+        let launch_hash = parent_create::publish(&work, &launch, &binding.principal).unwrap();
+        assert!(parent_create::admit(&work, &launch_hash, "another-tenant").is_err());
+        launch_hash
+    };
+    let evidence = crate::dispatch_http::prove_parent_http(
+        &work,
+        &launch_hash,
+        &binding.incarnation,
+        borrowed,
+        cancel,
+    );
+    if automatic {
+        let provisioned: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(work.join("interop-provisioned.json")).unwrap())
+                .unwrap();
+        binding.incarnation = serde_json::from_value(provisioned["incarnation"].clone()).unwrap();
+        let uid = provisioned["runUID"].as_str().unwrap();
+        assert_eq!(
+            binding.incarnation,
+            warden::parent_permit::run_incarnation("kind-celln-deployed-live-proof", uid).unwrap()
+        );
+        for directory in [
+            "parent-issuance",
+            "trusted-parent-permits",
+            "trusted-parent-launches",
+        ] {
+            let count = std::fs::read_dir(work.join(directory)).unwrap().count();
+            if std::env::var_os("CELLN_INTEROP_HOLD_SECONDS").is_some() {
+                // Two proof parents plus the fresh hands-on parent. Users may
+                // create further runs in the isolated supervised namespace.
+                assert!(count >= 3, "missing hands-on authority record");
+            } else {
+                assert_eq!(count, if reuse { 2 } else { 1 });
+            }
+        }
+    }
+    let mut children = Vec::new();
+    assert_eq!(evidence.len(), 2);
+    let mut turns: Vec<_> = evidence
+        .iter()
+        .cloned()
+        .map(|result| (binding.incarnation.clone(), result))
+        .collect();
+    if reuse {
+        let second: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(work.join("interop-reused.json")).unwrap())
+                .unwrap();
+        let parent: Hash = serde_json::from_value(second["incarnation"].clone()).unwrap();
+        assert_ne!(parent, binding.incarnation);
+        assert_eq!(
+            parent,
+            warden::parent_permit::run_incarnation(
+                "kind-celln-deployed-live-proof",
+                second["runUID"].as_str().unwrap()
+            )
+            .unwrap()
+        );
+        assert_eq!(second["templateUnchanged"], true);
+        let results = second["results"].as_array().unwrap();
+        assert_eq!(results.len(), 2);
+        turns.extend(
+            results
+                .iter()
+                .cloned()
+                .map(|result| (parent.clone(), result)),
+        );
+    }
+    for (parent, result) in &turns {
+        let id = result["turnId"].as_str().unwrap();
+        let warden::parent_journal::TurnStatus::ParentCommitted(record) =
+            warden::parent_journal::inspect_turn(&work.join("parent-journal"), parent, id).unwrap()
+        else {
+            panic!("missing commit")
+        };
+        let audit_root = if std::env::var_os("CELLN_INTEROP_DISPATCHER_BINARY").is_some() {
+            work.join("parent-audit")
+        } else {
+            work.clone()
+        };
+        let proof: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(audit_root.join(format!("worker-proof-{}.json", &record.child.0[7..])))
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(proof["broker"]["requests"], if borrowed { 2 } else { 1 });
+        assert_eq!(proof["broker"]["denied"], 0);
+        let events: Vec<serde_json::Value> = proof["output"]
+            .as_str()
+            .unwrap()
+            .lines()
+            .filter_map(|line| line.strip_prefix("CELLN_HARNESS_EVENT "))
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        let tools: Vec<_> = events
+            .iter()
+            .filter(|event| event["type"] == "tool")
+            .collect();
+        assert_eq!(tools.len(), usize::from(borrowed));
+        if borrowed {
+            assert_eq!(tools[0]["name"], "uppercase");
+            assert_eq!(
+                tools[0]["hash"],
+                Hash::of(&std::fs::read(work.join("uppercase")).unwrap()).0
+            );
+            assert_eq!(tools[0]["arguments"]["text"], "violet");
+            assert_eq!(tools[0]["result"]["text"], "VIOLET");
+            assert_eq!(
+                events
+                    .iter()
+                    .find(|event| event["type"] == "completed")
+                    .unwrap()["calls"],
+                1
+            );
+        }
+        children.push(record.child);
+    }
+    assert_ne!(children[0], children[1]);
+    assert_eq!(
+        children
+            .iter()
+            .map(|child| &child.0)
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        children.len()
+    );
+    std::fs::write(
+        work.join("pair-results.json"),
+        serde_json::to_vec_pretty(
+            &json!({"results":evidence,"children":children,"ownerJoined":true,"borrowedUppercase":borrowed}),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let credential_path = key.path.clone();
+    drop(key);
+    assert!(!credential_path.exists());
+    eprintln!("PASS: declared signed parent + worker, per-child broker, real retained model context, joined teardown. Evidence: {}",work.display());
+}

--- a/crates/celln-cli/src/dispatch_parent_process_tests.rs
+++ b/crates/celln-cli/src/dispatch_parent_process_tests.rs
@@ -1,0 +1,238 @@
+//! Real dispatcher-process qualification; no in-process owner registry.
+use super::*;
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
+use std::process::{Child, Command, Stdio};
+
+struct OwnedChild(Child);
+impl Drop for OwnedChild {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn http(
+    address: std::net::SocketAddr,
+    method: &str,
+    path: &str,
+    token: &str,
+    body: &str,
+) -> String {
+    let mut stream = TcpStream::connect_timeout(&address, Duration::from_secs(3)).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    write!(stream,"{method} {path} HTTP/1.1\r\nHost: {address}\r\nAuthorization: Bearer {token}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",body.len()).unwrap();
+    let mut reply = String::new();
+    stream.read_to_string(&mut reply).unwrap();
+    reply
+}
+
+fn start(
+    binary: &Path,
+    root: &Path,
+    address: std::net::SocketAddr,
+    token: &Path,
+    label: &str,
+) -> OwnedChild {
+    let log = std::fs::File::create(root.join(format!("dispatcher-{label}.log"))).unwrap();
+    let mut child = OwnedChild(
+        Command::new(binary)
+            .args(["--root"])
+            .arg(root)
+            .args([
+                "dispatcher",
+                "--listen",
+                &address.to_string(),
+                "--token-file",
+            ])
+            .arg(token)
+            .args(["--mote-store"])
+            .arg(root.join("motes"))
+            .args(["--tool-store"])
+            .arg(root.join("tools"))
+            .args([
+                "--max-cells",
+                "2",
+                "--memory-bytes",
+                "2147483648",
+                "--egress-slots",
+                "1",
+            ])
+            .env_clear()
+            .env("PATH", "/usr/bin:/bin")
+            .stdout(Stdio::from(log.try_clone().unwrap()))
+            .stderr(Stdio::from(log))
+            .spawn()
+            .unwrap(),
+    );
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        assert!(
+            child.0.try_wait().unwrap().is_none(),
+            "dispatcher exited before readiness"
+        );
+        if TcpStream::connect_timeout(&address, Duration::from_millis(50)).is_ok() {
+            break;
+        }
+        assert!(Instant::now() < deadline, "dispatcher readiness timed out");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(http(address, "GET", "/v1/health", "", "").starts_with("HTTP/1.1 200"));
+    child
+}
+
+pub(super) fn prove(root: &Path, borrowed: bool, binary: &Path) -> Vec<serde_json::Value> {
+    // Explicit private retention of real guest events for this qualification.
+    std::fs::DirBuilder::new()
+        .mode(0o700)
+        .create(root.join("parent-audit"))
+        .unwrap();
+    assert!(binary.is_absolute() && binary.is_file());
+    assert!(
+        std::env::var_os("CELLN_INTEROP_PROVISION_BINARY").is_some(),
+        "real dispatcher requires fresh issuance mode"
+    );
+    let client = std::env::var_os("CELLN_PARENT_INTEROP_BINARY").expect("external client required");
+    let parent_token = "parent-process-proof-credential-24";
+    let dispatcher_token = "dispatcher-process-proof-distinct-24";
+    super::tests::policy(root, parent_token, "test:parent");
+    let parent_path = root.join("interop-token");
+    let dispatcher_path = root.join("dispatcher-token");
+    for (path, value) in [
+        (&parent_path, parent_token),
+        (&dispatcher_path, dispatcher_token),
+    ] {
+        std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(path)
+            .unwrap()
+            .write_all(value.as_bytes())
+            .unwrap();
+    }
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    drop(listener);
+    let dispatcher = start(binary, root, address, &dispatcher_path, "live");
+    eprintln!("real dispatcher process started: {}", dispatcher.0.id());
+    let result_path = root.join("interop-results.json");
+    let hold = std::env::var("CELLN_INTEROP_HOLD_SECONDS")
+        .map(|value| value.parse::<u64>().expect("integer hold seconds"))
+        .unwrap_or(0);
+    assert!(hold <= 43200, "hold seconds exceed development bound");
+    let timeout = if hold == 0 { 100 } else { hold + 190 };
+    let go_timeout = format!("{timeout}s");
+    let mut go = OwnedChild(
+        Command::new(client)
+            .args([
+                "-test.run",
+                "^TestLiveCellnParentClient$",
+                "-test.v",
+                "-test.timeout",
+                &go_timeout,
+            ])
+            .env("CELLN_INTEROP_ORIGIN", format!("http://{address}"))
+            .env("CELLN_INTEROP_TOKEN_FILE", &parent_path)
+            .env("CELLN_INTEROP_BORROWED", borrowed.to_string())
+            .env("CELLN_INTEROP_RESULT", &result_path)
+            .env_remove("CELLN_INTEROP_LAUNCH")
+            .env_remove("CELLN_INTEROP_PARENT")
+            .spawn()
+            .unwrap(),
+    );
+    let deadline = Instant::now() + Duration::from_secs(timeout + 5);
+    loop {
+        if let Some(status) = go.0.try_wait().unwrap() {
+            assert!(status.success(), "external process driver failed");
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "external process driver timed out"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let results: Vec<serde_json::Value> =
+        serde_json::from_slice(&std::fs::read(result_path).unwrap()).unwrap();
+    assert_eq!(results.len(), 2);
+    let mut records = vec![serde_json::from_slice::<serde_json::Value>(
+        &std::fs::read(root.join("interop-provisioned.json")).unwrap(),
+    )
+    .unwrap()];
+    if std::env::var("CELLN_INTEROP_REUSE_TEMPLATE").as_deref() == Ok("true") {
+        records.push(
+            serde_json::from_slice(&std::fs::read(root.join("interop-reused.json")).unwrap())
+                .unwrap(),
+        );
+    }
+    if hold > 0 {
+        records.push(
+            serde_json::from_slice(&std::fs::read(root.join("hands-on.json")).unwrap()).unwrap(),
+        );
+    }
+    for record in &records {
+        let id = record["incarnation"].as_str().unwrap();
+        let stopped = http(
+            address,
+            "POST",
+            &format!("/v1/parents/{id}/stop"),
+            parent_token,
+            "",
+        );
+        assert!(
+            stopped.starts_with("HTTP/1.1 200") && stopped.contains("\"teardownConfirmed\":true"),
+            "{stopped}"
+        );
+        let body =
+            json!({"apiVersion":"celln.parent-create/v1","launchProfile":record["launchProfile"]})
+                .to_string();
+        assert!(
+            http(address, "POST", "/v1/parents", parent_token, &body).starts_with("HTTP/1.1 409")
+        );
+        assert!(http(
+            address,
+            "GET",
+            &format!("/v1/parents/{id}"),
+            dispatcher_token,
+            ""
+        )
+        .starts_with("HTTP/1.1 401"));
+    }
+    let response = http(address, "GET", "/v1/capabilities", dispatcher_token, "");
+    assert!(response.starts_with("HTTP/1.1 200"));
+    let capacity: crate::capabilities::DispatcherCapabilities =
+        serde_json::from_str(response.split_once("\r\n\r\n").unwrap().1).unwrap();
+    assert_eq!(capacity.node.live_cells, 0);
+    assert_eq!(capacity.node.memory_bytes, 2u64 << 30);
+    // Dispatcher has no shutdown API; stop only after every parent joined.
+    drop(dispatcher);
+    let recovered = start(binary, root, address, &dispatcher_path, "recovered");
+    for record in &records {
+        let id = record["incarnation"].as_str().unwrap();
+        let path = format!("/v1/parents/{id}");
+        let status = http(address, "GET", &path, parent_token, "");
+        assert!(
+            status.starts_with("HTTP/1.1 200")
+                && status.contains("ContextLost")
+                && status.contains("\"statusIsLiveOwnerObservation\":false"),
+            "{status}"
+        );
+        for action in ["turns", "stop", "cancel"] {
+            assert!(http(
+                address,
+                "POST",
+                &format!("{path}/{action}"),
+                parent_token,
+                "{}"
+            )
+            .starts_with("HTTP/1.1 409"));
+        }
+    }
+    drop(recovered);
+    std::fs::write(root.join("dispatcher-process-proof.json"),serde_json::to_vec_pretty(&json!({"parents":records.len(),"joinedBeforeProcessStop":true,"capacityReclaimed":true,"restartHistoricalOnly":true})).unwrap()).unwrap();
+    std::fs::remove_file(parent_path).unwrap();
+    std::fs::remove_file(dispatcher_path).unwrap();
+    results
+}

--- a/crates/celln-cli/src/dispatch_parent_worker.rs
+++ b/crates/celln-cli/src/dispatch_parent_worker.rs
@@ -1,0 +1,405 @@
+//! Declared native worker: fixed signed closure + host policy, forked per turn.
+use super::*;
+use celln_manifest::Hash;
+use pilot::turn_worker::Template;
+use warden::{parent_lease::ReservedTurn, parent_permit::Binding};
+
+pub(super) struct PreparedWorker {
+    declared: PreparedDeclared,
+    request: ExecutionRequest,
+    binding: Binding,
+    template: Template,
+    brokers: super::parent_model::ChildBrokers,
+    root: std::path::PathBuf,
+}
+
+fn check_tools(
+    closure: &celln_manifest::closure::Closure,
+    template: &Template,
+) -> Result<(), String> {
+    let tools = &template.policy().tools;
+    if closure.entrypoint == "/pilot-fetch" || !closure.members.contains_key("/pilot-fetch") {
+        return Err("worker lacks admitted broker helper".into());
+    }
+    if closure.sources.is_empty() {
+        let mut expected =
+            std::collections::BTreeSet::from([closure.entrypoint.as_str(), "/pilot-fetch"]);
+        for tool in tools {
+            if !expected.insert(&tool.path)
+                || !closure
+                    .members
+                    .get(&tool.path)
+                    .is_some_and(|m| m.hash == tool.hash)
+            {
+                return Err("borrowed tool does not match worker closure".into());
+            }
+        }
+        if closure
+            .members
+            .keys()
+            .map(String::as_str)
+            .collect::<std::collections::BTreeSet<_>>()
+            != expected
+        {
+            return Err("worker closure contains unselected executable members".into());
+        }
+    } else {
+        closure.validate()?;
+        if closure.sources.len() != tools.len() + 1 {
+            return Err("worker composition does not match tool selection".into());
+        }
+        let runtime = closure.sources[0].parse()?.closure;
+        if runtime.entrypoint != closure.entrypoint || !runtime.members.contains_key("/pilot-fetch")
+        {
+            return Err("worker runtime does not own entrypoint and broker".into());
+        }
+        for (source, tool) in closure.sources.iter().skip(1).zip(tools) {
+            let source = source.parse()?.closure;
+            if source.entrypoint != tool.path
+                || source.members[&source.entrypoint].hash != tool.hash
+            {
+                return Err("borrowed tool composition root mismatch".into());
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn prepare_worker(
+    request: &ExecutionRequest,
+    template: Template,
+    profile: Hash,
+    binding: &Binding,
+    mote_root: &Path,
+    tool_root: &Path,
+    state_root: &Path,
+) -> Result<PreparedWorker, String> {
+    if request.harness.is_some()
+        || request.forge.is_some()
+        || !request.inputs.is_empty()
+        || !request.capabilities.egress.is_empty()
+        || request.capabilities.workspace != celln_spec::WorkspaceAccess::None
+        || request.execution.lane != celln_spec::RequestedLane::Agent
+        || !request.execution.require_hardware_isolation
+        || request.capabilities.memory_bytes != binding.child_memory_bytes
+        || request.capabilities.timeout_ms != binding.turn_timeout_ms
+        || request.tools.len() != 1
+        || request.tools[0].closure.is_none()
+        || !request
+            .invocation
+            .as_ref()
+            .is_some_and(|i| i.args.is_empty())
+    {
+        return Err("worker request exceeds native turn contract".into());
+    }
+    let brokers = super::parent_model::ChildBrokers::new(
+        state_root,
+        profile,
+        binding.clone(),
+        request,
+        &template,
+    )?;
+    let declared = prepare_declared(request, mote_root, tool_root, state_root)?;
+    let closure = super::super::closure::resolve(request, &declared.resolved, state_root)?
+        .ok_or("worker needs signed closure")?;
+    check_tools(&closure.signed.closure, &template)?;
+    Ok(PreparedWorker {
+        declared,
+        request: request.clone(),
+        binding: binding.clone(),
+        template,
+        brokers,
+        root: state_root.into(),
+    })
+}
+
+impl PreparedWorker {
+    pub(super) fn matches_parent(&self, binding: &Binding) -> bool {
+        &self.binding == binding
+    }
+    /// ParentSession must already have durably reserved this turn. The complete
+    /// cell owner is consumed/dropped by run_cell before this returns a result.
+    pub(super) fn execute(
+        &mut self,
+        turn: &ReservedTurn,
+    ) -> Result<pilot::parent_session::DestroyedChild, String> {
+        let audit_directory = parent_audit_directory(&self.root)?;
+        #[cfg(test)]
+        let audit_directory = audit_directory.or_else(|| Some(self.root.clone()));
+        if turn.parent != self.binding.incarnation
+            || turn.limits.memory_bytes != self.binding.child_memory_bytes
+        {
+            return Err("worker reservation does not match pinned memory or parent".into());
+        }
+        let args = self.template.arguments(turn).map_err(|e| e.to_string())?;
+        authorize(&self.request, &self.root)?;
+        let closure =
+            super::super::closure::resolve(&self.request, &self.declared.resolved, &self.root)?
+                .ok_or("worker closure unavailable")?;
+        check_tools(&closure.signed.closure, &self.template)?;
+        for member in closure.signed.closure.members.values() {
+            local_agent_constraint(&member.hash, &self.root)?;
+        }
+        let mut broker = self.brokers.for_turn(turn)?;
+        // Kept through the owned VM execution; any exit revokes all grant copies.
+        let _workspace_lease = self.brokers.workspace_for_turn(turn, &mut broker)?;
+        let mut invocation: serde_json::Value =
+            serde_json::from_slice(&self.declared.invocation).map_err(|e| e.to_string())?;
+        invocation["args"] = serde_json::json!(args);
+        invocation["allow_fetch"] = serde_json::json!(true);
+        let invocation = serde_json::to_vec(&invocation).map_err(|e| e.to_string())?;
+        if invocation.len() > warden::MAX_INVOCATION_BYTES {
+            return Err("worker invocation exceeds bound".into());
+        }
+        let mut cell = self.declared.mote.fork()?;
+        cell.set_invocation(&invocation)
+            .map_err(|e| e.to_string())?;
+        let mut request = self.request.clone();
+        request.id = turn.child.0.clone();
+        request.workload.id = turn.child.0.clone();
+        request.capabilities.timeout_ms = u64::try_from(turn.limits.timeout.as_millis())
+            .map_err(|_| "worker timeout overflow")?;
+        if request.capabilities.timeout_ms == 0 {
+            return Err("remaining worker timeout is below execution resolution".into());
+        }
+        request.capabilities.egress = broker
+            .allow_hosts
+            .iter()
+            .map(|host| format!("https://{host}"))
+            .collect();
+        let mut outcome = super::super::run_cell_with_broker(
+            &request,
+            &request.invocation.as_ref().unwrap().alias,
+            cell,
+            &self.root,
+            Some(broker),
+        )?;
+        super::super::validate_executed_tool(&mut outcome, &self.declared.resolved.program_hash);
+        // run_cell_with_broker returned only after dropping its owned VM.
+        // Do not convert execution errors or authority-report mismatches into
+        // a cancellation acknowledgement. Parent cancellation still prevents
+        // the later parent-scope context commit.
+        let cancelled = cancelled_after_teardown(
+            outcome.denial.as_deref(),
+            celln_control::current().and_then(|control| control.reason()),
+        );
+        let answer = if cancelled {
+            "Turn cancelled after child teardown.".into()
+        } else {
+            if outcome.denial.is_some() || outcome.timed_out || outcome.exit_code != Some(0) {
+                return Err("native worker failed; child torn down, no result committed".into());
+            }
+            answer(
+                outcome
+                    .output
+                    .as_deref()
+                    .ok_or("missing native worker output")?,
+            )?
+        };
+        // Explicit host opt-in only: contains sensitive conversation/tool data,
+        // never authority to replay. Default production operation retains none.
+        if let Some(directory) = audit_directory {
+            retain_audit(
+                &directory,
+                &turn.child,
+                &serde_json::to_vec_pretty(&serde_json::json!({"broker":outcome.broker,
+                "output":String::from_utf8_lossy(outcome.output.as_deref().unwrap_or_default()),
+                "cancelled":cancelled,
+                "execution":outcome.execution}))
+                .map_err(|e| e.to_string())?,
+            )?;
+        }
+        Ok(pilot::parent_session::DestroyedChild {
+            child: turn.child.clone(),
+            succeeded: !cancelled,
+            answer,
+        })
+    }
+}
+
+// Only called on the successful, VM-destroyed return path of the executor.
+fn cancelled_after_teardown(denial: Option<&str>, reason: Option<celln_control::Stopped>) -> bool {
+    reason == Some(celln_control::Stopped::Cancelled) && denial == Some("execution cancelled")
+}
+
+#[test]
+fn cancelled_result_requires_host_cancellation_without_authority_mismatch() {
+    use celln_control::Stopped;
+    assert!(cancelled_after_teardown(
+        Some("execution cancelled"),
+        Some(Stopped::Cancelled)
+    ));
+    for (denial, reason) in [
+        (Some("execution cancelled"), None),
+        (Some("execution cancelled"), Some(Stopped::Deadline)),
+        (
+            Some("executed tool report mismatch"),
+            Some(Stopped::Cancelled),
+        ),
+        (None, Some(Stopped::Cancelled)),
+    ] {
+        assert!(!cancelled_after_teardown(denial, reason));
+    }
+}
+
+fn parent_audit_directory(root: &Path) -> Result<Option<std::path::PathBuf>, String> {
+    use std::os::unix::fs::PermissionsExt;
+    let directory = root.join("parent-audit");
+    let metadata = match std::fs::symlink_metadata(&directory) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err("parent audit policy unavailable".into()),
+    };
+    if !metadata.is_dir() || metadata.permissions().mode() & 0o077 != 0 {
+        return Err("parent-audit must be an operator-private directory, not a symlink".into());
+    }
+    Ok(Some(directory))
+}
+
+fn retain_audit(directory: &Path, child: &Hash, bytes: &[u8]) -> Result<(), String> {
+    use std::io::Write;
+    if bytes.len() > 262144 {
+        return Err("parent audit exceeds bound".into());
+    }
+    let mut file = tempfile::NamedTempFile::new_in(directory).map_err(|e| e.to_string())?;
+    file.write_all(bytes).map_err(|e| e.to_string())?;
+    file.as_file().sync_all().map_err(|e| e.to_string())?;
+    file.persist_noclobber(directory.join(format!("worker-proof-{}.json", &child.0[7..])))
+        .map_err(|_| "parent audit publication refused; preserve turn identity")?;
+    std::fs::File::open(directory)
+        .and_then(|file| file.sync_all())
+        .map_err(|e| e.to_string())
+}
+
+#[test]
+fn parent_audit_requires_private_opt_in_and_never_overwrites() {
+    use std::os::unix::fs::PermissionsExt;
+    let root = tempfile::tempdir().unwrap();
+    assert!(parent_audit_directory(root.path()).unwrap().is_none());
+    let directory = root.path().join("parent-audit");
+    std::fs::create_dir(&directory).unwrap();
+    std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(parent_audit_directory(root.path()).is_err());
+    std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o700)).unwrap();
+    assert_eq!(
+        parent_audit_directory(root.path()).unwrap(),
+        Some(directory.clone())
+    );
+    let child = Hash::of(b"audit-child");
+    retain_audit(&directory, &child, b"evidence").unwrap();
+    let path = directory.join(format!("worker-proof-{}.json", &child.0[7..]));
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+    assert!(retain_audit(&directory, &child, b"replacement").is_err());
+    assert_eq!(std::fs::read(path).unwrap(), b"evidence");
+    assert!(retain_audit(&directory, &Hash::of(b"oversized"), &vec![0; 262145]).is_err());
+    assert_eq!(std::fs::read_dir(&directory).unwrap().count(), 1);
+    let other = tempfile::tempdir().unwrap();
+    std::os::unix::fs::symlink(directory, other.path().join("parent-audit")).unwrap();
+    assert!(parent_audit_directory(other.path()).is_err());
+}
+
+fn answer(output: &[u8]) -> Result<String, String> {
+    let output = std::str::from_utf8(output).map_err(|_| "invalid native worker output")?;
+    let mut answer = None;
+    for line in output
+        .lines()
+        .filter_map(|l| l.strip_prefix("CELLN_HARNESS_EVENT "))
+    {
+        let event: serde_json::Value =
+            serde_json::from_str(line).map_err(|_| "invalid native worker event")?;
+        if event["type"] == "completed" {
+            if answer.is_some() {
+                return Err("duplicate worker completion".into());
+            }
+            let text = event["answer"].as_str().ok_or("missing worker answer")?;
+            if text.trim().is_empty() || text.len() > 2048 || text.contains('\0') {
+                return Err("worker answer exceeds parent contract".into());
+            }
+            answer = Some(text.to_owned());
+        }
+    }
+    answer.ok_or_else(|| "missing worker completion".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn worker_closure_cannot_expand_or_substitute_borrowed_tools() {
+        use celln_manifest::closure::{Closure, Member};
+        let schema = r#"{"type":"object","properties":{"text":{"type":"string","minLength":1,"maxLength":64}},"required":["text"],"additionalProperties":false}"#;
+        let tool_hash = Hash::of(b"borrowed").0;
+        let template=Template::new(serde_json::from_value(serde_json::json!({
+            "contract":"celln.json-tools/v1","task":"","system":"host persona",
+            "url":"https://api.deepseek.com/chat/completions","model":"deepseek-chat",
+            "max_turns":2,"max_calls":1,"tools":[{"name":"borrowed","path":"/borrowed","hash":tool_hash,
+                "description":"selected tool","input_schema":{"bytes":schema,"hash":Hash::of(schema.as_bytes()).0},
+                "output_schema":{"bytes":schema,"hash":Hash::of(schema.as_bytes()).0},
+                "input_bytes":1024,"output_bytes":1024,"timeout_ms":1000}]
+        })).unwrap()).unwrap();
+        let mut closure = Closure {
+            api_version: "celln.dev/closure-v1".into(),
+            sources: vec![],
+            toolfs: Hash::of(b"image").0,
+            entrypoint: "/worker".into(),
+            interpreter: false,
+            members: std::collections::BTreeMap::from([
+                (
+                    "/worker".into(),
+                    Member {
+                        hash: Hash::of(b"worker").0,
+                        dependencies: Default::default(),
+                    },
+                ),
+                (
+                    "/pilot-fetch".into(),
+                    Member {
+                        hash: Hash::of(b"fetch").0,
+                        dependencies: Default::default(),
+                    },
+                ),
+                (
+                    "/borrowed".into(),
+                    Member {
+                        hash: tool_hash.clone(),
+                        dependencies: Default::default(),
+                    },
+                ),
+            ]),
+        };
+        assert!(check_tools(&closure, &template).is_ok());
+        closure.members.get_mut("/borrowed").unwrap().hash = Hash::of(b"substitute").0;
+        assert!(check_tools(&closure, &template).is_err());
+        closure.members.get_mut("/borrowed").unwrap().hash = tool_hash;
+        closure.members.insert(
+            "/extra".into(),
+            Member {
+                hash: Hash::of(b"extra").0,
+                dependencies: Default::default(),
+            },
+        );
+        assert!(check_tools(&closure, &template).is_err());
+        closure.members.remove("/extra");
+        closure.members.remove("/pilot-fetch");
+        assert!(check_tools(&closure, &template).is_err());
+    }
+    #[test]
+    fn completion_is_unique_bounded_and_requires_structured_event() {
+        assert_eq!(
+            answer(b"CELLN_HARNESS_EVENT {\"type\":\"completed\",\"answer\":\"hello\"}\n").unwrap(),
+            "hello"
+        );
+        for output in [
+            "hello",
+            "CELLN_HARNESS_EVENT {}",
+            "CELLN_HARNESS_EVENT {\"type\":\"completed\",\"answer\":\"\"}",
+        ] {
+            assert!(answer(output.as_bytes()).is_err());
+        }
+        let event = "CELLN_HARNESS_EVENT {\"type\":\"completed\",\"answer\":\"hello\"}\n";
+        assert!(answer(event.repeat(2).as_bytes()).is_err());
+    }
+}

--- a/crates/celln-cli/src/dispatch_parents.rs
+++ b/crates/celln-cli/src/dispatch_parents.rs
@@ -1,0 +1,1182 @@
+//! Experimental lifecycle routes. Creation selects an operator-owned profile;
+//! no enduring capability is advertised until deployed integration is proven.
+//! Parent routes deliberately do not accept the shared dispatcher credential.
+use super::*;
+use celln_manifest::Hash;
+use serde_json::json;
+
+#[cfg(all(test, target_os = "linux"))]
+#[path = "dispatch_parent_process_tests.rs"]
+mod process_tests;
+
+/// Test/internal capacity gate. Creation uses spawn_after_check to claim its
+/// durable identity after the same one-shot/prewarm capacity check. Artifact
+/// preparation then runs on the reserved owner thread before parent launch.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) fn spawn_admitted<F, H>(
+    state: &State,
+    principal: &str,
+    incarnation: &Hash,
+    lifetime: Duration,
+    reservation: Reservation,
+    initialize: F,
+) -> Result<()>
+where
+    F: FnOnce() -> std::result::Result<H, String> + Send + 'static,
+    H: FnMut(&[u8]) -> std::result::Result<Vec<u8>, String> + 'static,
+{
+    spawn_after_check(state, principal, incarnation, lifetime, reservation, || {
+        Ok(move |_| initialize())
+    })
+}
+
+fn spawn_after_check<A, F, H>(
+    state: &State,
+    principal: &str,
+    incarnation: &Hash,
+    lifetime: Duration,
+    reservation: Reservation,
+    admit: A,
+) -> Result<()>
+where
+    A: FnOnce() -> Result<F>,
+    F: FnOnce(
+            Arc<warden::parent_child_control::ChildControlSlot>,
+        ) -> std::result::Result<H, String>
+        + Send
+        + 'static,
+    H: FnMut(&[u8]) -> std::result::Result<Vec<u8>, String> + 'static,
+{
+    let registry = state
+        .executions
+        .lock()
+        .map_err(|_| anyhow::anyhow!("dispatcher capacity unavailable"))?;
+    let node = current_node(state, &registry);
+    if node.max_cells.saturating_sub(node.live_cells) < 2
+        || reservation.memory_bytes == 0
+        || reservation.memory_bytes > node.memory_bytes
+        || reservation.egress_slots > node.egress_slots
+    {
+        bail!("parent capacity exhausted");
+    }
+    let initialize = admit()?;
+    state
+        .parents
+        .spawn_admitted_with_children(
+            principal,
+            incarnation,
+            lifetime,
+            reservation.memory_bytes,
+            initialize,
+        )
+        .map_err(anyhow::Error::msg)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Clients {
+    api_version: String,
+    clients: Vec<Client>,
+}
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Client {
+    principal: String,
+    token_hash: String,
+}
+
+fn hash_valid(hash: &str) -> bool {
+    hash.strip_prefix("blake3:").is_some_and(|s| {
+        s.len() == 64
+            && s.bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    })
+}
+
+/// Reopen on every operation so rotation/revocation takes effect without a
+/// dispatcher restart. Operator file contains hashes of high-entropy bearer
+/// secrets, not plaintext credentials; it is never an uploadable store object.
+fn authenticate(root: &Path, bearer: Option<&str>) -> Result<Option<String>> {
+    let mut bytes = Vec::new();
+    std::fs::File::open(root.join("trusted-parent-clients.json"))?
+        .take(65537)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > 65536 {
+        bail!("parent client policy exceeds bound");
+    }
+    let clients: Clients = serde_json::from_slice(&bytes)?;
+    if clients.api_version != "celln.parent-clients/v1" || clients.clients.len() > 128 {
+        bail!("invalid parent client policy");
+    }
+    let mut seen = BTreeSet::new();
+    for client in &clients.clients {
+        if client.principal.is_empty()
+            || client.principal.len() > 512
+            || client.principal.chars().any(char::is_control)
+            || !hash_valid(&client.token_hash)
+            || !seen.insert(&client.token_hash)
+        {
+            bail!("invalid parent client policy");
+        }
+    }
+    let Some(bearer) = bearer
+        .filter(|b| (24..=4096).contains(&b.len()) && b.bytes().all(|c| c.is_ascii_graphic()))
+    else {
+        return Ok(None);
+    };
+    let digest = Hash::of(bearer.as_bytes());
+    let mut principal = None;
+    // Scan every entry; do not return at the first matching credential.
+    for client in clients.clients {
+        if constant_time_eq(client.token_hash.as_bytes(), digest.0.as_bytes()) {
+            principal = Some(client.principal);
+        }
+    }
+    Ok(principal)
+}
+
+pub(super) struct RequestMetadata<'a> {
+    pub length: usize,
+    pub bearer: Option<&'a str>,
+    pub respond_async: bool,
+}
+
+pub(super) fn handle(
+    state: &State,
+    stream: &mut TcpStream,
+    reader: &mut impl Read,
+    method: &str,
+    path: &str,
+    metadata: RequestMetadata<'_>,
+) -> Result<()> {
+    let RequestMetadata {
+        length,
+        bearer,
+        respond_async,
+    } = metadata;
+    let principal = match authenticate(&state.root, bearer) {
+        Ok(Some(principal)) => principal,
+        Ok(None) => return reply(stream, 401, &json!({"error":"unauthorized"})),
+        Err(_) => {
+            return reply(
+                stream,
+                503,
+                &json!({"error":"parent authentication unavailable"}),
+            )
+        }
+    };
+    if path == "/v1/parents" {
+        if method != "POST" {
+            return reply(stream, 404, &json!({"error":"not found"}));
+        }
+        return create(state, stream, reader, length, &principal);
+    }
+    let mut parts = path.trim_start_matches("/v1/parents/").split('/');
+    let id = parts.next().unwrap_or_default();
+    let action = parts.next();
+    let turn = parts.next();
+    let turn_action = parts.next();
+    if !hash_valid(id)
+        || parts.next().is_some()
+        || (turn.is_some() && action != Some("turns"))
+        || (turn_action.is_some() && turn_action != Some("cancel"))
+    {
+        return reply(stream, 404, &json!({"error":"parent owner not found"}));
+    }
+    let id = Hash(id.into());
+    let (status, live_observation) = match state.parents.status(&principal, &id) {
+        Ok(status) => (status, true),
+        Err(_)
+            if warden::parent_journal::historical_owner(
+                &state.root.join("parent-journal"),
+                &id,
+                &principal,
+            )
+            .unwrap_or(false) =>
+        {
+            // Durable ownership permits reading evidence, never turn delivery,
+            // cancellation or a claim that teardown was confirmed after restart.
+            if method != "GET" {
+                return reply(
+                    stream,
+                    409,
+                    &json!({"error":"live parent unavailable; context lost",
+                    "retryAuthorized":false,"teardownConfirmed":false}),
+                );
+            }
+            (warden::parent_registry::Status::ContextLost, false)
+        }
+        Err(_) => return reply(stream, 404, &json!({"error":"parent owner not found"})),
+    };
+    if let Some(turn) = turn {
+        if turn.is_empty()
+            || turn.len() > 64
+            || !turn
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b"_-".contains(&b))
+        {
+            return reply(stream, 404, &json!({"error":"turn not found"}));
+        }
+        if method == "POST" && turn_action == Some("cancel") {
+            if length != 0 {
+                return reply(
+                    stream,
+                    400,
+                    &json!({"error":"cancellation body must be empty"}),
+                );
+            }
+            // The immutable parent/turn pair selects exactly one child. Never
+            // interpret this as "cancel whichever child is active now".
+            let identity = warden::parent_child_control::Identity {
+                child: Hash::of(&serde_json::to_vec(&(&id.0, turn))?),
+                parent: id,
+                turn: turn.into(),
+            };
+            return match state.parents.cancel_child(&principal, &identity) {
+                Ok(()) => reply(
+                    stream,
+                    202,
+                    &json!({"cancellationRequested":true,
+                    "teardownConfirmed":false,"retryAuthorized":false}),
+                ),
+                Err(_) => reply(
+                    stream,
+                    409,
+                    &json!({"error":"exact live child unavailable",
+                    "teardownConfirmed":false,"retryAuthorized":false}),
+                ),
+            };
+        }
+        if method != "GET" || turn_action.is_some() {
+            return reply(stream, 404, &json!({"error":"turn not found"}));
+        }
+        return match warden::parent_journal::inspect_turn(
+            &state.root.join("parent-journal"),
+            &id,
+            turn,
+        ) {
+            Ok(record) => reply(
+                stream,
+                200,
+                &json!({"turn":record,"retryAuthorized":false,"ownerStatus":format!("{status:?}")}),
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => reply(
+                stream,
+                404,
+                &json!({"error":"turn not found","retryAuthorized":false}),
+            ),
+            Err(_) => reply(
+                stream,
+                503,
+                &json!({"error":"turn journal unavailable","retryAuthorized":false}),
+            ),
+        };
+    }
+    match (method, action) {
+        ("GET", None) => reply(
+            stream,
+            200,
+            &json!({"incarnation":id.0,"status":format!("{status:?}"),"statusIsLiveOwnerObservation":live_observation,"retryAuthorized":false}),
+        ),
+        ("POST", Some("cancel")) => {
+            state
+                .parents
+                .cancel(&principal, &id)
+                .map_err(anyhow::Error::msg)?;
+            reply(
+                stream,
+                202,
+                &json!({"cancellationRequested":true,"teardownConfirmed":false}),
+            )
+        }
+        ("POST", Some("stop")) => match state.parents.stop(&principal, &id) {
+            Ok(()) => reply(stream, 200, &json!({"teardownConfirmed":true})),
+            Err(_) => reply(
+                stream,
+                409,
+                &json!({"error":"parent teardown pending or uncertain"}),
+            ),
+        },
+        ("POST", Some("turns")) => {
+            if length == 0 || length > warden::parent_mailbox::MAX_FRAME_BYTES {
+                return reply(stream, 413, &json!({"error":"invalid turn size"}));
+            }
+            let mut bytes = vec![0; length];
+            stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+            reader.read_exact(&mut bytes)?;
+            let pending = match state.parents.submit(&principal, &id, &bytes) {
+                Ok(pending) => pending,
+                Err(_) => {
+                    return reply(
+                        stream,
+                        409,
+                        &json!({"error":"parent unavailable or turn active; reconcile original turn"}),
+                    )
+                }
+            };
+            if respond_async {
+                // Dropping the response receiver does not cancel the admitted
+                // owner. Its durable journal remains the source of completion.
+                return reply(
+                    stream,
+                    202,
+                    &json!({"pending":true,"retryAuthorized":false}),
+                );
+            }
+            match pending.recv_timeout(Duration::from_secs(30)) {
+                Ok(Ok(bytes)) => reply(
+                    stream,
+                    200,
+                    &serde_json::from_slice::<serde_json::Value>(&bytes)?,
+                ),
+                Ok(Err(_)) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => reply(
+                    stream,
+                    409,
+                    &json!({"error":"turn failed or context lost; reconcile original turn"}),
+                ),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => reply(
+                    stream,
+                    202,
+                    &json!({"pending":true,"retryAuthorized":false}),
+                ),
+            }
+        }
+        _ => reply(stream, 404, &json!({"error":"not found"})),
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CreateRequest {
+    api_version: String,
+    launch_profile: Hash,
+}
+
+/// Explicit hardware proof uses the actual authenticated HTTP request handler,
+/// capacity gate, durable claim, registry, turn delivery and joined stop.
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) fn prove_parent_http(
+    root: &Path,
+    launch: &Hash,
+    id: &Hash,
+    borrowed: bool,
+    cancel: bool,
+) -> Vec<serde_json::Value> {
+    if let Some(binary) = std::env::var_os("CELLN_INTEROP_DISPATCHER_BINARY") {
+        return process_tests::prove(root, borrowed, Path::new(&binary));
+    }
+    let mut state = super::tests::lifecycle_state(root);
+    state.probe.max_cells = 2;
+    state.probe.memory_bytes = 2u64 << 30;
+    state.probe.egress_slots = 1;
+    state.parents = warden::parent_registry::ParentRegistry::new(4, 2u64 << 30).unwrap();
+    let token = "parent-hardware-http-proof-credential";
+    tests::policy(root, token, "test:parent");
+    let body = json!({"apiVersion":"celln.parent-create/v1","launchProfile":launch}).to_string();
+    let replies = if let Some(binary) = std::env::var_os("CELLN_PARENT_INTEROP_BINARY") {
+        prove_external_client(
+            &state,
+            root,
+            launch,
+            id,
+            borrowed,
+            Path::new(&binary),
+            token,
+        )
+    } else {
+        let created = tests::http(&state, "POST", "/v1/parents", token, &body);
+        assert!(created.starts_with("HTTP/1.1 202"), "{created}");
+        let ready_deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            let response = tests::http(&state, "GET", &format!("/v1/parents/{}", id.0), token, "");
+            assert!(response.starts_with("HTTP/1.1 200"), "{response}");
+            if response.contains("\"status\":\"Ready\"") {
+                break;
+            }
+            assert!(
+                response.contains("\"status\":\"Initializing\""),
+                "{response}"
+            );
+            assert!(Instant::now() < ready_deadline, "parent never became ready");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let mut replies = Vec::new();
+        let messages = if borrowed {
+            [("one", "My value is violet. Call uppercase with my value and answer only the tool result text."),
+         ("two", "Find the value stated in the first user message of this conversation. Call uppercase on that value now. Answer only the tool result text.")]
+        } else {
+            [
+                ("one", "My value is violet. Remember it."),
+                (
+                    "two",
+                    "What was my original value? Reply with that value only.",
+                ),
+            ]
+        };
+        for (turn, message) in messages {
+            if cancel && turn == "two" {
+                prove_cancelled_model_child(&state, root, id, token);
+            }
+            let response = tests::http(
+                &state,
+                "POST",
+                &format!("/v1/parents/{}/turns", id.0),
+                token,
+                &json!({"kind":"turn","apiVersion":pilot::parent_harness::VERSION,
+                "turnId":turn,"message":message})
+                .to_string(),
+            );
+            assert!(response.starts_with("HTTP/1.1 200"), "{response}");
+            let reply: serde_json::Value =
+                serde_json::from_str(response.split_once("\r\n\r\n").unwrap().1).unwrap();
+            assert_eq!(reply["succeeded"], true);
+            if turn == "two" {
+                assert!(reply["answer"]
+                    .as_str()
+                    .unwrap()
+                    .to_lowercase()
+                    .contains("violet"));
+            }
+            replies.push(reply);
+        }
+        replies
+    };
+    let provisioned: Option<serde_json::Value> = std::env::var_os("CELLN_INTEROP_PROVISION_BINARY")
+        .map(|_| {
+            serde_json::from_slice(&std::fs::read(root.join("interop-provisioned.json")).unwrap())
+                .unwrap()
+        });
+    let provisioned_id: Hash;
+    let provisioned_launch: Hash;
+    let (id, body) = if let Some(record) = provisioned {
+        provisioned_id = serde_json::from_value(record["incarnation"].clone()).unwrap();
+        provisioned_launch = serde_json::from_value(record["launchProfile"].clone()).unwrap();
+        (
+            &provisioned_id,
+            json!({"apiVersion":"celln.parent-create/v1","launchProfile":provisioned_launch})
+                .to_string(),
+        )
+    } else {
+        (id, body)
+    };
+    let stopped = tests::http(
+        &state,
+        "POST",
+        &format!("/v1/parents/{}/stop", id.0),
+        token,
+        "",
+    );
+    assert!(stopped.starts_with("HTTP/1.1 200"), "{stopped}");
+    assert!(stopped.contains("\"teardownConfirmed\":true"));
+    assert_eq!(state.parents.reserved_capacity().unwrap().owners, 0);
+    if std::env::var("CELLN_INTEROP_REUSE_TEMPLATE").as_deref() == Ok("true") {
+        let second: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(root.join("interop-reused.json")).unwrap())
+                .unwrap();
+        let second_id = second["incarnation"].as_str().unwrap();
+        let stopped = tests::http(
+            &state,
+            "POST",
+            &format!("/v1/parents/{second_id}/stop"),
+            token,
+            "",
+        );
+        assert!(
+            stopped.starts_with("HTTP/1.1 200") && stopped.contains("\"teardownConfirmed\":true")
+        );
+        let replay =
+            json!({"apiVersion":"celln.parent-create/v1","launchProfile":second["launchProfile"]})
+                .to_string();
+        assert!(
+            tests::http(&state, "POST", "/v1/parents", token, &replay).starts_with("HTTP/1.1 409")
+        );
+    }
+    assert!(tests::http(&state, "POST", "/v1/parents", token, &body).starts_with("HTTP/1.1 409"));
+    // Fresh serving state has no live-owner entries. Durable ownership grants
+    // historical reads only, including after operator admission expiry.
+    let recovered = super::tests::lifecycle_state(root);
+    let path = format!("/v1/parents/{}", id.0);
+    let status = tests::http(&recovered, "GET", &path, token, "");
+    assert!(status.starts_with("HTTP/1.1 200"), "{status}");
+    assert!(
+        status.contains("ContextLost") && status.contains("\"statusIsLiveOwnerObservation\":false")
+    );
+    assert_eq!(replies.len(), 2);
+    for result in &replies {
+        let turn = result["turnId"].as_str().unwrap();
+        let response = tests::http(
+            &recovered,
+            "GET",
+            &format!("{path}/turns/{turn}"),
+            token,
+            "",
+        );
+        assert!(response.starts_with("HTTP/1.1 200"), "{response}");
+        assert!(response.contains("parent-committed") && response.contains("ContextLost"));
+    }
+    for action in ["turns", "stop", "cancel"] {
+        let response = tests::http(&recovered, "POST", &format!("{path}/{action}"), token, "{}");
+        assert!(response.starts_with("HTTP/1.1 409"), "{response}");
+        assert!(response.contains("\"retryAuthorized\":false"));
+    }
+    tests::policy(root, token, "unrelated-tenant");
+    assert!(tests::http(&recovered, "GET", &path, token, "").starts_with("HTTP/1.1 404"));
+    assert!(tests::http(
+        &recovered,
+        "GET",
+        &format!("{path}/turns/{}", replies[0]["turnId"].as_str().unwrap()),
+        token,
+        ""
+    )
+    .starts_with("HTTP/1.1 404"));
+    replies
+}
+
+// Observe only owned subprocess IDs and executable names, never model request
+// arguments or credential files. This proves interruption during model
+// transport, not that the remote provider received or billed the request.
+#[cfg(all(test, target_os = "linux"))]
+fn prove_cancelled_model_child(state: &State, root: &Path, id: &Hash, token: &str) {
+    let body = json!({"kind":"turn","apiVersion":pilot::parent_harness::VERSION,
+        "turnId":"cancelled","message":"My value is orange. Call uppercase on my value."})
+    .to_string();
+    let pending = state
+        .parents
+        .submit("test:parent", id, body.as_bytes())
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let curl = loop {
+        let mut found = None;
+        for task in std::fs::read_dir("/proc/self/task").unwrap().flatten() {
+            let children =
+                std::fs::read_to_string(task.path().join("children")).unwrap_or_default();
+            for pid in children.split_whitespace() {
+                if std::fs::read_to_string(format!("/proc/{pid}/comm"))
+                    .unwrap_or_default()
+                    .trim()
+                    == "curl"
+                {
+                    found = Some(pid.to_owned());
+                }
+            }
+        }
+        if let Some(pid) = found {
+            break pid;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "model transport never became observable"
+        );
+        std::thread::sleep(Duration::from_millis(1));
+    };
+    let response = tests::http(
+        state,
+        "POST",
+        &format!("/v1/parents/{}/turns/cancelled/cancel", id.0),
+        token,
+        "",
+    );
+    assert!(response.starts_with("HTTP/1.1 202"), "{response}");
+    let reply = pending
+        .recv_timeout(Duration::from_secs(10))
+        .unwrap()
+        .unwrap();
+    let reply: serde_json::Value = serde_json::from_slice(&reply).unwrap();
+    assert_eq!(reply["succeeded"], false);
+    assert_eq!(reply["answer"], "Turn cancelled after child teardown.");
+    assert!(
+        !Path::new(&format!("/proc/{curl}")).exists(),
+        "model subprocess not joined"
+    );
+    assert_eq!(
+        state.parents.status("test:parent", id).unwrap(),
+        warden::parent_registry::Status::Ready
+    );
+    assert!(matches!(
+        warden::parent_journal::inspect_turn(&root.join("parent-journal"), id, "cancelled")
+            .unwrap(),
+        warden::parent_journal::TurnStatus::ParentCommitted(_)
+    ));
+    std::fs::write(root.join("cancelled-model-proof.json"), serde_json::to_vec(&json!({"parent":id,"turn":reply,"modelTransportObserved":true,"modelProcessJoined":true,"parentReady":true})).unwrap()).unwrap();
+}
+
+/// Test-only bridge: serve the real handler to a separately built client.
+/// The executable is explicitly operator-selected, never request supplied.
+#[cfg(all(test, target_os = "linux"))]
+fn prove_external_client(
+    state: &State,
+    root: &Path,
+    launch: &Hash,
+    id: &Hash,
+    borrowed: bool,
+    binary: &Path,
+    token: &str,
+) -> Vec<serde_json::Value> {
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    assert!(binary.is_absolute() && binary.is_file());
+    let token_path = root.join("interop-token");
+    let result_path = root.join("interop-results.json");
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&token_path)
+        .unwrap()
+        .write_all(token.as_bytes())
+        .unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let origin = format!("http://{}", listener.local_addr().unwrap());
+    let mut child = std::process::Command::new(binary)
+        .args([
+            "-test.run",
+            "^TestLiveCellnParentClient$",
+            "-test.v",
+            "-test.timeout",
+            "100s",
+        ])
+        .env("CELLN_INTEROP_ORIGIN", origin)
+        .env("CELLN_INTEROP_TOKEN_FILE", &token_path)
+        .env("CELLN_INTEROP_LAUNCH", &launch.0)
+        .env("CELLN_INTEROP_PARENT", &id.0)
+        .env("CELLN_INTEROP_BORROWED", borrowed.to_string())
+        .env("CELLN_INTEROP_RESULT", &result_path)
+        .spawn()
+        .unwrap();
+    let done = AtomicBool::new(false);
+    let status = std::thread::scope(|scope| {
+        let server = scope.spawn(|| {
+            while !done.load(Ordering::Acquire) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        super::handle(stream, state).unwrap();
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5))
+                    }
+                    Err(e) => panic!("interop accept: {e}"),
+                }
+            }
+        });
+        let deadline = Instant::now() + Duration::from_secs(105);
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break Ok(status),
+                Ok(None) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(10))
+                }
+                other => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break Err(format!("interop child timeout/wait: {other:?}"));
+                }
+            }
+        };
+        done.store(true, Ordering::Release);
+        server.join().unwrap();
+        status
+    });
+    std::fs::remove_file(token_path).unwrap();
+    assert!(status.unwrap().success(), "external parent client failed");
+    serde_json::from_slice(&std::fs::read(result_path).unwrap()).unwrap()
+}
+
+fn create(
+    state: &State,
+    stream: &mut TcpStream,
+    reader: &mut impl Read,
+    length: usize,
+    principal: &str,
+) -> Result<()> {
+    if length == 0 || length > 1024 {
+        return reply(stream, 413, &json!({"error":"invalid creation size"}));
+    }
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    let mut bytes = vec![0; length];
+    reader.read_exact(&mut bytes)?;
+    let request = match serde_json::from_slice::<CreateRequest>(&bytes) {
+        Ok(request)
+            if request.api_version == "celln.parent-create/v1"
+                && hash_valid(&request.launch_profile.0) =>
+        {
+            request
+        }
+        _ => {
+            return reply(
+                stream,
+                400,
+                &json!({"error":"invalid parent creation request"}),
+            )
+        }
+    };
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (state, principal, request);
+        reply(
+            stream,
+            503,
+            &json!({"error":"parent creation unsupported on this host"}),
+        )
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let admission = match crate::dispatch::parent_create::admit(
+            &state.root,
+            &request.launch_profile,
+            principal,
+        ) {
+            Ok(admission) => admission,
+            Err(_) => {
+                return reply(
+                    stream,
+                    403,
+                    &json!({"error":"parent launch not authorized"}),
+                )
+            }
+        };
+        let id = admission.incarnation().clone();
+        let lifetime = admission.lifetime();
+        let reservation = Reservation {
+            memory_bytes: admission.reserved_memory_bytes(),
+            egress_slots: 1,
+        };
+        // Claim is serialized after capacity checks but before owner creation.
+        // Any subsequent failure is non-retryable for this incarnation.
+        match spawn_after_check(state, principal, &id, lifetime, reservation, || {
+            admission.claim(principal).map_err(anyhow::Error::msg)
+        }) {
+            Ok(()) => reply(
+                stream,
+                202,
+                &json!({"incarnation":id.0,
+                "initializationPending":true,"retryAuthorized":false}),
+            ),
+            Err(_) => reply(
+                stream,
+                409,
+                &json!({"error":"parent creation refused; reconcile incarnation",
+                "incarnation":id.0,"retryAuthorized":false}),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn exact_turn_http_cancel_preserves_parent_and_rejects_stale_requests() {
+        let root = tempfile::tempdir().unwrap();
+        let state = super::super::tests::lifecycle_state(root.path());
+        let token = "child-cancel-http-test-credential";
+        policy(root.path(), token, "tenant");
+        let id = Hash::of(b"child-cancel-http");
+        let bound = id.clone();
+        let (entered, ready) = std::sync::mpsc::sync_channel(1);
+        state
+            .parents
+            .spawn_admitted_with_children(
+                "tenant",
+                &id,
+                Duration::from_secs(30),
+                4096,
+                move |children| {
+                    Ok(move |bytes: &[u8]| {
+                        let turn = String::from_utf8(bytes.to_vec()).map_err(|e| e.to_string())?;
+                        let reserved = warden::parent_lease::ReservedTurn {
+                            parent: bound.clone(),
+                            child: Hash::of(&serde_json::to_vec(&(&bound.0, &turn)).unwrap()),
+                            request: warden::parent_protocol::TurnRequest {
+                                api_version: warden::parent_protocol::VERSION.into(),
+                                turn_id: turn,
+                                task: "test".into(),
+                            },
+                            limits: warden::parent_lease::TurnLimits {
+                                memory_bytes: 4096,
+                                timeout: Duration::from_secs(5),
+                                model_requests: 0,
+                                output_tokens: 0,
+                            },
+                        };
+                        let (identity, control) = children.register(&reserved)?;
+                        entered.send(()).map_err(|e| e.to_string())?;
+                        while control.check().is_ok() {
+                            std::thread::sleep(Duration::from_millis(1));
+                        }
+                        celln_control::check().map_err(|e| e.to_string())?;
+                        // Synthetic worker: routing proof only, not VM teardown proof.
+                        children.retire(&identity)?;
+                        Ok(b"cancelled".to_vec())
+                    })
+                },
+            )
+            .unwrap();
+        let path = format!("/v1/parents/{}/turns", id.0);
+        for turn in ["first", "second"] {
+            let pending = state
+                .parents
+                .submit("tenant", &id, turn.as_bytes())
+                .unwrap();
+            ready.recv_timeout(Duration::from_secs(2)).unwrap();
+            let exact = format!("{path}/{turn}/cancel");
+            assert!(http(&state, "POST", &exact, "wrong-token", "").starts_with("HTTP/1.1 401"));
+            assert!(http(&state, "GET", &exact, token, "").starts_with("HTTP/1.1 404"));
+            assert!(http(&state, "POST", &exact, token, "{}").starts_with("HTTP/1.1 400"));
+            assert!(
+                http(&state, "POST", &format!("{path}/missing/cancel"), token, "")
+                    .starts_with("HTTP/1.1 409")
+            );
+            if turn == "second" {
+                assert!(
+                    http(&state, "POST", &format!("{path}/first/cancel"), token, "")
+                        .starts_with("HTTP/1.1 409")
+                );
+            }
+            assert!(pending.try_recv().is_err());
+            let response = http(&state, "POST", &exact, token, "");
+            assert!(response.starts_with("HTTP/1.1 202"), "{response}");
+            assert!(response.contains("\"teardownConfirmed\":false"));
+            assert_eq!(
+                pending
+                    .recv_timeout(Duration::from_secs(2))
+                    .unwrap()
+                    .unwrap(),
+                b"cancelled"
+            );
+            assert_eq!(
+                state.parents.status("tenant", &id).unwrap(),
+                warden::parent_registry::Status::Ready
+            );
+            assert_eq!(
+                state.parents.reserved_capacity().unwrap().memory_bytes,
+                4096
+            );
+        }
+        state.parents.stop("tenant", &id).unwrap();
+    }
+    #[test]
+    fn historical_http_access_is_read_only_and_requires_durable_owner() {
+        let root = tempfile::tempdir().unwrap();
+        let state = super::super::tests::lifecycle_state(root.path());
+        let token = "historical-http-test-credential";
+        policy(root.path(), token, "tenant");
+        let id = Hash::of(b"historical-http");
+        let journal = warden::parent_journal::ParentJournal::create(
+            &root.path().join("parent-journal"),
+            id.clone(),
+        )
+        .unwrap();
+        let path = format!("/v1/parents/{}", id.0);
+        assert!(http(&state, "GET", &path, token, "").starts_with("HTTP/1.1 404"));
+        journal.bind_owner("tenant").unwrap();
+        let response = http(&state, "GET", &path, token, "");
+        assert!(response.starts_with("HTTP/1.1 200") && response.contains("ContextLost"));
+        for action in ["turns", "stop", "cancel"] {
+            assert!(
+                http(&state, "POST", &format!("{path}/{action}"), token, "{}")
+                    .starts_with("HTTP/1.1 409")
+            );
+        }
+        policy(root.path(), token, "another");
+        assert!(http(&state, "GET", &path, token, "").starts_with("HTTP/1.1 404"));
+        assert_eq!(state.parents.reserved_capacity().unwrap().owners, 0);
+    }
+    pub(super) fn policy(root: &Path, token: &str, principal: &str) {
+        std::fs::write(root.join("trusted-parent-clients.json"), json!({"apiVersion":"celln.parent-clients/v1", "clients":[{"principal":principal,"tokenHash":Hash::of(token.as_bytes()).0}]}).to_string()).unwrap();
+    }
+    #[test]
+    fn creation_accepts_only_bounded_operator_profile_selection() {
+        let root = tempfile::tempdir().unwrap();
+        let state = super::super::tests::lifecycle_state(root.path());
+        let token = "parent-create-test-credential-long-enough";
+        policy(root.path(), token, "tenant");
+        for body in [
+            "{}".to_string(),
+            json!({"apiVersion":"celln.parent-create/v1",
+            "launchProfile":"../../elsewhere"})
+            .to_string(),
+            json!({"apiVersion":"celln.parent-create/v1","launchProfile":Hash::of(b"launch"),
+                "principal":"someone-else"})
+            .to_string(),
+        ] {
+            assert!(http(&state, "POST", "/v1/parents", token, &body).starts_with("HTTP/1.1 400"));
+        }
+        assert!(
+            http(&state, "POST", "/v1/parents", token, &"x".repeat(1025))
+                .starts_with("HTTP/1.1 413")
+        );
+        #[cfg(target_os = "linux")]
+        assert!(http(
+            &state,
+            "POST",
+            "/v1/parents",
+            token,
+            &json!({"apiVersion":"celln.parent-create/v1","launchProfile":Hash::of(b"missing")})
+                .to_string()
+        )
+        .starts_with("HTTP/1.1 403"));
+        assert!(!root.path().join("parent-journal").exists());
+        assert_eq!(state.parents.reserved_capacity().unwrap().owners, 0);
+    }
+    pub(super) fn http(state: &State, method: &str, path: &str, token: &str, body: &str) -> String {
+        http_preference(state, method, path, token, body, false)
+    }
+
+    fn http_preference(
+        state: &State,
+        method: &str,
+        path: &str,
+        token: &str,
+        body: &str,
+        respond_async: bool,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(3)))
+            .unwrap();
+        let prefer = if respond_async {
+            "Prefer: respond-async\r\n"
+        } else {
+            ""
+        };
+        write!(client, "{method} {path} HTTP/1.1\r\nAuthorization: Bearer {token}\r\n{prefer}Content-Length: {}\r\n\r\n{body}", body.len()).unwrap();
+        let (server, _) = listener.accept().unwrap();
+        super::super::handle(server, state).unwrap();
+        let mut response = String::new();
+        client.read_to_string(&mut response).unwrap();
+        response
+    }
+    #[test]
+    fn async_turn_acknowledges_before_worker_completion_without_cancelling_owner() {
+        let root = tempfile::tempdir().unwrap();
+        let state = super::super::tests::lifecycle_state(root.path());
+        let token = "async-parent-test-credential";
+        policy(root.path(), token, "tenant");
+        let id = Hash::of(b"async-parent");
+        let (release, wait) = std::sync::mpsc::sync_channel(1);
+        let (finished, done) = std::sync::mpsc::sync_channel(1);
+        state
+            .parents
+            .spawn_admitted("tenant", &id, Duration::from_secs(10), 4096, move || {
+                Ok(move |_: &[u8]| {
+                    wait.recv_timeout(Duration::from_secs(2))
+                        .map_err(|e| e.to_string())?;
+                    celln_control::check().map_err(|e| e.to_string())?;
+                    finished.send(()).unwrap();
+                    Ok(vec![])
+                })
+            })
+            .unwrap();
+        let response = http_preference(
+            &state,
+            "POST",
+            &format!("/v1/parents/{}/turns", id.0),
+            token,
+            "{}",
+            true,
+        );
+        assert!(response.starts_with("HTTP/1.1 202"), "{response}");
+        assert!(response.contains("\"pending\":true"));
+        assert!(done.try_recv().is_err());
+        assert_eq!(
+            state.parents.reserved_capacity().unwrap().memory_bytes,
+            4096
+        );
+        release.send(()).unwrap();
+        done.recv_timeout(Duration::from_secs(2)).unwrap();
+        state.parents.stop("tenant", &id).unwrap();
+    }
+    #[test]
+    fn parent_capacity_gate_serializes_competitors_and_respects_prewarm() {
+        type Handler = fn(&[u8]) -> std::result::Result<Vec<u8>, String>;
+        let root = tempfile::tempdir().unwrap();
+        let mut state = super::super::tests::lifecycle_state(root.path());
+        state.probe.max_cells = 2;
+        *state.prewarm.lock().unwrap() = Some(Reservation {
+            memory_bytes: 4096,
+            egress_slots: 0,
+        });
+        assert!(spawn_admitted(
+            &state,
+            "tenant",
+            &Hash::of(b"blocked"),
+            Duration::from_secs(10),
+            Reservation {
+                memory_bytes: 4096,
+                egress_slots: 0
+            },
+            || -> std::result::Result<Handler, String> {
+                panic!("capacity refusal must not initialize a runtime")
+            }
+        )
+        .is_err());
+        *state.prewarm.lock().unwrap() = None;
+        let start = std::sync::Barrier::new(2);
+        std::thread::scope(|scope| {
+            let first = scope.spawn(|| {
+                start.wait();
+                spawn_admitted(
+                    &state,
+                    "tenant",
+                    &Hash::of(b"one"),
+                    Duration::from_secs(10),
+                    Reservation {
+                        memory_bytes: 4096,
+                        egress_slots: 0,
+                    },
+                    || Ok(|_: &[u8]| Ok(vec![1])),
+                )
+            });
+            start.wait();
+            let second = spawn_admitted(
+                &state,
+                "tenant",
+                &Hash::of(b"two"),
+                Duration::from_secs(10),
+                Reservation {
+                    memory_bytes: 4096,
+                    egress_slots: 0,
+                },
+                || Ok(|_: &[u8]| Ok(vec![1])),
+            );
+            assert_ne!(first.join().unwrap().is_ok(), second.is_ok());
+        });
+        assert_eq!(state.parents.reserved_capacity().unwrap().owners, 1);
+        for name in [b"one", b"two"] {
+            let id = Hash::of(name);
+            if state.parents.status("tenant", &id).is_ok() {
+                state.parents.stop("tenant", &id).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn http_session_commits_turn_and_reads_journal_after_stop() {
+        let root = tempfile::tempdir().unwrap();
+        let state = super::super::tests::lifecycle_state(root.path());
+        let token = "public-parent-session-test-token-24";
+        policy(root.path(), token, "tenant-one");
+        let id = Hash::of(b"session");
+        let session_id = id.clone();
+        let journal_root = root.path().join("parent-journal");
+        pilot::parent_session::spawn_registered(
+            &state.parents,
+            "tenant-one",
+            &id,
+            Duration::from_secs(10),
+            4096,
+            move || {
+                let journal = warden::parent_journal::ParentJournal::create(
+                    &journal_root,
+                    session_id.clone(),
+                )?;
+                let lease = warden::parent_lease::ParentLease::new(
+                    session_id,
+                    Duration::from_secs(10),
+                    warden::parent_lease::TurnLimits {
+                        memory_bytes: 4096,
+                        timeout: Duration::from_secs(1),
+                        model_requests: 0,
+                        output_tokens: 0,
+                    },
+                    2,
+                    0,
+                    0,
+                )?;
+                let mut context = pilot::parent_harness::ParentContext::default();
+                Ok(pilot::parent_session::ParentSession::new(
+                    move |bytes: &[u8]| {
+                        Ok(serde_json::to_vec(
+                            &context.exchange(bytes).map_err(anyhow::Error::msg)?,
+                        )?)
+                    },
+                    |turn: &warden::parent_lease::ReservedTurn| {
+                        Ok(pilot::parent_session::DestroyedChild {
+                            child: turn.child.clone(),
+                            succeeded: true,
+                            answer: "fixture answer".into(),
+                        })
+                    },
+                    lease,
+                    journal,
+                ))
+            },
+        )
+        .unwrap();
+        let path = format!("/v1/parents/{}", id.0);
+        for turn in ["one", "two"] {
+            let body = json!({"kind":"turn", "apiVersion":pilot::parent_harness::VERSION,"turnId":turn,"message":"hello"}).to_string();
+            assert!(http(&state, "POST", &format!("{path}/turns"), token, &body)
+                .contains("fixture answer"));
+            let observed = http(&state, "GET", &format!("{path}/turns/{turn}"), token, "");
+            assert!(observed.contains("parent-committed"));
+            assert!(observed.contains("\"retryAuthorized\":false"));
+        }
+        assert!(http(&state, "POST", &format!("{path}/stop"), token, "")
+            .contains("\"teardownConfirmed\":true"));
+        assert!(http(&state, "GET", &format!("{path}/turns/one"), token, "")
+            .contains("parent-committed"));
+        policy(root.path(), token, "tenant-two");
+        assert!(http(&state, "GET", &format!("{path}/turns/one"), token, "")
+            .starts_with("HTTP/1.1 404"));
+    }
+
+    #[test]
+    fn duplicate_credentials_and_unknown_policy_fields_fail_closed() {
+        let root = tempfile::tempdir().unwrap();
+        let token = "public-parent-auth-negative-token-24";
+        for value in [
+            json!({"apiVersion":"celln.parent-clients/v1", "clients":[
+                {"principal":"one","tokenHash":Hash::of(token.as_bytes()).0},
+                {"principal":"two","tokenHash":Hash::of(token.as_bytes()).0}]}),
+            json!({"apiVersion":"celln.parent-clients/v1", "clients":[], "allowAll":true}),
+        ] {
+            std::fs::write(
+                root.path().join("trusted-parent-clients.json"),
+                value.to_string(),
+            )
+            .unwrap();
+            assert!(authenticate(root.path(), Some(token)).is_err());
+        }
+    }
+
+    #[test]
+    fn real_http_routes_isolate_principals_rotate_credentials_and_refuse_creation() {
+        let root = tempfile::tempdir().unwrap();
+        let state = super::super::tests::lifecycle_state(root.path());
+        let token = "public-parent-test-token-at-least-24";
+        let id = Hash::of(b"incarnation");
+        state
+            .parents
+            .spawn_admitted("tenant-one", &id, Duration::from_secs(10), 4096, || {
+                Ok(|_: &[u8]| Ok(br#"{"kind":"completed"}"#.to_vec()))
+            })
+            .unwrap();
+        let path = format!("/v1/parents/{}", id.0);
+        assert!(http(&state, "GET", &path, token, "").starts_with("HTTP/1.1 503"));
+        policy(root.path(), token, "tenant-one");
+        assert!(http(&state, "GET", &path, &state.token, "").starts_with("HTTP/1.1 401"));
+        let status = http(&state, "GET", &path, token, "");
+        assert!(
+            status.contains("Ready") || status.contains("Initializing"),
+            "{status}"
+        );
+        assert!(http(&state, "POST", &format!("{path}/turns"), token, "{}").contains("completed"));
+        assert!(http(&state, "POST", "/v1/parents", token, "{}").starts_with("HTTP/1.1 400"));
+        policy(root.path(), token, "tenant-two");
+        for suffix in ["", "/turns", "/stop", "/cancel"] {
+            assert!(
+                http(&state, "POST", &format!("{path}{suffix}"), token, "{}")
+                    .starts_with("HTTP/1.1 404")
+            );
+        }
+        let rotated = "rotated-public-parent-test-token-24";
+        policy(root.path(), rotated, "tenant-one");
+        assert!(http(&state, "GET", &path, token, "").starts_with("HTTP/1.1 401"));
+        assert!(http(&state, "POST", &format!("{path}/stop"), rotated, "")
+            .contains("\"teardownConfirmed\":true"));
+        assert!(http(&state, "GET", &path, rotated, "").contains("Stopped"));
+    }
+}

--- a/crates/celln-cli/src/dispatch_prewarm_tests.rs
+++ b/crates/celln-cli/src/dispatch_prewarm_tests.rs
@@ -69,6 +69,7 @@ pub(super) fn prove_prewarm_on_kvm(request: &ExecutionRequest, root: &Path, sour
 }
 fn state(root: &Path) -> State {
     State {
+        parents: warden::parent_registry::ParentRegistry::new(1024, 268435456).unwrap(),
         token_file: PathBuf::new(),
         token: "public-prewarm-test-token-24bytes".into(),
         egress_policy: EgressPolicy::new(&[]).unwrap(),

--- a/crates/celln-cli/src/dispatch_starter_live_tests.rs
+++ b/crates/celln-cli/src/dispatch_starter_live_tests.rs
@@ -1,0 +1,282 @@
+use super::*;
+use std::time::Duration;
+
+#[test]
+#[ignore = "explicit billable DeepSeek/KVM native starter toolbox proof"]
+fn native_parent_starter_cross_turn_live() {
+    let Some(key_path) = std::env::var_os("CELLN_PARENT_MODEL_KEY_FROM_ZSHRC") else {
+        eprintln!("SKIP: explicit model key source required");
+        return;
+    };
+    let _proof = crate::dispatch::warm::PROOF_LOCK.lock().unwrap();
+    if !Path::new("/dev/kvm").exists() {
+        eprintln!("SKIP: no KVM");
+        return;
+    }
+    let Some(kernel) = warden::vmm::boot::BootConfig::host_kernel() else {
+        eprintln!("SKIP: no kernel");
+        return;
+    };
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let binaries = repo.join("target/x86_64-unknown-linux-musl/release");
+    for name in [
+        "celln-harness-parent",
+        "celln-harness-turn",
+        "celln-pilot",
+        "pilot-fetch",
+        "celln-workspace-read",
+        "celln-workspace-write",
+        "celln-https-fetch",
+    ] {
+        assert!(
+            binaries.join(name).exists(),
+            "build static guest binary {name} first"
+        );
+    }
+    let work = repo.join(format!(
+        "target/starter-live-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir(&work).unwrap();
+    let runtime = crate::dispatch::tests::test_runtime_root(&work).unwrap();
+    let key = credential::from_zshrc(Path::new(&key_path)).unwrap();
+    let mut parent_request = bundle(
+        &work,
+        &runtime,
+        &kernel,
+        "parent",
+        &[("/parent", binaries.join("celln-harness-parent"))],
+    );
+    let programs = [
+        ("/worker", binaries.join("celln-harness-turn")),
+        ("/pilot-fetch", binaries.join("pilot-fetch")),
+        ("/workspace-read", binaries.join("celln-workspace-read")),
+        ("/workspace-write", binaries.join("celln-workspace-write")),
+        ("/https-fetch", binaries.join("celln-https-fetch")),
+    ];
+    let mut worker_request = bundle(&work, &runtime, &kernel, "worker", &programs);
+    parent_request.capabilities.timeout_ms = 240000;
+    worker_request.capabilities.timeout_ms = 60000;
+    std::fs::write(work.join("trusted-motes.json"), json!({"apiVersion":"celln.dev/v1alpha1","bundles":[parent_request.mote.as_ref().unwrap().hash,worker_request.mote.as_ref().unwrap().hash]}).to_string()).unwrap();
+    let output = json!({"type":"object","properties":{"revision":{"type":"integer","minimum":0,"maximum":65536},"content":{"type":"string","minLength":0,"maxLength":4096},"error":{"type":"string","minLength":1,"maxLength":1024}},"required":[],"additionalProperties":false}).to_string();
+    let schema = |value: String| json!({"hash":Hash::of(value.as_bytes()).0,"bytes":value});
+    let specifications = [
+        (
+            "workspace-read",
+            "/workspace-read",
+            json!({"type":"object","properties":{"name":{"type":"string","minLength":1,"maxLength":256}},"required":["name"],"additionalProperties":false}),
+        ),
+        (
+            "workspace-write",
+            "/workspace-write",
+            json!({"type":"object","properties":{"name":{"type":"string","minLength":1,"maxLength":256},"revision":{"type":"integer","minimum":0,"maximum":65536},"content":{"type":"string","minLength":0,"maxLength":4096}},"required":["name","revision","content"],"additionalProperties":false}),
+        ),
+        (
+            "https-fetch",
+            "/https-fetch",
+            json!({"type":"object","properties":{"url":{"type":"string","minLength":1,"maxLength":2048}},"required":["url"],"additionalProperties":false}),
+        ),
+    ];
+    let tools: Vec<_> = specifications.iter().map(|(name, path, input)| {
+        let source = programs.iter().find(|(member, _)| member == path).unwrap();
+        json!({"name":name,"path":path,"hash":Hash::of(&std::fs::read(&source.1).unwrap()).0,
+            "description":name,"input_schema":schema(input.to_string()),"output_schema":schema(output.clone()),
+            "input_bytes":8192,"output_bytes":32768,"timeout_ms":30000})
+    }).collect();
+    let template = pilot::turn_worker::Template::new(serde_json::from_value(json!({
+        "contract":"celln.json-tools/v1","task":"","system":"Execute exactly the tool operation requested on this turn. Never substitute remembered conversation for reading a file. After the tool returns, reply briefly using its result.",
+        "url":"https://api.deepseek.com/chat/completions","model":"deepseek-chat","tools":tools,
+        "max_turns":3,"max_calls":1,"require_tool_call":true
+    })).unwrap()).unwrap();
+    let mut binding = super::super::parent_tests::binding(&parent_request);
+    binding.incarnation = Hash::of(work.as_os_str().as_encoded_bytes());
+    binding.lifetime_ms = 240000;
+    binding.turn_timeout_ms = 60000;
+    binding.turn_model_requests = 3;
+    binding.turn_output_tokens = 1536;
+    binding.max_turns = 3;
+    binding.total_model_requests = 9;
+    binding.total_output_tokens = 4608;
+    let profile = serde_json::to_vec(&json!({"apiVersion":"celln.parent-model-profile/v1","principal":binding.principal,
+        "requestBinding":worker_request.configuration_binding(celln_spec::ConfigurationRole::Worker).unwrap(),
+        "templateBinding":template.binding(),"credentialFile":key.path,"url":template.policy().url,"model":template.policy().model,
+        "maxRequests":3,"maxOutputTokens":512,"maxTotalOutputTokens":1536,
+        "workspace":{"read":true,"write":true,"maxOperations":4,"maxFiles":8,"maxFileBytes":4096,"maxTotalBytes":16384},
+        "fetch":{"allowHosts":["example.com"],"maxRequests":4,"maxResponseBytes":4096,"timeoutMs":10000}
+    })).unwrap();
+    let profile_hash = Hash::of(&profile);
+    std::fs::create_dir(work.join("trusted-parent-models")).unwrap();
+    std::fs::write(
+        work.join("trusted-parent-models")
+            .join(format!("{}.json", &profile_hash.0[7..])),
+        profile,
+    )
+    .unwrap();
+    binding.worker_configuration =
+        super::super::parent_model::worker_binding(&worker_request, &template, &profile_hash)
+            .unwrap();
+    if std::env::var("CELLN_INTEROP_STARTER").as_deref() == Ok("true") {
+        assert!(std::env::var_os("CELLN_PARENT_INTEROP_BINARY").is_some());
+        assert!(std::env::var_os("CELLN_INTEROP_PROVISION_BINARY").is_some());
+        let mut catalogue_tools = Vec::new();
+        for tool in &template.policy().tools {
+            let source = programs
+                .iter()
+                .find(|(path, _)| *path == tool.path)
+                .unwrap();
+            let packaged = bundle(
+                &work,
+                &runtime,
+                &kernel,
+                &format!("{}-tool", tool.name),
+                &[(source.0, source.1.clone())],
+            );
+            let mut limits = json!({"timeoutMillis":30000,"memoryBytes":268435456u64,"argumentBytes":8192,"outputBytes":32768,"workspace":"none","effects":"none"});
+            if tool.name == "https-fetch" {
+                limits["effects"] = json!("external-side-effects");
+                limits["https"] = json!({"allowHosts":["example.com"],"maxRequests":4,"maxResponseBytes":4096,"timeoutMillis":10000});
+            } else {
+                let write = tool.name == "workspace-write";
+                if write {
+                    limits["effects"] = json!("external-side-effects");
+                }
+                limits["artifacts"] = json!({"operation":if write {"write"} else {"read"},"maxOperations":4,"maxFiles":8,"maxFileBytes":4096,"maxTotalBytes":16384});
+            }
+            let policy: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(work.join("trusted-closures.json")).unwrap())
+                    .unwrap();
+            catalogue_tools.push(json!({"name":tool.name,"spec":{
+                "revision":"v1","description":tool.description,"supportOwner":"isolated-hardware-proof","publisherKey":policy["publishers"][0],
+                "executable":{"hash":packaged.tools[0].hash},"closure":packaged.tools[0].closure,
+                "entryPoint":tool.path,"invocationABI":"celln.json-stdio/v1",
+                "argumentsSchema":{"hash":tool.input_schema.hash},"resultSchema":{"hash":tool.output_schema.hash},
+                "platform":"linux/amd64","lane":"tool","limits":limits
+            }}));
+        }
+        let policy: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(work.join("trusted-closures.json")).unwrap())
+                .unwrap();
+        std::fs::write(work.join("interop-catalogue.json"), serde_json::to_vec(&json!({
+            "systemPrompt":template.policy().system,"tools":catalogue_tools,
+            "worker":{"revision":"v1","contractVersion":"celln.json-tools/v1","publisherKey":policy["publishers"][0],
+                "executable":{"hash":worker_request.tools[0].hash},"closure":worker_request.tools[0].closure,"mote":worker_request.mote,
+                "entryPoint":"/worker","platform":"linux/amd64","lane":"agent","lifecycle":"disposable-one-shot",
+                "json":{"maxTurns":3,"maxCalls":1},"limits":{"timeoutMillis":60000,"memoryBytes":268435456u64,"taskBytes":2048,"outputBytes":65536,"workspace":"none"}}
+        })).unwrap()).unwrap();
+        parent_request.capabilities.timeout_ms = 180000;
+        for directory in [
+            "parent-issuance",
+            "trusted-parent-permits",
+            "trusted-parent-launches",
+        ] {
+            std::fs::create_dir(work.join(directory)).unwrap();
+        }
+        std::fs::write(work.join("interop-native-template.json"), serde_json::to_vec(&json!({
+            "admissionWindowMs":120000,"parent":parent_request,"worker":worker_request,
+            "template":template.policy(),"modelProfile":profile_hash,
+            "reservedMemoryBytes":2 * (binding.parent_memory_bytes + binding.child_memory_bytes) + (256u64 << 20),
+            "maxTurns":2,"turnModelRequests":3,"turnOutputTokens":1536,"totalModelRequests":6,"totalOutputTokens":3072
+        })).unwrap()).unwrap();
+        crate::dispatch_http::prove_parent_http(
+            &work,
+            &Hash::of(b"not-pre-issued"),
+            &binding.incarnation,
+            true,
+            false,
+        );
+        if std::env::var("CELLN_INTEROP_BROWSER_CANCEL").as_deref() != Ok("true") {
+            // A held hands-on environment permits user-chosen writes/content.
+            // Its joined lifecycle remains checked by prove_parent_http; do
+            // not relabel legitimate user turns as failed fixture assertions.
+            eprintln!("starter hands-on environment joined: {}", work.display());
+            return;
+        }
+        let mut counts = [0usize; 3];
+        for entry in std::fs::read_dir(work.join("parent-audit")).unwrap() {
+            let entry = entry.unwrap();
+            if !entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("worker-proof-")
+            {
+                continue;
+            }
+            let proof: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(entry.path()).unwrap()).unwrap();
+            for event in proof["output"]
+                .as_str()
+                .unwrap_or_default()
+                .lines()
+                .filter_map(|line| line.strip_prefix("CELLN_HARNESS_EVENT "))
+            {
+                let event: serde_json::Value = serde_json::from_str(event).unwrap();
+                if event["type"] != "tool" {
+                    continue;
+                }
+                assert!(event["result"].get("error").is_none(), "{event}");
+                match event["name"].as_str().unwrap() {
+                    "workspace-write" => {
+                        assert_eq!(event["result"]["revision"], 1);
+                        counts[0] += 1;
+                    }
+                    "workspace-read" => {
+                        assert_eq!(event["result"]["content"], "violet");
+                        counts[1] += 1;
+                    }
+                    "https-fetch" => {
+                        assert!(event["result"]["content"]
+                            .as_str()
+                            .unwrap()
+                            .contains("Example Domain"));
+                        counts[2] += 1;
+                    }
+                    _ => panic!("unselected tool in starter proof"),
+                }
+            }
+        }
+        assert!(
+            counts.iter().all(|count| *count > 0),
+            "missing starter operations: {counts:?}"
+        );
+        eprintln!("full-system starter proof: {}", work.display());
+        return;
+    }
+    std::fs::create_dir(work.join("trusted-parent-permits")).unwrap();
+    let permit = warden::parent_permit::Permit::issue(binding.clone(), Duration::from_secs(240))
+        .unwrap()
+        .publish(&work)
+        .unwrap();
+    let control = celln_control::Control::new(Duration::from_secs(240)).unwrap();
+    control.scope(|| {
+        let parent = prepare_parent(&parent_request, &work.join("motes"), &work.join("tools"), &work, &permit, &binding, &binding.principal).unwrap();
+        let worker = super::super::parent_worker::prepare_worker(&worker_request, template, profile_hash, &binding, &work.join("motes"), &work.join("tools"), &work).unwrap();
+        let mut session = parent.into_session(worker).unwrap();
+        for (id, task, tool) in [
+            ("write", "Call workspace-write with name notes.txt, revision 0, content violet. Report its revision.", "workspace-write"),
+            ("read", "Call workspace-read for notes.txt now. Report the content returned by the tool.", "workspace-read"),
+            ("fetch", "Call https-fetch for https://example.com/ now. Report the page title returned by the tool.", "https-fetch"),
+        ] {
+            let result = session.submit(&serde_json::to_vec(&json!({"kind":"turn","apiVersion":pilot::parent_harness::VERSION,"turnId":id,"message":task})).unwrap()).unwrap();
+            eprintln!("starter turn {id}: {}", String::from_utf8_lossy(&result));
+            let child = Hash::of(&serde_json::to_vec(&(&binding.incarnation.0, id)).unwrap());
+            let proof: serde_json::Value = serde_json::from_slice(&std::fs::read(work.join(format!("worker-proof-{}.json", &child.0[7..]))).unwrap()).unwrap();
+            assert_eq!(proof["broker"]["denied"], 0, "{proof}");
+            let events: Vec<serde_json::Value> = proof["output"].as_str().unwrap().lines().filter_map(|line| line.strip_prefix("CELLN_HARNESS_EVENT ")).map(|line| serde_json::from_str(line).unwrap()).collect();
+            let event = events.iter().find(|event| event["type"] == "tool").expect("actual guest tool invocation");
+            assert_eq!(event["name"], tool);
+            assert!(event["result"].get("error").is_none(), "{event}");
+            match id {
+                "write" => assert_eq!(event["result"]["revision"], 1),
+                "read" => assert_eq!(event["result"]["content"], "violet"),
+                "fetch" => assert!(event["result"]["content"].as_str().unwrap().contains("Example Domain")),
+                _ => unreachable!(),
+            }
+        }
+        drop(session); // joins/drops the retained parent and its workspace owner
+    });
+    eprintln!("native starter proof: {}", work.display());
+}

--- a/crates/celln-cli/src/dispatch_substrate.rs
+++ b/crates/celln-cli/src/dispatch_substrate.rs
@@ -6,6 +6,23 @@ use celln_spec::ExecutionRequest;
 use serde::Deserialize;
 use std::path::Path;
 
+#[cfg(all(test, target_os = "linux"))]
+#[path = "dispatch_parent_launcher_tests.rs"]
+mod parent_tests;
+
+#[cfg(all(test, target_os = "linux"))]
+#[path = "dispatch_parent_pair_tests.rs"]
+mod pair_tests;
+
+#[path = "dispatch_parent_model.rs"]
+#[allow(dead_code)] // Composed worker launch is not exposed by creation yet.
+mod parent_model;
+
+#[cfg(target_os = "linux")]
+#[path = "dispatch_parent_worker.rs"]
+#[allow(dead_code)] // Creation awaits composition of parent and worker handles.
+mod parent_worker;
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct TrustedMotes {
@@ -85,12 +102,335 @@ fn file_archive(name: &str, bytes: &[u8]) -> Vec<u8> {
     archive
 }
 
+#[cfg(target_os = "linux")]
+struct PreparedDeclared {
+    request_binding: celln_manifest::Hash,
+    mote: super::warm::PinnedMote,
+    invocation: Vec<u8>,
+    identity: super::SubstrateIdentity,
+    resolved: ResolvedBundle,
+}
+
+#[cfg(not(target_os = "linux"))]
+struct PreparedDeclared;
+
+// Internal launcher building block. Public creation remains disabled until the
+// paired worker/broker admission is composed; mailbox permission is never
+// inferred from a signed executable or from an ordinary ExecutionRequest.
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+pub(super) struct PreparedParent {
+    declared: PreparedDeclared,
+    request: ExecutionRequest,
+    state_root: std::path::PathBuf,
+    permit_hash: celln_manifest::Hash,
+    binding: warden::parent_permit::Binding,
+    principal: String,
+}
+
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+pub(super) struct ForkedParent {
+    pub cell: warden::vmm::boot::LinuxCell,
+    pub lease: warden::parent_lease::ParentLease,
+    pub journal: warden::parent_journal::ParentJournal,
+    pub identity: super::SubstrateIdentity,
+}
+
+#[cfg(target_os = "linux")]
+fn validate_parent_request(
+    request: &ExecutionRequest,
+    binding: &warden::parent_permit::Binding,
+) -> Result<(), String> {
+    if request.configuration_binding(celln_spec::ConfigurationRole::Parent)?
+        != binding.parent_configuration
+        || request.harness.is_some()
+        || request.forge.is_some()
+        || !request.inputs.is_empty()
+        || !request.capabilities.egress.is_empty()
+        || request.capabilities.workspace != celln_spec::WorkspaceAccess::None
+        || request.execution.lane != celln_spec::RequestedLane::Agent
+        || !request.execution.require_hardware_isolation
+        || request.capabilities.memory_bytes != binding.parent_memory_bytes
+        || request.capabilities.timeout_ms != binding.lifetime_ms
+        || request.workload.caller != binding.principal
+        || request.tools.len() != 1
+        || request.tools[0].closure.is_none()
+        || !request
+            .invocation
+            .as_ref()
+            .is_some_and(|i| i.args.is_empty())
+    {
+        return Err("parent request is not bound to the confined mailbox contract".into());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+pub(super) fn prepare_parent(
+    request: &ExecutionRequest,
+    mote_root: &Path,
+    tool_root: &Path,
+    state_root: &Path,
+    permit_hash: &celln_manifest::Hash,
+    binding: &warden::parent_permit::Binding,
+    principal: &str,
+) -> Result<PreparedParent, String> {
+    validate_parent_request(request, binding)?;
+    // Early refusal precedes expensive warm preparation; final launch rechecks.
+    warden::parent_permit::authorize(state_root, permit_hash, binding, principal)
+        .map_err(|e| e.to_string())?;
+    let declared = prepare_declared(request, mote_root, tool_root, state_root)?;
+    if declared.identity.closure.is_none() {
+        return Err("parent requires admitted signed closure".into());
+    }
+    Ok(PreparedParent {
+        declared,
+        request: request.clone(),
+        state_root: state_root.into(),
+        permit_hash: permit_hash.clone(),
+        binding: binding.clone(),
+        principal: principal.into(),
+    })
+}
+
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+impl PreparedParent {
+    /// Compose only matching, independently prepared handles on the live owner
+    /// thread. Each mailbox response also checks Pilot's actual execution grant.
+    fn into_session(
+        self,
+        worker: parent_worker::PreparedWorker,
+    ) -> Result<DeclaredParentSession, String> {
+        self.into_claimed_session(worker, None, None)
+    }
+
+    fn into_claimed_session(
+        self,
+        mut worker: parent_worker::PreparedWorker,
+        claim: Option<ParentClaim>,
+        children: Option<std::sync::Arc<warden::parent_child_control::ChildControlSlot>>,
+    ) -> Result<DeclaredParentSession, String> {
+        if !worker.matches_parent(&self.binding) {
+            return Err("parent/worker permit mismatch".into());
+        }
+        let owner_control =
+            celln_control::current().ok_or("native parent requires serving-owner control")?;
+        let child_control = children.unwrap_or_else(|| {
+            std::sync::Arc::new(warden::parent_child_control::ChildControlSlot::new(
+                self.binding.incarnation.clone(),
+                owner_control,
+            ))
+        });
+        let expected = self.declared.resolved.program_hash.clone();
+        let ForkedParent {
+            mut cell,
+            lease,
+            journal,
+            ..
+        } = self.launch_claimed(claim)?;
+        let transport = move |bytes: &[u8]| -> anyhow::Result<Vec<u8>> {
+            cell.deliver_parent_message(bytes)?;
+            let report = cell.run()?;
+            anyhow::ensure!(
+                report.end == warden::vmm::boot::BootEnd::Parked,
+                "parent did not yield a mailbox response"
+            );
+            anyhow::ensure!(
+                !report.console.contains("Linux version"),
+                "unexpected parent hot boot"
+            );
+            let mut grants = 0;
+            for line in report
+                .console
+                .lines()
+                .filter_map(|l| l.strip_prefix(pilot::dispatch_report::PREFIX))
+            {
+                match serde_json::from_str::<pilot::dispatch_report::Frame>(line)? {
+                    pilot::dispatch_report::Frame::Started { grant } => {
+                        anyhow::ensure!(
+                            grant.tool == expected
+                                && grant.lane == "agent"
+                                && !grant.fetch
+                                && grant.workspace.as_deref() == Some("none"),
+                            "parent execution grant mismatch"
+                        );
+                        grants += 1;
+                    }
+                    pilot::dispatch_report::Frame::Failed { .. }
+                    | pilot::dispatch_report::Frame::Signal { .. }
+                    | pilot::dispatch_report::Frame::Exit { .. } => {
+                        anyhow::bail!("parent execution ended unexpectedly")
+                    }
+                    _ => {}
+                }
+            }
+            anyhow::ensure!(grants == 1, "missing or duplicate parent execution grant");
+            cell.take_parent_response()?
+                .ok_or_else(|| anyhow::anyhow!("parent response missing"))
+        };
+        let session: DeclaredParentSession = pilot::parent_session::ParentSession::new(
+            Box::new(transport),
+            Box::new(move |turn| worker.execute(turn).map_err(anyhow::Error::msg)),
+            lease,
+            journal,
+        );
+        Ok(session.with_child_control(child_control))
+    }
+    /// Call on the admitted owner thread after paired-worker verification and
+    /// node reservation. Claim precedes fork; a failed fork retains the durable
+    /// incarnation tombstone. Run only to Pilot's parent exec acknowledgement;
+    /// no turn is delivered and no worker is spawned here.
+    pub(super) fn launch(self) -> Result<ForkedParent, String> {
+        self.launch_claimed(None)
+    }
+
+    fn launch_claimed(mut self, claim: Option<ParentClaim>) -> Result<ForkedParent, String> {
+        validate_parent_request(&self.request, &self.binding)?;
+        authorize(&self.request, &self.state_root)?;
+        let closure =
+            super::closure::resolve(&self.request, &self.declared.resolved, &self.state_root)?
+                .ok_or("parent signed closure unavailable")?;
+        for member in closure.signed.closure.members.values() {
+            local_agent_constraint(&member.hash, &self.state_root)?;
+        }
+        let mut invocation: serde_json::Value =
+            serde_json::from_slice(&self.declared.invocation).map_err(|e| e.to_string())?;
+        invocation["allow_parent_mailbox"] = serde_json::json!(true);
+        let invocation = serde_json::to_vec(&invocation).map_err(|e| e.to_string())?;
+        if invocation.len() > warden::MAX_INVOCATION_BYTES {
+            return Err("parent invocation exceeds bound".into());
+        }
+        // Recheck revocation/admission expiry even when creation claimed before
+        // preparation. Never reset the original lease's elapsed lifetime.
+        warden::parent_permit::authorize(
+            &self.state_root,
+            &self.permit_hash,
+            &self.binding,
+            &self.principal,
+        )
+        .map_err(|e| e.to_string())?;
+        let (lease, journal) = match claim {
+            Some(claim) => claim,
+            None => warden::parent_permit::claim(
+                &self.state_root,
+                &self.permit_hash,
+                &self.binding,
+                &self.principal,
+            )
+            .map_err(|e| e.to_string())?,
+        };
+        let mut cell = self.declared.mote.fork()?;
+        cell.set_timeout(std::time::Duration::from_millis(self.binding.lifetime_ms));
+        cell.set_invocation(&invocation)
+            .map_err(|e| e.to_string())?;
+        cell.enable_parent_mailbox().map_err(|e| e.to_string())?;
+        // The workload may use its mailbox before the guest supervisor gets
+        // scheduled to report exec success. Wait for that protected report
+        // before delivering any turn; do not weaken subsequent grant checks.
+        let marker = format!(
+            "{}{}",
+            pilot::dispatch_report::PREFIX,
+            serde_json::to_string(&pilot::dispatch_report::Frame::Started {
+                grant: pilot::dispatch_report::ExecutionGrant {
+                    tool: self.declared.resolved.program_hash.clone(),
+                    lane: "agent".into(),
+                    workspace: Some("none".into()),
+                    fetch: false,
+                }
+            })
+            .map_err(|e| e.to_string())?
+        );
+        cell.stop_when_guest_prints(&marker);
+        let started = cell.run().map_err(|e| e.to_string())?;
+        if started.end != warden::vmm::boot::BootEnd::Parked
+            || !started.console.ends_with(&marker)
+            || started.console.contains("Linux version")
+        {
+            return Err("parent startup execution grant was not confirmed".into());
+        }
+        cell.clear_stop_marker();
+        self.declared.identity.invocation = celln_manifest::Hash::of(&invocation).0;
+        Ok(ForkedParent {
+            cell,
+            lease,
+            journal,
+            identity: self.declared.identity,
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+type ParentTransport = Box<dyn FnMut(&[u8]) -> anyhow::Result<Vec<u8>>>;
+#[cfg(target_os = "linux")]
+type WorkerTransport = Box<
+    dyn FnMut(
+        &warden::parent_lease::ReservedTurn,
+    ) -> anyhow::Result<pilot::parent_session::DestroyedChild>,
+>;
+#[cfg(target_os = "linux")]
+type DeclaredParentSession = pilot::parent_session::ParentSession<ParentTransport, WorkerTransport>;
+
+#[cfg(target_os = "linux")]
+type ParentClaim = (
+    warden::parent_lease::ParentLease,
+    warden::parent_journal::ParentJournal,
+);
+
+#[cfg(target_os = "linux")]
+#[path = "dispatch_parent_create.rs"]
+pub(crate) mod parent_create;
+
 pub(crate) fn launch_declared(
     request: &ExecutionRequest,
     mote_root: &Path,
     tool_root: &Path,
     state_root: &Path,
 ) -> Result<(LaunchOutcome, ResolvedBundle), String> {
+    let prepared = prepare_declared(request, mote_root, tool_root, state_root)?;
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = prepared;
+        Err("sealing cells needs Linux with /dev/kvm".into())
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // A retained substrate is not a grant. Recheck live policy after warm
+        // preparation and before every execution, even on a cache hit.
+        if request.configuration_binding(celln_spec::ConfigurationRole::OneShot)?
+            != prepared.request_binding
+        {
+            return Err("prepared execution configuration mismatch".into());
+        }
+        authorize(request, state_root)?;
+        let closure = super::closure::resolve(request, &prepared.resolved, state_root)?;
+        let harness = super::harness::resolve(request, closure.as_ref(), state_root)?;
+        let mut cell = prepared.mote.fork()?;
+        cell.set_invocation(&prepared.invocation)
+            .map_err(|e| e.to_string())?;
+        if let Some(h) = harness {
+            super::harness::claim(request, state_root)?;
+            cell.enable_http_fetch(h.policy);
+        }
+        let invocation = request.invocation.as_ref().ok_or("invocation required")?;
+        let mut outcome = super::run_cell(request, &invocation.alias, cell, state_root)?;
+        outcome.substrate = Some(prepared.identity);
+        super::validate_executed_tool(&mut outcome, &prepared.resolved.program_hash);
+        Ok((outcome, prepared.resolved))
+    }
+}
+
+/// Preparation may boot only an authority-free template. The returned pinned
+/// handle performs fork-only execution and contains no model credential.
+/// It is private until enduring admission binds it to an owner and lease.
+fn prepare_declared(
+    request: &ExecutionRequest,
+    mote_root: &Path,
+    tool_root: &Path,
+    state_root: &Path,
+) -> Result<PreparedDeclared, String> {
     super::check_supported_authority(request)?;
     authorize(request, state_root)?;
     let inputs = super::inputs::resolve(request, state_root)?;
@@ -160,7 +500,7 @@ pub(crate) fn launch_declared(
             toolfs: resolved.toolfs_hash.clone(),
             invocation: celln_manifest::Hash::of(&run).0,
         };
-        let mut cell = super::warm::fork(key, vec![resolved.program_hash.clone()], || {
+        let mote = super::warm::pin(key, vec![resolved.program_hash.clone()], || {
             // The shared template contains no request args, credentials or
             // egress grant. Only enable the post-fork invocation channel.
             std::fs::write(&kernel, &resolved.kernel_bytes).map_err(|e| e.to_string())?;
@@ -171,16 +511,14 @@ pub(crate) fn launch_declared(
             cfg.mem_size = request.capabilities.memory_bytes as usize;
             Ok((cfg, resolved.toolfs_bytes.clone()))
         })?;
-        cell.set_invocation(&run).map_err(|e| e.to_string())?;
-        // Re-read the operator grant after potentially slow warm preparation.
-        if let Some(h) = super::harness::resolve(request, closure.as_ref(), state_root)? {
-            super::harness::claim(request, state_root)?;
-            cell.enable_http_fetch(h.policy);
-        }
-        let mut outcome = super::run_cell(request, &invocation.alias, cell, state_root)?;
-        outcome.substrate = Some(identity);
-        super::validate_executed_tool(&mut outcome, &resolved.program_hash);
-        Ok((outcome, resolved))
+        Ok(PreparedDeclared {
+            request_binding: request
+                .configuration_binding(celln_spec::ConfigurationRole::OneShot)?,
+            mote,
+            invocation: run,
+            identity,
+            resolved,
+        })
     }
 }
 

--- a/crates/celln-cli/src/dispatch_warm.rs
+++ b/crates/celln-cli/src/dispatch_warm.rs
@@ -4,9 +4,8 @@
 use std::sync::{Arc, Mutex, OnceLock};
 use warden::vmm::boot::{BootConfig, BootEnd, LinuxCell, Mote};
 
-// One retained template bounds idle RAM to one configured guest. In-flight
-// forks keep their own references. This is separate from active guest-RAM
-// reservations; it is not included in a process-RSS guarantee.
+// The cache retains one template. Explicit pins and in-flight forks can retain
+// evicted templates too; their owners must account for that memory separately.
 type Cached = Option<(String, Arc<Mote>, Availability)>;
 
 #[derive(Clone, serde::Serialize)]
@@ -39,6 +38,30 @@ pub(super) fn fork(
     tools: Vec<String>,
     prepare: impl FnOnce() -> Result<(BootConfig, Vec<u8>), String>,
 ) -> Result<LinuxCell, String> {
+    pin(key, tools, prepare)?.fork()
+}
+
+/// A prepared substrate retained independently of cache eviction. It carries
+/// no per-cell invocation, model credentials, or execution authorization.
+/// An enduring owner must acquire this before accepting turns, account for its
+/// retained memory, and recheck live admission/grants before each child fork.
+pub(super) struct PinnedMote {
+    mote: Arc<Mote>,
+}
+
+impl PinnedMote {
+    /// Strictly fork-only: no cache lookup, preparation callback or boot path.
+    pub(super) fn fork(&self) -> Result<LinuxCell, String> {
+        celln_control::check().map_err(|e| e.to_string())?;
+        LinuxCell::fork_from(&self.mote).map_err(|e| e.to_string())
+    }
+}
+
+pub(super) fn pin(
+    key: String,
+    tools: Vec<String>,
+    prepare: impl FnOnce() -> Result<(BootConfig, Vec<u8>), String>,
+) -> Result<PinnedMote, String> {
     let mote = {
         let mutex = CACHE.get_or_init(|| Mutex::new(None));
         let mut cache = loop {
@@ -87,12 +110,63 @@ pub(super) fn fork(
         }
     };
     celln_control::check().map_err(|e| e.to_string())?;
-    LinuxCell::fork_from(&mote).map_err(|e| e.to_string())
+    Ok(PinnedMote { mote })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pinned_mote_forks_after_eviction_while_parent_retains_context() {
+        let Some(initrd) = std::env::var_os("CELLN_PARENT_PROBE_INITRD") else {
+            eprintln!("skipping: requires CELLN_PARENT_PROBE_INITRD from mkparent-probe.sh");
+            return;
+        };
+        let Some(kernel) = BootConfig::host_kernel() else {
+            return;
+        };
+        if !std::path::Path::new("/dev/kvm").exists() {
+            return;
+        }
+        let _guard = PROOF_LOCK.lock().unwrap();
+        let pin = pin("parent-pin-proof".into(), vec![], || {
+            Ok((
+                BootConfig::new(kernel).with_initrd(std::path::PathBuf::from(initrd)),
+                vec![0; 4096],
+            ))
+        })
+        .unwrap();
+        let mut parent = pin.fork().unwrap();
+        parent.enable_parent_mailbox().unwrap();
+        parent
+            .deliver_parent_message(b"remember:parent-only")
+            .unwrap();
+        assert_eq!(parent.run().unwrap().end, BootEnd::Parked);
+        assert_eq!(
+            parent.take_parent_response().unwrap().unwrap(),
+            b"1:parent-only"
+        );
+        evict();
+        // The cache is empty. These calls cannot prepare or boot a template.
+        for turn in 2..=3 {
+            let mut child = pin.fork().unwrap();
+            child.enable_parent_mailbox().unwrap();
+            child.deliver_parent_message(b"recall").unwrap();
+            let report = child.run().unwrap();
+            assert_eq!(report.end, BootEnd::Parked, "{}", report.tail(20));
+            assert!(!report.console.contains("Linux version"));
+            assert_eq!(child.take_parent_response().unwrap().unwrap(), b"1:");
+            drop(child);
+            parent.deliver_parent_message(b"recall").unwrap();
+            assert_eq!(parent.run().unwrap().end, BootEnd::Parked);
+            assert_eq!(
+                parent.take_parent_response().unwrap().unwrap(),
+                format!("{turn}:parent-only").as_bytes()
+            );
+        }
+        eprintln!("pinned mote proof: cache evicted, two real child VMs dropped, parent guest state retained");
+    }
     #[test]
     fn deadline_interrupts_waiting_for_another_preparation() {
         let _guard = CACHE.get_or_init(|| Mutex::new(None)).lock().unwrap();

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -69,6 +69,12 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
+    /// Publish one run's parent authority from an independently authorized local plan; does not launch.
+    ParentProvision {
+        plan: PathBuf,
+        #[arg(long)]
+        principal: String,
+    },
     /// Inspect a request binding for operator review; grants no authority.
     HarnessBinding { request: PathBuf },
     /// Inspect this host's boot clock for bounded model-profile expiry (no authority).
@@ -498,6 +504,17 @@ fn resolve_root(explicit: &Option<PathBuf>) -> PathBuf {
 fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
     let root = resolve_root(&cli.root);
     match &cli.cmd {
+        Cmd::ParentProvision { plan, principal } => {
+            #[cfg(target_os = "linux")]
+            {
+                dispatch::parent_create::provision_file(&root, plan, principal)
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = (plan, principal);
+                anyhow::bail!("parent provisioning requires Linux host authority")
+            }
+        }
         Cmd::HarnessBinding { request } => dispatch::harness::inspect_binding(request),
         Cmd::Closure(ClosureCmd::AdmitPrepared {
             candidate,

--- a/crates/celln-control/src/lib.rs
+++ b/crates/celln-control/src/lib.rs
@@ -17,6 +17,7 @@ pub struct Control(Arc<Inner>);
 struct Inner {
     deadline: Instant,
     stop: AtomicU8,
+    parent: Option<Control>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -43,9 +44,34 @@ impl Control {
         Ok(Self(Arc::new(Inner {
             deadline,
             stop: AtomicU8::new(0),
+            parent: None,
+        })))
+    }
+    /// Independently cancellable work whose lifetime cannot exceed its parent.
+    /// Cancelling a child does not cancel its parent or siblings. Parent stop
+    /// remains effective inside the child's thread-local scope. This only
+    /// signals cooperative interruption; it does not acknowledge VM teardown.
+    pub fn child(&self, timeout: Duration) -> io::Result<Self> {
+        let requested = Instant::now()
+            .checked_add(timeout)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "deadline overflow"))?;
+        Ok(Self(Arc::new(Inner {
+            deadline: requested.min(self.0.deadline),
+            stop: AtomicU8::new(0),
+            parent: Some(self.clone()),
         })))
     }
     pub fn reason(&self) -> Option<Stopped> {
+        if let Some(reason) = self.0.parent.as_ref().and_then(Control::reason) {
+            let code = match reason {
+                Stopped::Cancelled => 1,
+                Stopped::Deadline => 2,
+            };
+            let _ = self
+                .0
+                .stop
+                .compare_exchange(0, code, Ordering::SeqCst, Ordering::SeqCst);
+        }
         if Instant::now() >= self.0.deadline {
             let _ = self
                 .0
@@ -115,5 +141,60 @@ mod tests {
         let c = Control::new(Duration::ZERO).unwrap();
         c.cancel();
         assert_eq!(c.reason(), Some(Stopped::Deadline));
+    }
+
+    #[test]
+    fn child_cancellation_preserves_parent_and_sibling() {
+        let parent = Control::new(Duration::from_secs(60)).unwrap();
+        let child = parent.child(Duration::from_secs(30)).unwrap();
+        let sibling = parent.child(Duration::from_secs(30)).unwrap();
+        parent.scope(|| {
+            child.scope(|| {
+                child.cancel();
+                assert!(check().is_err());
+            });
+            assert!(check().is_ok());
+        });
+        assert_eq!(child.reason(), Some(Stopped::Cancelled));
+        assert!(parent.check().is_ok());
+        assert!(sibling.check().is_ok());
+        assert!(current().is_none());
+    }
+
+    #[test]
+    fn parent_cancellation_reaches_nested_child_scope() {
+        let parent = Control::new(Duration::from_secs(60)).unwrap();
+        let child = parent.child(Duration::from_secs(30)).unwrap();
+        let grandchild = child.child(Duration::from_secs(20)).unwrap();
+        grandchild.scope(|| {
+            parent.cancel();
+            assert!(check().is_err());
+        });
+        assert_eq!(grandchild.reason(), Some(Stopped::Cancelled));
+        assert_eq!(child.reason(), Some(Stopped::Cancelled));
+        assert!(current().is_none());
+    }
+
+    #[test]
+    fn descendants_cannot_extend_deadlines_or_revive_stopped_parent() {
+        let parent = Control::new(Duration::from_secs(60)).unwrap();
+        let child = parent.child(Duration::from_secs(120)).unwrap();
+        assert_eq!(child.0.deadline, parent.0.deadline);
+        let short = parent.child(Duration::ZERO).unwrap();
+        assert_eq!(short.reason(), Some(Stopped::Deadline));
+        assert!(parent.check().is_ok());
+        short.cancel();
+        assert_eq!(short.reason(), Some(Stopped::Deadline));
+        parent.cancel();
+        assert_eq!(
+            parent.child(Duration::from_secs(120)).unwrap().reason(),
+            Some(Stopped::Cancelled)
+        );
+        assert_eq!(short.reason(), Some(Stopped::Deadline));
+        let expired = Control::new(Duration::ZERO).unwrap();
+        assert_eq!(
+            expired.child(Duration::from_secs(120)).unwrap().reason(),
+            Some(Stopped::Deadline)
+        );
     }
 }

--- a/crates/celln-pilot/Cargo.toml
+++ b/crates/celln-pilot/Cargo.toml
@@ -20,6 +20,18 @@ name = "pilot-fetch"
 path = "src/fetch.rs"
 
 [[bin]]
+name = "celln-workspace-read"
+path = "src/workspace_read.rs"
+
+[[bin]]
+name = "celln-workspace-write"
+path = "src/workspace_write.rs"
+
+[[bin]]
+name = "celln-https-fetch"
+path = "src/https_fetch.rs"
+
+[[bin]]
 name = "celln-demo"
 path = "src/demo.rs"
 
@@ -61,9 +73,22 @@ name = "celln-harness-proof"
 path = "src/harness_proof.rs"
 required-features = ["kvm"]
 
+[[bin]]
+name = "celln-parent-proof"
+path = "src/parent_proof.rs"
+required-features = ["kvm"]
+
 [lib]
 name = "pilot"
 path = "src/lib.rs"
+
+[[bin]]
+name = "celln-harness-parent"
+path = "src/harness_parent.rs"
+
+[[bin]]
+name = "celln-harness-turn"
+path = "src/harness_turn.rs"
 
 [dependencies]
 celln-manifest.workspace = true
@@ -75,3 +100,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
+
+[dev-dependencies]
+celln-control.workspace = true
+tempfile.workspace = true

--- a/crates/celln-pilot/src/guest.rs
+++ b/crates/celln-pilot/src/guest.rs
@@ -619,6 +619,10 @@ struct RunRequest {
     /// host-authored; guest arguments cannot cause pilot to retain raw-I/O.
     #[serde(default)]
     allow_fetch: bool,
+    /// Host-delivered parent-only transport. Pilot pre-grants exactly three
+    /// ports before dropping all capabilities; no raw-I/O capability is kept.
+    #[serde(default)]
+    allow_parent_mailbox: bool,
     /// Opt-in framed dispatcher output; absent keeps the legacy console ABI.
     #[serde(default)]
     report_output_limit: Option<usize>,
@@ -657,6 +661,8 @@ struct RunFile {
     #[serde(default)]
     allow_fetch: bool,
     #[serde(default)]
+    allow_parent_mailbox: bool,
+    #[serde(default)]
     report_output_limit: Option<usize>,
     #[serde(default)]
     force_agent_lane: bool,
@@ -691,6 +697,7 @@ impl RunFile {
                 agent_authored_input: self.agent_authored_input,
                 root: self.root,
                 allow_fetch: self.allow_fetch,
+                allow_parent_mailbox: self.allow_parent_mailbox,
                 report_output_limit: self.report_output_limit,
                 force_agent_lane: self.force_agent_lane,
                 expected_hash: self.expected_hash,
@@ -774,16 +781,30 @@ fn child_error(error_fd: i32, error: io::Error) -> ! {
     }
 }
 
+/// This is configuration validation, not manifest/closure admission.
+fn validate_parent_mailbox_request(req: &RunRequest) -> io::Result<()> {
+    if req.allow_parent_mailbox
+        && (req.allow_fetch
+            || !req.force_agent_lane
+            || req.workspace_access != Some(WorkspaceAccess::None)
+            || req.expected_hash.is_none()
+            || req.closure_members.is_none())
+    {
+        return Err(io::Error::from(io::ErrorKind::InvalidInput));
+    }
+    Ok(())
+}
+
 /// Execute the already-opened, already-hashed file without another pathname
-/// lookup. `execveat(AT_EMPTY_PATH)` binds the exec to this exact file
-/// description even if its old name is replaced between verification and
-/// execution.
+/// lookup. `execveat(AT_EMPTY_PATH)` binds exec to this file description even
+/// if its old name is replaced between verification and execution.
 fn exec_open_file(
     file: &File,
     req: &RunRequest,
     confine: bool,
     grant: Option<pilot::dispatch_report::ExecutionGrant>,
 ) -> io::Result<ExitStatus> {
+    validate_parent_mailbox_request(req)?;
     let capture = if req.report_output_limit.is_some() {
         let mut fds = [-1; 2];
         if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } != 0 {
@@ -876,6 +897,15 @@ fn exec_open_file(
         if let Some(root) = &req.root {
             if let Err(error) = enter_root(root) {
                 child_error(error_pipe[1], error);
+            }
+        }
+        if req.allow_parent_mailbox {
+            // I/O bitmap bits survive exec, unlike the privilege used to set
+            // them. Grant only the mailbox, then enter_agent_lane drops every
+            // capability (fetch is forbidden for this parent configuration).
+            // The existing seccomp filter also denies acquiring any new range.
+            if unsafe { libc::ioperm(0x520, 3, 1) } != 0 {
+                child_error(error_pipe[1], io::Error::last_os_error());
             }
         }
         if confine || req.workspace_access.is_some() {
@@ -1421,6 +1451,39 @@ mod tests {
     use super::*;
 
     #[test]
+    fn parent_mailbox_is_explicit_confined_and_separate_from_fetch() {
+        let base = serde_json::json!({"path":"/parent", "alias":"/parent",
+            "allow_parent_mailbox":true, "force_agent_lane":true,
+            "workspace_access":"none", "expected_hash":"test-hash",
+            "closure_members":{}});
+        let file: RunFile = serde_json::from_value(base.clone()).unwrap();
+        let requests = file.invocations();
+        assert!(requests[0].allow_parent_mailbox);
+        validate_parent_mailbox_request(&requests[0]).unwrap();
+        for (field, value) in [
+            ("allow_fetch", serde_json::json!(true)),
+            ("force_agent_lane", serde_json::json!(false)),
+            ("workspace_access", serde_json::json!("read-write")),
+            ("workspace_access", serde_json::Value::Null),
+            ("expected_hash", serde_json::Value::Null),
+            ("closure_members", serde_json::Value::Null),
+        ] {
+            let mut invalid = base.clone();
+            invalid[field] = value;
+            let request: RunRequest = serde_json::from_value(invalid).unwrap();
+            assert!(
+                validate_parent_mailbox_request(&request).is_err(),
+                "{field}"
+            );
+        }
+        let legacy: RunRequest = serde_json::from_value(serde_json::json!({
+            "path":"/tool", "alias":"/tool", "allow_fetch":true}))
+        .unwrap();
+        assert!(!legacy.allow_parent_mailbox);
+        validate_parent_mailbox_request(&legacy).unwrap();
+    }
+
+    #[test]
     fn member_check_envelope_has_no_legacy_execution_fallback() {
         let bytes = br#"{"verify_closure":{"version":"celln.dev/sealed-members-v1","challenge":"test","members":{}}}"#;
         // RunFile intentionally retains the pre-extension execution parser.
@@ -1462,6 +1525,7 @@ mod tests {
             agent_authored_input: false,
             root: None,
             allow_fetch: false,
+            allow_parent_mailbox: false,
             report_output_limit: None,
             force_agent_lane: false,
             expected_hash: None,

--- a/crates/celln-pilot/src/harness_json.rs
+++ b/crates/celln-pilot/src/harness_json.rs
@@ -1,68 +1,7 @@
-//! Native schema-bound JSON/stdin-stdout adapter; no arbitrary OCI compatibility.
-#[cfg(target_os = "linux")]
-fn run() -> anyhow::Result<()> {
-    use anyhow::{ensure, Context};
-    use celln_manifest::Hash;
-    use std::io::Read;
-    let raw = std::env::args()
-        .nth(1)
-        .context("missing host configuration")?;
-    ensure!(raw.len() <= 65536, "configuration exceeds delivery limit");
-    let config: pilot::json_harness::Config = serde_json::from_str(&raw)?;
-    pilot::json_harness::validate(&config)?;
-    // The host must deliver this runtime and all lent executables as a signed
-    // sealed closure. These checks are fail-closed diagnostics, not a substitute
-    // for the host's hardware sealing or grant verification.
-    for tool in &config.tools {
-        let mut options = std::fs::OpenOptions::new();
-        use std::os::unix::fs::OpenOptionsExt;
-        options
-            .read(true)
-            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
-        let file = options.open(&tool.path)?;
-        ensure!(file.metadata()?.is_file(), "tool is not a regular file");
-        let mut bytes = Vec::new();
-        file.take(536870913).read_to_end(&mut bytes)?;
-        ensure!(
-            bytes.len() <= 536870912 && Hash::of(&bytes).0 == tool.hash,
-            "lent executable identity mismatch"
-        );
-        ensure!(
-            std::fs::OpenOptions::new()
-                .write(true)
-                .open(&tool.path)
-                .is_err(),
-            "lent executable is writable"
-        );
-    }
-    pilot::json_harness::run(
-        &config,
-        |wire| {
-            pilot::harness_io::child(
-                "/pilot-fetch",
-                &["--json-stdin".into()],
-                wire,
-                1_048_576,
-                std::time::Duration::from_secs(45),
-            )
-        },
-        |tool, input| {
-            pilot::harness_io::child(
-                &tool.path,
-                &[],
-                input,
-                tool.output_bytes,
-                std::time::Duration::from_millis(tool.timeout_ms),
-            )
-        },
-        |event| println!("CELLN_HARNESS_EVENT {event}"),
-    )?;
-    Ok(())
-}
-
+//! Existing one-shot entry point: no retained context accepted here.
 fn main() {
     #[cfg(target_os = "linux")]
-    if let Err(error) = run() {
+    if let Err(error) = pilot::json_guest::run(&[], None) {
         eprintln!("CELLN_HARNESS_ERROR {error:#}");
         std::process::exit(1);
     }

--- a/crates/celln-pilot/src/harness_parent.rs
+++ b/crates/celln-pilot/src/harness_parent.rs
@@ -1,0 +1,66 @@
+//! Native parent adapter. Pilot must grant the mailbox before exec; this
+//! process never acquires capabilities or opens a network connection.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn run() -> anyhow::Result<()> {
+    use std::arch::asm;
+    fn read() -> u8 {
+        let byte;
+        unsafe {
+            asm!("in al, dx", out("al") byte, in("dx") 0x520u16, options(nomem, nostack));
+        }
+        byte
+    }
+    fn write(port: u16, byte: u8) {
+        unsafe {
+            asm!("out dx, al", in("al") byte, in("dx") port, options(nomem, nostack));
+        }
+    }
+    fn word() -> u16 {
+        let value;
+        unsafe {
+            asm!("in ax, dx", out("ax") value, in("dx") 0x520u16, options(nomem, nostack));
+        }
+        value
+    }
+    let mut context = pilot::parent_harness::ParentContext::default();
+    loop {
+        // Empty RX reads are 0xff. Poll the low 16 bits atomically so host
+        // delivery after startup acknowledgement cannot split an idle read
+        // across a frame boundary. Valid frames are <=8192 bytes. A 32-bit
+        // IN would need permission for 0x523, outside the three-port grant.
+        let low = loop {
+            let value = word();
+            if value != u16::MAX {
+                break value;
+            }
+        };
+        let len = (u32::from(low) | (u32::from(word()) << 16)) as usize;
+        anyhow::ensure!(
+            (1..=warden::parent_mailbox::MAX_FRAME_BYTES).contains(&len),
+            "invalid mailbox frame"
+        );
+        let input: Vec<u8> = (0..len).map(|_| read()).collect();
+        let reply = context.exchange(&input).map_err(anyhow::Error::msg)?;
+        let output = serde_json::to_vec(&reply)?;
+        anyhow::ensure!(
+            output.len() <= warden::parent_mailbox::MAX_FRAME_BYTES,
+            "reply exceeds mailbox bound"
+        );
+        for byte in output {
+            write(0x521, byte);
+        }
+        write(0x522, 1);
+    }
+}
+fn main() {
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    if let Err(error) = run() {
+        eprintln!("parent stopped: {error}");
+        std::process::exit(1);
+    }
+    #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+    {
+        eprintln!("Unsupported: parent mailbox requires Linux x86_64");
+        std::process::exit(1);
+    }
+}

--- a/crates/celln-pilot/src/harness_turn.rs
+++ b/crates/celln-pilot/src/harness_turn.rs
@@ -1,0 +1,20 @@
+//! Separate turn-worker artifact. Host config controls model, tools and persona.
+#[cfg(target_os = "linux")]
+fn run() -> anyhow::Result<()> {
+    use anyhow::Context;
+    let raw = std::env::args().nth(2).context("missing parent context")?;
+    let context = pilot::turn_worker::ContextInput::decode(&raw)?;
+    pilot::json_guest::run(&context.history, Some(&context.message))
+}
+fn main() {
+    #[cfg(target_os = "linux")]
+    if let Err(error) = run() {
+        eprintln!("CELLN_HARNESS_ERROR {error:#}");
+        std::process::exit(1);
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("Unsupported: native turn worker requires Linux");
+        std::process::exit(5);
+    }
+}

--- a/crates/celln-pilot/src/https_fetch.rs
+++ b/crates/celln-pilot/src/https_fetch.rs
@@ -1,0 +1,6 @@
+fn main() {
+    #[cfg(target_os = "linux")]
+    pilot::starter_tools::main("fetch");
+    #[cfg(not(target_os = "linux"))]
+    panic!("Unsupported: starter tools require Linux sealed-cell execution");
+}

--- a/crates/celln-pilot/src/json_guest.rs
+++ b/crates/celln-pilot/src/json_guest.rs
@@ -1,0 +1,69 @@
+//! Native schema-bound JSON/stdin-stdout adapter; no arbitrary OCI compatibility.
+#[cfg(target_os = "linux")]
+pub fn run(
+    history: &[crate::json_harness::Exchange],
+    expected_task: Option<&str>,
+) -> anyhow::Result<()> {
+    use anyhow::{ensure, Context};
+    use celln_manifest::Hash;
+    use std::io::Read;
+    let raw = std::env::args()
+        .nth(1)
+        .context("missing host configuration")?;
+    ensure!(raw.len() <= 65536, "configuration exceeds delivery limit");
+    let config: crate::json_harness::Config = serde_json::from_str(&raw)?;
+    ensure!(
+        expected_task.map_or(true, |task| task == config.task),
+        "worker task/context mismatch"
+    );
+    crate::json_harness::validate(&config)?;
+    // The host must deliver this runtime and all lent executables as a signed
+    // sealed closure. These checks are fail-closed diagnostics, not a substitute
+    // for the host's hardware sealing or grant verification.
+    for tool in &config.tools {
+        let mut options = std::fs::OpenOptions::new();
+        use std::os::unix::fs::OpenOptionsExt;
+        options
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        let file = options.open(&tool.path)?;
+        ensure!(file.metadata()?.is_file(), "tool is not a regular file");
+        let mut bytes = Vec::new();
+        file.take(536870913).read_to_end(&mut bytes)?;
+        ensure!(
+            bytes.len() <= 536870912 && Hash::of(&bytes).0 == tool.hash,
+            "lent executable identity mismatch"
+        );
+        ensure!(
+            std::fs::OpenOptions::new()
+                .write(true)
+                .open(&tool.path)
+                .is_err(),
+            "lent executable is writable"
+        );
+    }
+    crate::json_harness::run_with_history(
+        &config,
+        history,
+        |wire| {
+            crate::harness_io::child(
+                "/pilot-fetch",
+                &["--json-stdin".into()],
+                wire,
+                1_048_576,
+                std::time::Duration::from_secs(45),
+            )
+        },
+        |tool, input| {
+            crate::harness_io::child(
+                &tool.path,
+                &[],
+                input,
+                tool.output_bytes,
+                std::time::Duration::from_millis(tool.timeout_ms),
+            )
+        },
+        |event| println!("CELLN_HARNESS_EVENT {event}"),
+    )?;
+    Ok(())
+}

--- a/crates/celln-pilot/src/json_harness.rs
+++ b/crates/celln-pilot/src/json_harness.rs
@@ -2,29 +2,42 @@
 //! already lent name; schemas and limits are immutable host-provided ceilings.
 use anyhow::{bail, ensure, Context, Result};
 use celln_manifest::{tool_schema::ToolSchema, Hash};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::BTreeSet;
 
 pub const CONTRACT: &str = "celln.json-tools/v1";
+
+/// Committed text context from the native parent, never system instructions,
+/// tool definitions, credentials, or unfinished tool calls.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Exchange {
+    pub user: String,
+    pub assistant: String,
+}
 
 #[cfg(test)]
 #[path = "json_harness_tests.rs"]
 mod tests;
 
 pub fn validate(config: &Config) -> Result<()> {
-    let tools = compile(config)?;
-    model_request(config, &tools, &initial_messages(config)).map(|_| ())
+    validate_with_history(config, &[])
 }
 
-#[derive(Deserialize)]
+pub fn validate_with_history(config: &Config, history: &[Exchange]) -> Result<()> {
+    let tools = compile(config)?;
+    model_request(config, &tools, &contextual_messages(config, history)?, 0).map(|_| ())
+}
+
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Schema {
     pub bytes: String,
     pub hash: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Tool {
     pub name: String,
@@ -38,7 +51,7 @@ pub struct Tool {
     pub timeout_ms: u64,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     pub contract: String,
@@ -49,6 +62,14 @@ pub struct Config {
     pub tools: Vec<Tool>,
     pub max_turns: usize,
     pub max_calls: usize,
+    /// Explicit host-template requirement, not a grant to any additional tool.
+    /// Omission preserves the original serialized template and optional calls.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub require_tool_call: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 struct CheckedTool<'a> {
@@ -76,6 +97,11 @@ fn compile(config: &Config) -> Result<Vec<CheckedTool<'_>>> {
         "turn/call/tool limit exceeds contract"
     );
     let mut names = BTreeSet::new();
+    ensure!(
+        !config.require_tool_call
+            || (!config.tools.is_empty() && config.max_calls > 0 && config.max_turns >= 2),
+        "required tool call needs a selected tool and call/result budgets"
+    );
     let mut paths = BTreeSet::new();
     config.tools.iter().map(|tool| {
         ensure!(!tool.name.is_empty() && tool.name.len() <= 64 && tool.name.bytes().all(|b| b.is_ascii_alphanumeric() || b"_-".contains(&b))
@@ -100,16 +126,28 @@ fn compile(config: &Config) -> Result<Vec<CheckedTool<'_>>> {
 /// Tool transport receives exact model argument bytes AFTER schema validation.
 pub fn run(
     config: &Config,
+    broker: impl FnMut(&[u8]) -> Result<Vec<u8>>,
+    execute: impl FnMut(&Tool, &[u8]) -> Result<Vec<u8>>,
+    event: impl FnMut(Value),
+) -> Result<String> {
+    run_with_history(config, &[], broker, execute, event)
+}
+
+/// Explicit native turn-worker entry point. The one-shot adapter calls `run`
+/// with no history; existing config and grant formats remain unchanged.
+pub fn run_with_history(
+    config: &Config,
+    history: &[Exchange],
     mut broker: impl FnMut(&[u8]) -> Result<Vec<u8>>,
     mut execute: impl FnMut(&Tool, &[u8]) -> Result<Vec<u8>>,
     mut event: impl FnMut(Value),
 ) -> Result<String> {
     let tools = compile(config)?;
-    let mut messages = initial_messages(config);
+    let mut messages = contextual_messages(config, history)?;
     let mut ids = BTreeSet::new();
     let mut calls = 0usize;
     for turn in 0..config.max_turns {
-        let wire = model_request(config, &tools, &messages)?;
+        let wire = model_request(config, &tools, &messages, calls)?;
         let response = broker(&wire)?;
         ensure!(response.len() <= 1_048_576, "model response exceeds limit");
         let response: Value = serde_json::from_slice(&response)?;
@@ -130,6 +168,10 @@ pub fn run(
         );
         event(json!({"type":"model","turn":turn,"model":config.model}));
         if tool_calls.is_empty() {
+            ensure!(
+                !config.require_tool_call || calls > 0,
+                "model completed without required tool execution"
+            );
             let answer = message["content"]
                 .as_str()
                 .context("missing final answer")?;
@@ -210,16 +252,49 @@ fn initial_messages(config: &Config) -> Vec<Value> {
     messages
 }
 
+fn contextual_messages(config: &Config, history: &[Exchange]) -> Result<Vec<Value>> {
+    ensure!(history.len() <= 16, "parent history count exceeds limit");
+    let mut bytes = 0usize;
+    for exchange in history {
+        for text in [&exchange.user, &exchange.assistant] {
+            ensure!(
+                !text.trim().is_empty() && !text.contains('\0'),
+                "invalid parent history text"
+            );
+            bytes = bytes
+                .checked_add(text.len())
+                .context("parent history overflow")?;
+            ensure!(bytes <= 4096, "parent history exceeds byte limit");
+        }
+    }
+    let mut messages = initial_messages(config);
+    let current = messages.pop().expect("initial user message always present");
+    for exchange in history {
+        messages.push(json!({"role":"user", "content":exchange.user}));
+        messages.push(json!({"role":"assistant", "content":exchange.assistant}));
+    }
+    messages.push(current);
+    Ok(messages)
+}
+
 fn model_request(
     config: &Config,
     tools: &[CheckedTool<'_>],
     messages: &[Value],
+    calls: usize,
 ) -> Result<Vec<u8>> {
     let mut body =
         json!({"model":config.model,"stream":false,"max_tokens":512,"messages":messages});
     if !tools.is_empty() {
         body["tools"] = json!(tools.iter().map(|t| &t.definition).collect::<Vec<_>>());
-        body["tool_choice"] = json!("auto");
+        // Provider request is advisory; completion is independently checked
+        // above. Once a tool has run, allow the final answer without forcing
+        // another side effect or replenishing the existing call budget.
+        body["tool_choice"] = json!(if config.require_tool_call && calls == 0 {
+            "required"
+        } else {
+            "auto"
+        });
     }
     let wire = serde_json::to_vec(
         &json!({"apiVersion":"celln.fetch/v1","method":"POST","url":config.url,"body":body}),

--- a/crates/celln-pilot/src/json_harness_tests.rs
+++ b/crates/celln-pilot/src/json_harness_tests.rs
@@ -1,6 +1,70 @@
 use super::*;
 use std::cell::Cell;
 
+#[test]
+fn parent_history_maps_to_roles_without_replacing_host_persona() {
+    let cfg = config(&[]);
+    let history = [Exchange {
+        user: "my value is violet".into(),
+        assistant: "recorded".into(),
+    }];
+    run_with_history(
+        &cfg,
+        &history,
+        |wire| {
+            let wire: Value = serde_json::from_slice(wire)?;
+            assert_eq!(
+                wire["body"]["messages"],
+                json!([
+                    {"role":"system", "content":cfg.system},
+                    {"role":"user", "content":"my value is violet"},
+                    {"role":"assistant", "content":"recorded"},
+                    {"role":"user", "content":cfg.task}
+                ])
+            );
+            Ok(answer())
+        },
+        |_, _| panic!("no tools requested"),
+        |_| {},
+    )
+    .unwrap();
+}
+
+#[test]
+fn invalid_or_oversized_context_never_reaches_model() {
+    let cfg = config(&[]);
+    for history in [
+        vec![Exchange {
+            user: "x".repeat(4096),
+            assistant: "y".into(),
+        }],
+        vec![Exchange {
+            user: "x\0".into(),
+            assistant: "y".into(),
+        }],
+        vec![
+            Exchange {
+                user: "x".into(),
+                assistant: "y".into()
+            };
+            17
+        ],
+    ] {
+        assert!(run_with_history(
+            &cfg,
+            &history,
+            |_| panic!("must refuse before model"),
+            |_, _| panic!("must refuse before tool"),
+            |_| {}
+        )
+        .is_err());
+    }
+    assert!(serde_json::from_value::<Exchange>(
+        json!({"user":"x", "assistant":"y", "system":"override"})
+    )
+    .is_err());
+}
+
 fn schema(bytes: &str) -> Schema {
     Schema {
         bytes: bytes.into(),
@@ -17,6 +81,7 @@ fn config(names: &[&str]) -> Config {
         model: "deepseek-chat".into(),
         max_turns: 6,
         max_calls: 6,
+        require_tool_call: false,
         tools: names
             .iter()
             .map(|name| Tool {
@@ -44,6 +109,99 @@ fn response(calls: Vec<Value>) -> Vec<u8> {
 }
 fn answer() -> Vec<u8> {
     serde_json::to_vec(&json!({"choices":[{"message":{"role":"assistant","content":"completed structured task"}}]})).unwrap()
+}
+
+#[test]
+fn required_tool_call_is_requested_and_locally_enforced_without_retry() {
+    let mut cfg = config(&["echo"]);
+    cfg.require_tool_call = true;
+    let mut events = Vec::new();
+    let mut requests = 0;
+    assert!(run(
+        &cfg,
+        |wire| {
+            requests += 1;
+            let wire: Value = serde_json::from_slice(wire).unwrap();
+            assert_eq!(wire["body"]["tool_choice"], "required");
+            Ok(answer())
+        },
+        |_, _| panic!("invented execution"),
+        |e| events.push(e)
+    )
+    .is_err());
+    assert_eq!(requests, 1);
+    assert!(!events.iter().any(|e| e["type"] == "completed"));
+    requests = 0;
+    let result = run(
+        &cfg,
+        |wire| {
+            requests += 1;
+            let wire: Value = serde_json::from_slice(wire).unwrap();
+            if requests == 1 {
+                assert_eq!(wire["body"]["tool_choice"], "required");
+                Ok(response(vec![call("one", "echo", r#"{"text":"hello"}"#)]))
+            } else {
+                assert_eq!(wire["body"]["tool_choice"], "auto");
+                Ok(answer())
+            }
+        },
+        |_, input| Ok(input.to_vec()),
+        |_| {},
+    )
+    .unwrap();
+    assert_eq!(result, "completed structured task");
+    assert_eq!(requests, 2);
+}
+
+#[test]
+fn required_tool_call_refuses_impossible_budgets_and_preserves_old_templates() {
+    let original = config(&["echo"]);
+    let raw = serde_json::to_value(&original).unwrap();
+    assert!(raw.get("require_tool_call").is_none());
+    let restored: Config = serde_json::from_value(raw.clone()).unwrap();
+    assert!(!restored.require_tool_call);
+    assert_eq!(serde_json::to_value(restored).unwrap(), raw);
+    let mut optional = original.clone();
+    optional.task.clear();
+    let mut required = optional.clone();
+    required.require_tool_call = true;
+    assert_ne!(
+        crate::turn_worker::Template::new(optional)
+            .unwrap()
+            .binding(),
+        crate::turn_worker::Template::new(required)
+            .unwrap()
+            .binding()
+    );
+    let mut required = original.clone();
+    required.require_tool_call = true;
+    assert!(run(
+        &required,
+        |_| Ok(response(vec![call(
+            "one",
+            "not-lent",
+            r#"{"text":"hello"}"#
+        )])),
+        |_, _| panic!("required policy expanded tool authority"),
+        |_| {}
+    )
+    .is_err());
+    for mode in 0..3 {
+        let mut cfg = original.clone();
+        cfg.require_tool_call = true;
+        match mode {
+            0 => cfg.tools.clear(),
+            1 => cfg.max_calls = 0,
+            _ => cfg.max_turns = 1,
+        }
+        assert!(run(
+            &cfg,
+            |_| panic!("invalid policy reached broker"),
+            |_, _| panic!("invalid policy executed"),
+            |_| {}
+        )
+        .is_err());
+    }
 }
 
 #[test]

--- a/crates/celln-pilot/src/lib.rs
+++ b/crates/celln-pilot/src/lib.rs
@@ -16,7 +16,12 @@ pub mod closure_check;
 pub mod dispatch_report;
 #[cfg(target_os = "linux")]
 pub mod harness_io;
+#[cfg(target_os = "linux")]
+pub mod json_guest;
 pub mod json_harness;
+pub mod parent_harness;
+pub mod parent_session;
+pub mod turn_worker;
 
 /// The result of asking pilot to run something.
 #[derive(Debug, PartialEq, Eq)]
@@ -136,3 +141,5 @@ mod tests {
         }
     }
 }
+#[cfg(target_os = "linux")]
+pub mod starter_tools;

--- a/crates/celln-pilot/src/parent_harness.rs
+++ b/crates/celln-pilot/src/parent_harness.rs
@@ -1,0 +1,186 @@
+//! Native enduring Harness context owner. Model/tool work belongs to a separate
+//! admitted turn worker. This module never chooses executable or model authority.
+use crate::json_harness::Exchange;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use warden::parent_protocol::{TurnRequest, MAX_REQUEST_BYTES, MAX_TASK_BYTES};
+
+pub const VERSION: &str = "celln.parent-context/v1";
+
+#[derive(Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase", deny_unknown_fields)]
+pub enum HostMessage {
+    Turn {
+        #[serde(rename = "apiVersion")]
+        api_version: String,
+        #[serde(rename = "turnId")]
+        turn_id: String,
+        message: String,
+    },
+    Result {
+        #[serde(rename = "apiVersion")]
+        api_version: String,
+        #[serde(rename = "turnId")]
+        turn_id: String,
+        succeeded: bool,
+        answer: String,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase", deny_unknown_fields)]
+pub enum ParentReply {
+    Spawn {
+        request: TurnRequest,
+    },
+    Completed {
+        #[serde(rename = "apiVersion")]
+        api_version: String,
+        #[serde(rename = "turnId")]
+        turn_id: String,
+        succeeded: bool,
+        answer: String,
+    },
+}
+
+#[derive(Default)]
+pub struct ParentContext {
+    history: Vec<Exchange>,
+    pending: Option<(String, String)>,
+    seen: BTreeSet<String>,
+}
+
+impl ParentContext {
+    /// Reject before mutating state. Invalid or mismatched results are not
+    /// interpreted as successful turns; failed work does not enter context.
+    pub fn exchange(&mut self, bytes: &[u8]) -> Result<ParentReply, &'static str> {
+        if bytes.is_empty() || bytes.len() > MAX_REQUEST_BYTES {
+            return Err("message bound exceeded");
+        }
+        let message: HostMessage =
+            serde_json::from_slice(bytes).map_err(|_| "invalid parent message")?;
+        match message {
+            HostMessage::Turn {
+                api_version,
+                turn_id,
+                message,
+            } => {
+                if api_version != VERSION {
+                    return Err("unsupported parent version");
+                }
+                if self.pending.is_some() {
+                    return Err("turn still pending");
+                }
+                if self.seen.contains(&turn_id) || self.seen.len() >= 1024 {
+                    return Err("turn replay or count exhausted");
+                }
+                if message.trim().is_empty() || message.contains('\0') {
+                    return Err("invalid user message");
+                }
+                // Explicit structured context, not a silently truncated prompt.
+                // The existing worker's 2 KiB bound still applies until the
+                // coordinated worker/spec/runtime contract is extended.
+                let task = serde_json::to_string(&serde_json::json!({
+                    "history":self.history, "message":message
+                }))
+                .map_err(|_| "context encoding failed")?;
+                let request = TurnRequest {
+                    api_version: warden::parent_protocol::VERSION.into(),
+                    turn_id: turn_id.clone(),
+                    task,
+                };
+                let encoded =
+                    serde_json::to_vec(&request).map_err(|_| "request encoding failed")?;
+                TurnRequest::decode(&encoded)
+                    .map_err(|_| "invalid turn identity or worker context full")?;
+                self.seen.insert(turn_id.clone());
+                self.pending = Some((turn_id, message));
+                Ok(ParentReply::Spawn { request })
+            }
+            HostMessage::Result {
+                api_version,
+                turn_id,
+                succeeded,
+                answer,
+            } => {
+                if api_version != VERSION {
+                    return Err("unsupported parent version");
+                }
+                let (id, _) = self.pending.as_ref().ok_or("no pending turn")?;
+                if id != &turn_id {
+                    return Err("result identity mismatch");
+                }
+                if answer.len() > MAX_TASK_BYTES
+                    || answer.contains('\0')
+                    || (succeeded && answer.trim().is_empty())
+                {
+                    return Err("invalid worker answer");
+                }
+                let (_, user) = self.pending.take().unwrap();
+                if succeeded {
+                    self.history.push(Exchange {
+                        user,
+                        assistant: answer.clone(),
+                    });
+                }
+                Ok(ParentReply::Completed {
+                    api_version: VERSION.into(),
+                    turn_id,
+                    succeeded,
+                    answer,
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn turn(id: &str, message: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({"kind":"turn", "apiVersion":VERSION, "turnId":id, "message":message})).unwrap()
+    }
+    fn result(id: &str, succeeded: bool) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({"kind":"result", "apiVersion":VERSION, "turnId":id, "succeeded":succeeded, "answer":"remembered"})).unwrap()
+    }
+    #[test]
+    fn next_worker_receives_committed_guest_context() {
+        let mut parent = ParentContext::default();
+        parent.exchange(&turn("one", "my value is violet")).unwrap();
+        parent.exchange(&result("one", true)).unwrap();
+        let ParentReply::Spawn { request } = parent.exchange(&turn("two", "what was it?")).unwrap()
+        else {
+            panic!()
+        };
+        let task: serde_json::Value = serde_json::from_str(&request.task).unwrap();
+        assert_eq!(task["history"][0]["user"], "my value is violet");
+        assert_eq!(task["history"][0]["assistant"], "remembered");
+        assert_eq!(task["message"], "what was it?");
+    }
+    #[test]
+    fn mismatched_results_busy_turns_and_replays_do_not_change_context() {
+        let mut parent = ParentContext::default();
+        parent.exchange(&turn("one", "secret")).unwrap();
+        assert!(parent.exchange(&turn("two", "busy")).is_err());
+        assert!(parent.exchange(&result("other", true)).is_err());
+        assert!(parent.history.is_empty());
+        parent.exchange(&result("one", false)).unwrap();
+        assert!(parent.history.is_empty());
+        assert!(parent.exchange(&turn("one", "replay")).is_err());
+        parent.exchange(&turn("two", "next")).unwrap();
+    }
+    #[test]
+    fn context_overflow_and_unknown_authority_fail_without_consuming_turn() {
+        let mut parent = ParentContext::default();
+        assert!(parent
+            .exchange(&turn("one", &"x".repeat(MAX_TASK_BYTES)))
+            .is_err());
+        assert!(parent.seen.is_empty());
+        let mut forged: serde_json::Value = serde_json::from_slice(&turn("one", "hello")).unwrap();
+        forged["executable"] = serde_json::json!("unapproved");
+        assert!(parent
+            .exchange(&serde_json::to_vec(&forged).unwrap())
+            .is_err());
+        parent.exchange(&turn("one", "hello")).unwrap();
+    }
+}

--- a/crates/celln-pilot/src/parent_proof.rs
+++ b/crates/celln-pilot/src/parent_proof.rs
@@ -1,0 +1,324 @@
+//! Explicit real-KVM proof; local test signing identity, not production admission.
+use anyhow::{ensure, Context, Result};
+use celln_manifest::{
+    closure::{Closure, Member},
+    Author, Entry, Hash, Manifest, Tier,
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+    process::Command,
+};
+use warden::vmm::boot::{BootConfig, BootEnd, LinuxCell};
+
+#[path = "proof_credential.rs"]
+mod credential;
+#[path = "parent_turn_proof.rs"]
+mod turns;
+
+fn main() -> Result<()> {
+    let real = std::env::args().any(|arg| arg == "--real-model");
+    let borrowed = std::env::args().any(|arg| arg == "--borrowed-tool");
+    let cancel_child = std::env::args().any(|arg| arg == "--cancel-child");
+    ensure!(
+        !cancel_child || !real,
+        "cancellation proof is deterministic only"
+    );
+    ensure!(
+        !borrowed || real,
+        "borrowed-tool proof requires --real-model"
+    );
+    let args: Vec<String> = std::env::args().collect();
+    let local_key = if let Some(index) = args.iter().position(|arg| arg == "--key-from-zshrc") {
+        ensure!(real, "startup key reading requires explicit --real-model");
+        Some(credential::from_zshrc(std::path::Path::new(
+            args.get(index + 1).context("missing startup file path")?,
+        ))?)
+    } else {
+        None
+    };
+    let native = real || cancel_child || std::env::args().any(|arg| arg == "--native-turns");
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let binaries = PathBuf::from(
+        std::env::var_os("CELLN_PILOT_DIR").context("static Pilot directory required")?,
+    );
+    let work = root.join(format!(
+        "target/parent-confined-proof-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir(&work)?;
+    if native {
+        std::fs::copy(binaries.join("celln-harness-parent"), work.join("parent"))?;
+    } else {
+        ensure!(
+            Command::new("rustc")
+                .args([
+                    "--edition=2021",
+                    "-O",
+                    "--target",
+                    "x86_64-unknown-linux-musl"
+                ])
+                .arg(root.join("crates/celln-pilot/tests/fixtures/parent_confined.rs"))
+                .arg("-o")
+                .arg(work.join("parent"))
+                .status()?
+                .success(),
+            "fixture compilation failed"
+        );
+    }
+    let mut mk = Command::new(root.join("scripts/mktoolfs.sh"));
+    mk.arg(work.join("toolfs.img"))
+        .arg("32")
+        .arg(work.join("parent"));
+    let worker_hash = if native {
+        if real {
+            std::fs::copy(binaries.join("celln-harness-turn"), work.join("worker"))?;
+            std::fs::copy(binaries.join("pilot-fetch"), work.join("pilot-fetch"))?;
+            mk.arg(work.join("pilot-fetch"));
+            if borrowed {
+                ensure!(
+                    Command::new("rustc")
+                        .args([
+                            "--edition=2021",
+                            "-O",
+                            "--target",
+                            "x86_64-unknown-linux-musl",
+                            "--cfg",
+                            "uppercase_tool"
+                        ])
+                        .arg(root.join("crates/celln-pilot/tests/fixtures/json_tool.rs"))
+                        .arg("-o")
+                        .arg(work.join("uppercase"))
+                        .status()?
+                        .success(),
+                    "borrowed tool build failed"
+                );
+                mk.arg(work.join("uppercase"));
+            }
+        } else {
+            ensure!(
+                Command::new("rustc")
+                    .args([
+                        "--edition=2021",
+                        "-O",
+                        "--target",
+                        "x86_64-unknown-linux-musl"
+                    ])
+                    .arg(root.join("crates/celln-pilot/tests/fixtures/turn_echo.rs"))
+                    .arg("-o")
+                    .arg(work.join("worker"))
+                    .status()?
+                    .success(),
+                "worker build failed"
+            );
+        }
+        mk.arg(work.join("worker"));
+        Some(Hash::of(&std::fs::read(work.join("worker"))?))
+    } else {
+        None
+    };
+    ensure!(mk.status()?.success(), "toolfs failed");
+    let payload = std::fs::read(work.join("toolfs.img"))?;
+    let hash = Hash::of(&std::fs::read(work.join("parent"))?);
+    let members = BTreeMap::from([(
+        "/parent".to_string(),
+        Member {
+            hash: hash.0.clone(),
+            dependencies: BTreeSet::new(),
+        },
+    )]);
+    let signed = Closure {
+        api_version: "celln.dev/closure-v1".into(),
+        sources: vec![],
+        toolfs: Hash::of(&payload).0,
+        entrypoint: "/parent".into(),
+        interpreter: false,
+        members: members.clone(),
+    }
+    .sign(&[42; 32])
+    .map_err(anyhow::Error::msg)?;
+    signed
+        .verify(&BTreeSet::from([signed.publisher.clone()]))
+        .map_err(anyhow::Error::msg)?;
+    std::fs::write(
+        work.join("signed-closure.json"),
+        serde_json::to_vec(&signed)?,
+    )?;
+    let mut manifest = Manifest::new();
+    if let Some(worker) = &worker_hash {
+        let mut worker_members = BTreeMap::from([(
+            "/worker".into(),
+            Member {
+                hash: worker.0.clone(),
+                dependencies: BTreeSet::new(),
+            },
+        )]);
+        if real {
+            worker_members
+                .get_mut("/worker")
+                .unwrap()
+                .dependencies
+                .insert("/pilot-fetch".into());
+            worker_members.insert(
+                "/pilot-fetch".into(),
+                Member {
+                    hash: Hash::of(&std::fs::read(work.join("pilot-fetch"))?).0,
+                    dependencies: BTreeSet::new(),
+                },
+            );
+            if borrowed {
+                worker_members
+                    .get_mut("/worker")
+                    .unwrap()
+                    .dependencies
+                    .insert("/uppercase".into());
+                worker_members.insert(
+                    "/uppercase".into(),
+                    Member {
+                        hash: Hash::of(&std::fs::read(work.join("uppercase"))?).0,
+                        dependencies: BTreeSet::new(),
+                    },
+                );
+            }
+        }
+        let worker_signed = Closure {
+            api_version: "celln.dev/closure-v1".into(),
+            sources: vec![],
+            toolfs: Hash::of(&payload).0,
+            entrypoint: "/worker".into(),
+            interpreter: false,
+            members: worker_members,
+        }
+        .sign(&[42; 32])
+        .map_err(anyhow::Error::msg)?;
+        worker_signed
+            .verify(&BTreeSet::from([worker_signed.publisher.clone()]))
+            .map_err(anyhow::Error::msg)?;
+        std::fs::write(
+            work.join("worker-closure.json"),
+            serde_json::to_vec(&worker_signed)?,
+        )?;
+        manifest.admit(Entry {
+            alias: "/worker".into(),
+            hash: worker.clone(),
+            tier: Tier::Verified,
+            interpreter: false,
+            author: Author::Host,
+            recipe: None,
+        });
+    }
+    manifest.admit(Entry {
+        alias: "/parent".into(),
+        hash: hash.clone(),
+        tier: Tier::Verified,
+        interpreter: false,
+        author: Author::Host,
+        recipe: None,
+    });
+    manifest.sign_standin();
+    std::fs::write(work.join("manifest.json"), serde_json::to_vec(&manifest)?)?;
+    ensure!(
+        Command::new(root.join("scripts/mkinitramfs.sh"))
+            .current_dir(&root)
+            .arg(work.join("initramfs.cpio"))
+            .env("CELLN_MANIFEST", work.join("manifest.json"))
+            .env("CELLN_PILOT_DIR", &binaries)
+            .env("CELLN_WARM_DISPATCH", "1")
+            .env_remove("CELLN_RUN_JSON")
+            .status()?
+            .success(),
+        "initrd failed"
+    );
+    let mut template = LinuxCell::boot(
+        BootConfig::new(BootConfig::host_kernel().context("kernel required")?)
+            .with_pmem(payload.len())
+            .with_initrd(work.join("initramfs.cpio")),
+    )?;
+    template.seal_tool(&Hash::of(&payload), &payload)?;
+    template.stop_when_guest_prints("CELLN:mote=parked");
+    ensure!(
+        template.run()?.end == BootEnd::Parked,
+        "template did not park"
+    );
+    let mote = template.park()?;
+    drop(template);
+    let mut parent = LinuxCell::fork_from(&mote)?;
+    let invocation = serde_json::json!({
+        "path":"/parent", "alias":"/parent", "root":"/tools", "args":[],
+        "force_agent_lane":true, "agent_authored_input":true, "allow_parent_mailbox":true,
+        "expected_hash":hash.0, "workspace_access":"none", "report_output_limit":8192,
+        "closure_members":members
+    });
+    parent.set_invocation(&serde_json::to_vec(&invocation)?)?;
+    parent.enable_parent_mailbox()?;
+    if let Some(worker_hash) = worker_hash {
+        let token = if real {
+            Some(if let Some(key) = &local_key {
+                key.path.clone()
+            } else {
+                PathBuf::from(
+                    std::env::var_os("CELLN_MODEL_TOKEN_FILE")
+                        .context("real model requires explicit host credential file")?,
+                )
+            })
+        } else {
+            None
+        };
+        return turns::run(
+            parent,
+            mote,
+            worker_hash,
+            work,
+            token,
+            borrowed,
+            cancel_child,
+        );
+    }
+    for (turn, message) in [
+        (1, &b"remember:private"[..]),
+        (2, &b"recall"[..]),
+        (3, &b"recall"[..]),
+    ] {
+        parent.deliver_parent_message(message)?;
+        let report = parent.run()?;
+        ensure!(
+            report.end == BootEnd::Parked,
+            "parent failed: {}",
+            report.tail(30)
+        );
+        ensure!(
+            parent.take_parent_response()?.context("no response")?
+                == format!("confined:{turn}:private").as_bytes(),
+            "guest state mismatch"
+        );
+        ensure!(
+            !report.console.contains("Linux version"),
+            "parent booted on hot path"
+        );
+    }
+    let mut ungranted = LinuxCell::fork_from(&mote)?;
+    let mut without_grant = invocation;
+    without_grant["allow_parent_mailbox"] = serde_json::json!(false);
+    ungranted.set_invocation(&serde_json::to_vec(&without_grant)?)?;
+    ungranted.enable_parent_mailbox()?;
+    ungranted.deliver_parent_message(b"recall")?;
+    let report = ungranted.run()?;
+    ensure!(
+        report.end == BootEnd::Shutdown,
+        "ungranted guest did not terminate: {}",
+        report.tail(30)
+    );
+    ensure!(
+        ungranted.take_parent_response()?.is_none(),
+        "ungranted guest accessed mailbox"
+    );
+    // Require the actual failed port instruction's guest signal, not merely
+    // a timeout or a guest that failed for an unrelated packaging reason.
+    ensure!(
+        report.console.contains("\"signal\":11"),
+        "missing guest SIGSEGV for ungranted I/O: {}",
+        report.tail(30)
+    );
+    println!("PASS: sealed parent through Pilot, 3 retained-state turns, guest capabilities empty; forbidden ioperm/iopl/network/device creation/raw-device access/code write refused; ungranted guest I/O faults. Evidence: {}", work.display());
+    Ok(())
+}

--- a/crates/celln-pilot/src/parent_session.rs
+++ b/crates/celln-pilot/src/parent_session.rs
@@ -1,0 +1,364 @@
+//! Host session sequencing. Transports/worker execution must be independently
+//! admitted by the serving owner; guest requests never choose those callbacks.
+//! Run inside ParentOwner so cancellation/deadline reaches the actual VMs.
+use crate::parent_harness::{HostMessage, ParentReply, VERSION};
+use anyhow::{ensure, Result};
+use celln_manifest::Hash;
+use warden::{
+    parent_journal::ParentJournal,
+    parent_lease::{ParentLease, ReservedTurn},
+};
+
+/// Build the complete session inside one control-aware serving owner. Runtime
+/// closures may own non-Send VM state because they stay on the owner thread.
+pub fn spawn_owner<F, P, W>(
+    lifetime: std::time::Duration,
+    initialize: F,
+) -> std::io::Result<warden::parent_owner::ParentOwner>
+where
+    F: FnOnce() -> Result<ParentSession<P, W>> + Send + 'static,
+    P: FnMut(&[u8]) -> Result<Vec<u8>> + 'static,
+    W: FnMut(&ReservedTurn) -> Result<DestroyedChild> + 'static,
+{
+    warden::parent_owner::ParentOwner::spawn(lifetime, move || {
+        let mut session = initialize().map_err(|e| e.to_string())?;
+        Ok(move |bytes: &[u8]| session.submit(bytes).map_err(|e| e.to_string()))
+    })
+}
+
+/// Register an independently admitted session with caller-scoped owner routing.
+pub fn spawn_registered<F, P, W>(
+    registry: &warden::parent_registry::ParentRegistry,
+    principal: &str,
+    incarnation: &Hash,
+    lifetime: std::time::Duration,
+    reserved_bytes: u64,
+    initialize: F,
+) -> Result<()>
+where
+    F: FnOnce() -> Result<ParentSession<P, W>> + Send + 'static,
+    P: FnMut(&[u8]) -> Result<Vec<u8>> + 'static,
+    W: FnMut(&ReservedTurn) -> Result<DestroyedChild> + 'static,
+{
+    registry
+        .spawn_admitted(
+            principal,
+            incarnation,
+            lifetime,
+            reserved_bytes,
+            move || {
+                let mut session = initialize().map_err(|e| e.to_string())?;
+                Ok(move |bytes: &[u8]| session.submit(bytes).map_err(|e| e.to_string()))
+            },
+        )
+        .map_err(anyhow::Error::msg)
+}
+
+/// Trusted executor's result, returned ONLY after actual child teardown.
+pub struct DestroyedChild {
+    pub child: Hash,
+    pub succeeded: bool,
+    pub answer: String,
+}
+
+pub struct ParentSession<P, W> {
+    parent: P,
+    worker: W,
+    lease: ParentLease,
+    journal: ParentJournal,
+    closed: bool,
+    child_control: Option<std::sync::Arc<warden::parent_child_control::ChildControlSlot>>,
+}
+
+impl<P, W> ParentSession<P, W>
+where
+    P: FnMut(&[u8]) -> Result<Vec<u8>>,
+    W: FnMut(&ReservedTurn) -> Result<DestroyedChild>,
+{
+    pub fn new(parent: P, worker: W, lease: ParentLease, journal: ParentJournal) -> Self {
+        Self {
+            parent,
+            worker,
+            lease,
+            journal,
+            closed: false,
+            child_control: None,
+        }
+    }
+
+    /// Install the admitted owner's exact-identity child control. Only worker
+    /// execution runs in its scope; parent mailbox commits retain parent control.
+    pub fn with_child_control(
+        mut self,
+        control: std::sync::Arc<warden::parent_child_control::ChildControlSlot>,
+    ) -> Self {
+        self.child_control = Some(control);
+        self
+    }
+
+    /// Only user turns enter here. Result envelopes are created internally
+    /// from the independently bound executor, never accepted from a client.
+    pub fn submit(&mut self, input: &[u8]) -> Result<Vec<u8>> {
+        ensure!(
+            !self.closed,
+            "parent session closed; reconcile original owner"
+        );
+        let result = self.turn(input);
+        if result.is_err() {
+            self.closed = true;
+            self.lease.stop();
+        }
+        result
+    }
+
+    fn turn(&mut self, input: &[u8]) -> Result<Vec<u8>> {
+        ensure!(!self.lease.expired(), "parent lease closed");
+        ensure!(
+            !input.is_empty() && input.len() <= warden::parent_mailbox::MAX_FRAME_BYTES,
+            "invalid input bound"
+        );
+        let HostMessage::Turn {
+            api_version,
+            turn_id,
+            message,
+        } = serde_json::from_slice(input)?
+        else {
+            anyhow::bail!("clients cannot inject child results");
+        };
+        ensure!(
+            api_version == VERSION && !message.trim().is_empty(),
+            "invalid user turn"
+        );
+        let response = (self.parent)(input)?;
+        ensure!(
+            response.len() <= warden::parent_mailbox::MAX_FRAME_BYTES,
+            "parent response overflow"
+        );
+        let ParentReply::Spawn { request } = serde_json::from_slice(&response)? else {
+            anyhow::bail!("parent did not request a worker");
+        };
+        ensure!(request.turn_id == turn_id, "parent changed turn identity");
+        let reservation = self.lease.reserve(&serde_json::to_vec(&request)?)?;
+        self.journal.reserve(&reservation)?;
+        let controlled = self
+            .child_control
+            .as_ref()
+            .map(|slot| slot.register(&reservation))
+            .transpose()
+            .map_err(anyhow::Error::msg)?;
+        let result = if let Some((_, control)) = &controlled {
+            control.scope(|| (self.worker)(&reservation))?
+        } else {
+            (self.worker)(&reservation)?
+        };
+        ensure!(
+            result.child == reservation.child,
+            "child result owner mismatch"
+        );
+        self.lease.confirm_child_destroyed(&result.child)?;
+        self.journal
+            .child_destroyed(&turn_id, &result.child, result.succeeded, &result.answer)?;
+        ensure!(!self.lease.expired(), "parent expired before result commit");
+        let response = (self.parent)(&serde_json::to_vec(&serde_json::json!({
+            "kind":"result", "apiVersion":VERSION, "turnId":turn_id,
+            "succeeded":result.succeeded, "answer":result.answer
+        }))?)?;
+        ensure!(
+            response.len() <= warden::parent_mailbox::MAX_FRAME_BYTES,
+            "parent acknowledgement overflow"
+        );
+        let ParentReply::Completed {
+            api_version,
+            turn_id: acknowledged,
+            succeeded,
+            answer,
+        } = serde_json::from_slice(&response)?
+        else {
+            anyhow::bail!("parent did not acknowledge result");
+        };
+        ensure!(
+            api_version == VERSION
+                && acknowledged == turn_id
+                && succeeded == result.succeeded
+                && answer == result.answer,
+            "parent acknowledgement mismatch"
+        );
+        self.journal.parent_committed(&turn_id, &result.child)?;
+        if let Some((identity, _)) = controlled {
+            self.child_control
+                .as_ref()
+                .unwrap()
+                .retire(&identity)
+                .map_err(anyhow::Error::msg)?;
+        }
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{cell::Cell, time::Duration};
+    use warden::parent_lease::TurnLimits;
+    fn setup() -> (ParentLease, ParentJournal, tempfile::TempDir) {
+        let root = tempfile::tempdir().unwrap();
+        let id = Hash::of(b"parent");
+        let journal = ParentJournal::create(root.path(), id.clone()).unwrap();
+        let lease = ParentLease::new(
+            id,
+            Duration::from_secs(30),
+            TurnLimits {
+                memory_bytes: 4096,
+                timeout: Duration::from_secs(1),
+                model_requests: 0,
+                output_tokens: 0,
+            },
+            2,
+            0,
+            0,
+        )
+        .unwrap();
+        (lease, journal, root)
+    }
+    fn input(id: &str) -> Vec<u8> {
+        serde_json::to_vec(
+            &serde_json::json!({"kind":"turn","apiVersion":VERSION,"turnId":id,"message":"hello"}),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn cancelled_worker_result_restores_parent_scope_and_retires_after_commit() {
+        // Protocol sequencing with a trusted synthetic DestroyedChild, not a
+        // VM teardown proof. Native execution must establish that independently.
+        let (lease, journal, _root) = setup();
+        let control = celln_control::Control::new(Duration::from_secs(30)).unwrap();
+        let slot = std::sync::Arc::new(warden::parent_child_control::ChildControlSlot::new(
+            Hash::of(b"parent"),
+            control.clone(),
+        ));
+        let mut context = crate::parent_harness::ParentContext::default();
+        let mut calls = 0;
+        let mut session = ParentSession::new(
+            |bytes: &[u8]| {
+                // Both the initial mailbox request and failed-result commit
+                // must see parent control, not the cancelled worker scope.
+                celln_control::check()?;
+                Ok(serde_json::to_vec(
+                    &context.exchange(bytes).map_err(anyhow::Error::msg)?,
+                )?)
+            },
+            |turn: &ReservedTurn| {
+                calls += 1;
+                if calls == 1 {
+                    let identity = warden::parent_child_control::Identity {
+                        parent: turn.parent.clone(),
+                        turn: turn.request.turn_id.clone(),
+                        child: turn.child.clone(),
+                    };
+                    slot.cancel(&identity).unwrap();
+                    assert!(celln_control::check().is_err());
+                } else {
+                    celln_control::check()?;
+                }
+                Ok(DestroyedChild {
+                    child: turn.child.clone(),
+                    succeeded: calls != 1,
+                    answer: if calls == 1 {
+                        "cancelled"
+                    } else {
+                        "next answer"
+                    }
+                    .into(),
+                })
+            },
+            lease,
+            journal,
+        )
+        .with_child_control(slot.clone());
+        control.scope(|| {
+            let first: ParentReply =
+                serde_json::from_slice(&session.submit(&input("one")).unwrap()).unwrap();
+            assert!(matches!(
+                first,
+                ParentReply::Completed {
+                    succeeded: false,
+                    ..
+                }
+            ));
+            assert!(control.check().is_ok());
+            let next: ParentReply =
+                serde_json::from_slice(&session.submit(&input("two")).unwrap()).unwrap();
+            assert!(matches!(
+                next,
+                ParentReply::Completed {
+                    succeeded: true,
+                    ..
+                }
+            ));
+        });
+    }
+    #[test]
+    fn session_sequences_actual_context_state_and_refuses_replay() {
+        let (lease, journal, _root) = setup();
+        let mut context = crate::parent_harness::ParentContext::default();
+        let calls = Cell::new(0);
+        let mut session = ParentSession::new(
+            |bytes: &[u8]| {
+                Ok(serde_json::to_vec(
+                    &context.exchange(bytes).map_err(anyhow::Error::msg)?,
+                )?)
+            },
+            |turn: &ReservedTurn| {
+                calls.set(calls.get() + 1);
+                Ok(DestroyedChild {
+                    child: turn.child.clone(),
+                    succeeded: true,
+                    answer: "answer".into(),
+                })
+            },
+            lease,
+            journal,
+        );
+        session.submit(&input("one")).unwrap();
+        session.submit(&input("two")).unwrap();
+        assert!(session.submit(&input("one")).is_err());
+        assert_eq!(calls.get(), 2);
+    }
+    #[test]
+    fn caller_cannot_inject_result_or_invoke_worker() {
+        let (lease, journal, _root) = setup();
+        let mut session = ParentSession::new(
+            |_: &[u8]| -> Result<Vec<u8>> { panic!("must not reach parent") },
+            |_: &ReservedTurn| -> Result<DestroyedChild> { panic!("must not reach worker") },
+            lease,
+            journal,
+        );
+        let forged = serde_json::to_vec(&serde_json::json!({"kind":"result","apiVersion":VERSION,"turnId":"one","succeeded":true,"answer":"forged"})).unwrap();
+        assert!(session.submit(&forged).is_err());
+    }
+    #[test]
+    fn changed_child_owner_closes_session_without_committing() {
+        let (lease, journal, _root) = setup();
+        let mut context = crate::parent_harness::ParentContext::default();
+        let mut session = ParentSession::new(
+            |bytes: &[u8]| {
+                Ok(serde_json::to_vec(
+                    &context.exchange(bytes).map_err(anyhow::Error::msg)?,
+                )?)
+            },
+            |_: &ReservedTurn| {
+                Ok(DestroyedChild {
+                    child: Hash::of(b"wrong"),
+                    succeeded: true,
+                    answer: "forged".into(),
+                })
+            },
+            lease,
+            journal,
+        );
+        assert!(session.submit(&input("one")).is_err());
+        assert!(session.closed);
+        assert!(session.submit(&input("two")).is_err());
+    }
+}

--- a/crates/celln-pilot/src/parent_turn_proof.rs
+++ b/crates/celln-pilot/src/parent_turn_proof.rs
@@ -1,0 +1,386 @@
+//! Explicit deterministic native-parent/child handoff test. Not production
+//! authorization, a durable owner, or real-model proof.
+use anyhow::{ensure, Context, Result};
+use celln_manifest::Hash;
+use serde_json::{json, Value};
+use std::{path::PathBuf, time::Duration};
+use warden::{
+    parent_lease::{ParentLease, TurnLimits},
+    vmm::boot::{BootEnd, LinuxCell, Mote},
+};
+
+fn exchange(parent: &mut LinuxCell, message: Value) -> Result<Value> {
+    parent.deliver_parent_message(&serde_json::to_vec(&message)?)?;
+    let report = parent.run()?;
+    ensure!(
+        report.end == BootEnd::Parked,
+        "native parent failed: {}",
+        report.tail(30)
+    );
+    ensure!(!report.console.contains("Linux version"), "parent hot boot");
+    Ok(serde_json::from_slice(
+        &parent
+            .take_parent_response()?
+            .context("missing parent response")?,
+    )?)
+}
+
+fn model_template(work: &std::path::Path, borrowed: bool) -> Result<pilot::turn_worker::Template> {
+    let mut config = json!({"contract":"celln.json-tools/v1", "task":"",
+        "system":"Answer briefly, in at most ten words. Remember user-provided values across the supplied conversation.",
+        "url":"https://api.deepseek.com/chat/completions", "model":"deepseek-chat", "tools":[], "max_turns":1,"max_calls":0});
+    if borrowed {
+        let schema = r#"{"type":"object","properties":{"text":{"type":"string","minLength":1,"maxLength":64}},"required":["text"],"additionalProperties":false}"#;
+        config["tools"] = json!([{"name":"uppercase","path":"/uppercase","hash":Hash::of(&std::fs::read(work.join("uppercase"))?).0,
+            "description":"Uppercase text", "input_schema":{"bytes":schema,"hash":Hash::of(schema.as_bytes()).0},
+            "output_schema":{"bytes":schema,"hash":Hash::of(schema.as_bytes()).0}, "input_bytes":1024,"output_bytes":256,"timeout_ms":1000}]);
+        config["max_turns"] = json!(3);
+        config["max_calls"] = json!(1);
+    }
+    pilot::turn_worker::Template::new(serde_json::from_value(config)?)
+}
+
+pub fn run(
+    mut parent: LinuxCell,
+    mote: Mote,
+    worker: Hash,
+    work: PathBuf,
+    token: Option<PathBuf>,
+    borrowed: bool,
+    cancel_child: bool,
+) -> Result<()> {
+    let real = token.is_some();
+    let template = if real {
+        Some(model_template(&work, borrowed)?)
+    } else {
+        None
+    };
+    let first = if cancel_child {
+        "block-child"
+    } else if borrowed {
+        "My value is violet. Call uppercase with my value and answer only the tool result text."
+    } else {
+        "my value is violet"
+    };
+    let second = if borrowed {
+        "Call uppercase on my original value again. Answer only the tool result text."
+    } else {
+        "repeat my value"
+    };
+    let evidence = std::sync::Arc::new(std::sync::Mutex::new(Vec::<Value>::new()));
+    let owner_evidence = evidence.clone();
+    let owner_work = work.clone();
+    let owner =
+        warden::parent_registry::ParentRegistry::new(1, 1 << 30).map_err(anyhow::Error::msg)?;
+    let incarnation = Hash::of(work.as_os_str().as_encoded_bytes());
+    pilot::parent_session::spawn_registered(
+        &owner,
+        "local-proof",
+        &incarnation,
+        Duration::from_secs(180),
+        1 << 30,
+        move || {
+            let work = owner_work;
+            let parent_id = Hash::of(work.as_os_str().as_encoded_bytes());
+            let journal = warden::parent_journal::ParentJournal::create(
+                &work.join("parent-journal"),
+                parent_id.clone(),
+            )?;
+            let lease = ParentLease::new(
+                parent_id,
+                Duration::from_secs(180),
+                TurnLimits {
+                    memory_bytes: 256 << 20,
+                    timeout: Duration::from_secs(if real { 60 } else { 10 }),
+                    model_requests: if borrowed {
+                        3
+                    } else if real {
+                        1
+                    } else {
+                        0
+                    },
+                    output_tokens: if borrowed {
+                        1536
+                    } else if real {
+                        512
+                    } else {
+                        0
+                    },
+                },
+                2,
+                if borrowed {
+                    6
+                } else if real {
+                    2
+                } else {
+                    0
+                },
+                if borrowed {
+                    3072
+                } else if real {
+                    1024
+                } else {
+                    0
+                },
+            )?;
+            let mut previous_answer = String::new();
+            let parent_transport = move |bytes: &[u8]| -> Result<Vec<u8>> {
+                Ok(serde_json::to_vec(&exchange(
+                    &mut parent,
+                    serde_json::from_slice(bytes)?,
+                )?)?)
+            };
+            let worker_transport = move |reservation: &warden::parent_lease::ReservedTurn| -> Result<pilot::parent_session::DestroyedChild> {
+        let id = reservation.request.turn_id.as_str();
+        let task: Value = serde_json::from_str(&reservation.request.task)?;
+        if id == "two" {
+            ensure!(
+                task["history"][0]["user"] == first,
+                "parent lost user context"
+            );
+            ensure!(
+                task["history"][0]["assistant"] == previous_answer,
+                "parent lost real child result"
+            );
+        }
+        let worker_args = template.as_ref().map(|t| t.arguments(reservation)).transpose()?;
+        let mut child = LinuxCell::fork_from(&mote)?;
+        child.set_timeout(reservation.limits.timeout);
+        let mut invocation = json!({"path":"/worker", "alias":"/worker", "root":"/tools",
+            "args":[reservation.request.task], "force_agent_lane":true, "expected_hash":worker.0,
+            "workspace_access":"none", "report_output_limit":8192,
+            "closure_members":{"/worker":{"hash":worker.0,"dependencies":[]}}});
+        if let Some(token) = token.as_deref() {
+            invocation["allow_fetch"] = json!(true);
+            invocation["closure_members"]["/worker"]["dependencies"] = json!(["/pilot-fetch"]);
+            invocation["closure_members"]["/pilot-fetch"] = json!({"hash":Hash::of(&std::fs::read(work.join("pilot-fetch"))?).0,"dependencies":[]});
+            if borrowed {
+                let tool_hash = Hash::of(&std::fs::read(work.join("uppercase"))?).0;
+                invocation["closure_members"]["/worker"]["dependencies"] =
+                    json!(["/pilot-fetch", "/uppercase"]);
+                invocation["closure_members"]["/uppercase"] =
+                    json!({"hash":tool_hash,"dependencies":[]});
+            }
+            invocation["args"] = json!(worker_args.context("missing worker template arguments")?);
+            let mut policy = warden::egress::HttpPolicy::new(vec!["api.deepseek.com".into()]);
+            policy.timeout = Duration::from_secs(45);
+            policy.max_requests = reservation.limits.model_requests as usize;
+            policy.json_posts.push(warden::egress::JsonPostGrant {
+                url: "https://api.deepseek.com/chat/completions".into(),
+                bearer_token_file: token.into(),
+                model: "deepseek-chat".into(),
+                max_output_tokens: 512,
+                max_total_output_tokens: reservation.limits.output_tokens,
+            });
+            child.enable_http_fetch(policy);
+        }
+        child.set_invocation(&serde_json::to_vec(&invocation)?)?;
+        let report = child.run()?;
+        if cancel_child {
+            std::fs::write(work.join("cancelled-child.console"), &report.console)?;
+            ensure!(report.end == BootEnd::TimedOut, "busy child was not interrupted");
+            let mut observed = Vec::new();
+            for line in report.console.lines().filter_map(|l| l.strip_prefix(pilot::dispatch_report::PREFIX)) {
+                if let pilot::dispatch_report::Frame::Output { bytes } = serde_json::from_str(line)? { observed.extend(bytes); }
+            }
+            ensure!(String::from_utf8(observed)?.contains("CHILD_BUSY_ENTERED"), "child never entered busy loop");
+            drop(child);
+            anyhow::bail!("busy child stopped and destroyed");
+        }
+        ensure!(
+            report.end == BootEnd::Shutdown,
+            "child failed: {}",
+            report.tail(30)
+        );
+        ensure!(!report.console.contains("Linux version"), "child hot boot");
+        let mut output = Vec::new();
+        let mut exited = false;
+        let mut checked = false;
+        for line in report
+            .console
+            .lines()
+            .filter_map(|l| l.strip_prefix(pilot::dispatch_report::PREFIX))
+        {
+            match serde_json::from_str::<pilot::dispatch_report::Frame>(line)? {
+                pilot::dispatch_report::Frame::Started { grant } => {
+                    ensure!(
+                        grant.tool == worker.0
+                            && grant.fetch == real
+                            && grant.workspace.as_deref() == Some("none"),
+                        "child grant mismatch"
+                    );
+                    checked = true;
+                }
+                pilot::dispatch_report::Frame::Output { bytes } => output.extend(bytes),
+                pilot::dispatch_report::Frame::Exit { code } => {
+                    ensure!(code == 0, "child exit failure");
+                    exited = true;
+                }
+                pilot::dispatch_report::Frame::Failed { .. }
+                | pilot::dispatch_report::Frame::Signal { .. } => {
+                    anyhow::bail!("child execution failed")
+                }
+                _ => {}
+            }
+        }
+        ensure!(checked && exited, "missing child hash/exit evidence");
+        if !real {
+            ensure!(
+                output == reservation.request.task.as_bytes(),
+                "deterministic child output mismatch"
+            );
+        }
+        std::fs::write(work.join(format!("child-{id}.console")), &report.console)?;
+        let model_activity = child.fetch_activity();
+        drop(child);
+        let output = String::from_utf8(output)?;
+        let answer = if real {
+            ensure!(
+                model_activity.0 == if borrowed { 2 } else { 1 },
+                "unexpected real model request count"
+            );
+            let events: Vec<Value> = output
+                .lines()
+                .filter_map(|l| l.strip_prefix("CELLN_HARNESS_EVENT "))
+                .map(serde_json::from_str)
+                .collect::<Result<_, _>>()?;
+            let completed = events
+                .iter()
+                .find(|e| e["type"] == "completed")
+                .context("no model completion")?;
+            if borrowed {
+                let tool_events: Vec<_> = events
+                    .iter()
+                    .filter(|event| event["type"] == "tool")
+                    .collect();
+                ensure!(
+                    tool_events.len() == 1 && tool_events[0]["name"] == "uppercase",
+                    "missing selected tool execution"
+                );
+                ensure!(completed["calls"] == 1, "tool call count mismatch");
+            }
+            let answer = completed["answer"]
+                .as_str()
+                .context("no model answer")?
+                .to_string();
+            if id == "two" {
+                ensure!(
+                    answer.to_lowercase().contains("violet"),
+                    "model did not recall retained context"
+                );
+            }
+            if borrowed {
+                ensure!(
+                    answer.trim() == "VIOLET",
+                    "model did not return borrowed tool result"
+                );
+            }
+            answer
+        } else {
+            output
+        };
+
+        previous_answer = answer.clone();
+        owner_evidence.lock().expect("proof evidence lock").push(json!({"parent":reservation.parent.0,"child":reservation.child.0,"turn":id,"worker":worker.0,
+            "request":{"kind":"spawn","request":reservation.request},"modelRequests":model_activity.0,
+            "realModel":real,"borrowedUppercase":borrowed,"childDestroyedBeforeCommit":true,
+            "workerTemplate":template.as_ref().map(|t| &t.binding().0)}));
+        Ok(pilot::parent_session::DestroyedChild { child:reservation.child.clone(), succeeded:true, answer })
+    };
+            Ok(pilot::parent_session::ParentSession::new(
+                parent_transport,
+                worker_transport,
+                lease,
+                journal,
+            ))
+        },
+    )?;
+    let mut completed_results = Vec::new();
+    for (id, message) in [("one", first), ("two", second)] {
+        let pending = owner
+            .submit(
+                "local-proof",
+                &incarnation,
+                &serde_json::to_vec(
+                    &json!({"kind":"turn","apiVersion":pilot::parent_harness::VERSION,
+            "turnId":id,"message":message}),
+                )?,
+            )
+            .map_err(anyhow::Error::msg)?;
+        if cancel_child {
+            std::thread::sleep(Duration::from_secs(1));
+            owner
+                .cancel("local-proof", &incarnation)
+                .map_err(anyhow::Error::msg)?;
+            let result = pending.recv_timeout(Duration::from_secs(3))?;
+            ensure!(
+                result
+                    .as_ref()
+                    .err()
+                    .is_some_and(|e| e == "busy child stopped and destroyed"),
+                "cancellation proof failed: {result:?}"
+            );
+            owner
+                .stop("local-proof", &incarnation)
+                .map_err(anyhow::Error::msg)?;
+            ensure!(
+                matches!(
+                    warden::parent_journal::inspect_turn(
+                        &work.join("parent-journal"),
+                        &Hash::of(work.as_os_str().as_encoded_bytes()),
+                        id
+                    )?,
+                    warden::parent_journal::TurnStatus::Reserved(_)
+                ),
+                "cancelled child must not have a durable result acknowledgement"
+            );
+            std::fs::write(
+                work.join("cancelled-tree.json"),
+                serde_json::to_vec_pretty(&json!({
+                    "guestBusyObserved":true, "childInterrupted":true, "childDestroyed":true,
+                    "parentOwnerJoined":true, "resultCommitted":false,
+                    "durableStage":"reserved", "liveContext":"lost"
+                }))?,
+            )?;
+            println!("PASS: busy child observed and interrupted, child dropped, parent owner joined. Evidence: {}", work.display());
+            return Ok(());
+        }
+        let reply = pending
+            .recv_timeout(Duration::from_secs(90))?
+            .map_err(anyhow::Error::msg)?;
+        completed_results.push(serde_json::from_slice::<Value>(&reply)?);
+    }
+    owner
+        .stop("local-proof", &incarnation)
+        .map_err(anyhow::Error::msg)?;
+    let mut evidence = evidence.lock().expect("proof evidence lock");
+    ensure!(
+        evidence[0]["child"] != evidence[1]["child"],
+        "child identity reused"
+    );
+    for (record, result) in evidence.iter_mut().zip(completed_results) {
+        let status = warden::parent_journal::inspect_turn(
+            &work.join("parent-journal"),
+            &Hash::of(work.as_os_str().as_encoded_bytes()),
+            record["turn"].as_str().context("missing turn identity")?,
+        )?;
+        let warden::parent_journal::TurnStatus::ParentCommitted(durable) = status else {
+            anyhow::bail!("missing durable parent acknowledgement after owner shutdown");
+        };
+        ensure!(
+            durable.child.0 == record["child"]
+                && durable.succeeded == result["succeeded"]
+                && durable.answer == result["answer"],
+            "durable result mismatch"
+        );
+        record["result"] = result;
+        record["durableStage"] = json!("parent-committed");
+        record["liveContext"] = json!("lost");
+    }
+    std::fs::write(
+        work.join("native-turns.json"),
+        serde_json::to_vec_pretty(&*evidence)?,
+    )?;
+    println!("PASS: composed native session, two distinct sealed child VMs, retained context, journaled commits, all VMs dropped. realModel={real}; NOT production admission. Evidence: {}", work.display());
+    Ok(())
+}

--- a/crates/celln-pilot/src/proof_credential.rs
+++ b/crates/celln-pilot/src/proof_credential.rs
@@ -1,0 +1,62 @@
+//! Explicit local proof helper: never execute/source a shell startup file.
+use anyhow::{ensure, Context, Result};
+use std::{
+    io::{Read, Write},
+    os::unix::fs::OpenOptionsExt,
+    path::{Path, PathBuf},
+};
+pub struct Credential {
+    pub path: PathBuf,
+}
+impl Drop for Credential {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+pub fn from_zshrc(path: &Path) -> Result<Credential> {
+    let mut input = String::new();
+    std::fs::File::open(path)?
+        .take(1_048_577)
+        .read_to_string(&mut input)?;
+    ensure!(input.len() <= 1_048_576, "startup file too large");
+    let values: Vec<&str> = input
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim().strip_prefix("export ").unwrap_or(line.trim());
+            line.strip_prefix("DEEPSEEK_API_KEY=")
+        })
+        .collect();
+    ensure!(
+        values.len() == 1,
+        "expected one literal DeepSeek key assignment"
+    );
+    let raw = values[0].trim();
+    let value = raw
+        .strip_prefix('"')
+        .and_then(|v| v.strip_suffix('"'))
+        .or_else(|| raw.strip_prefix('\'').and_then(|v| v.strip_suffix('\'')))
+        .unwrap_or(raw);
+    ensure!(
+        (16..=512).contains(&value.len())
+            && value
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b"-_".contains(&b)),
+        "key must be a literal token"
+    );
+    let path = std::env::temp_dir().join(format!(
+        "celln-proof-key-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos()
+    ));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)?;
+    let credential = Credential { path };
+    file.write_all(value.as_bytes())
+        .context("could not write private proof credential")?;
+    Ok(credential)
+}

--- a/crates/celln-pilot/src/starter_tools.rs
+++ b/crates/celln-pilot/src/starter_tools.rs
@@ -1,0 +1,91 @@
+//! Signed guest tool entrypoints. No host paths, shell, credentials or direct
+//! sockets: all effects go through independently granted host broker requests.
+use anyhow::{ensure, Result};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::{io::Read, time::Duration};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReadInput {
+    name: String,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WriteInput {
+    name: String,
+    revision: u64,
+    content: String,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FetchInput {
+    url: String,
+}
+
+fn request(kind: &str, input: &[u8]) -> Result<(Vec<String>, Vec<u8>)> {
+    let body = match kind {
+        "read" => {
+            let input: ReadInput = serde_json::from_slice(input)?;
+            json!({"operation":"read", "name":input.name})
+        }
+        "write" => {
+            let input: WriteInput = serde_json::from_slice(input)?;
+            json!({"operation":"write", "name":input.name,"revision":input.revision,"content":input.content})
+        }
+        "fetch" => {
+            let input: FetchInput = serde_json::from_slice(input)?;
+            ensure!(
+                input.url.starts_with("https://")
+                    && input.url.len() <= 8192
+                    && !input.url.contains('\0'),
+                "invalid HTTPS URL"
+            );
+            return Ok((vec![input.url], vec![]));
+        }
+        _ => anyhow::bail!("unknown starter tool"),
+    };
+    let wire = serde_json::to_vec(&json!({"apiVersion":"celln.workspace/v1","body":body}))?;
+    ensure!(wire.len() <= 8192, "workspace request exceeds wire limit");
+    Ok((vec!["--json-stdin".into()], wire))
+}
+
+fn run(kind: &str) -> Result<Value> {
+    let mut input = Vec::new();
+    std::io::stdin().take(8193).read_to_end(&mut input)?;
+    ensure!(input.len() <= 8192, "tool input exceeds limit");
+    let (args, wire) = request(kind, &input)?;
+    let result =
+        crate::harness_io::child("/pilot-fetch", &args, &wire, 65536, Duration::from_secs(30))?;
+    if kind == "fetch" {
+        Ok(json!({"content":std::str::from_utf8(&result)?}))
+    } else {
+        Ok(serde_json::from_slice(&result)?)
+    }
+}
+
+pub fn main(kind: &str) {
+    // Tool errors are data for the model, not fabricated success or a retry.
+    let output = run(kind).unwrap_or_else(|error| json!({"error":error.to_string()}));
+    println!("{output}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn strict_inputs_cannot_choose_a_host_path_command_or_identity() {
+        assert!(request("read", br#"{"name":"note.txt","parent":"other"}"#).is_err());
+        assert!(request("fetch", br#"{"url":"--config=/secret"}"#).is_err());
+        assert!(request("write", br#"{"name":"note.txt","content":"x"}"#).is_err());
+        let (args, wire) = request(
+            "write",
+            br#"{"name":"note.txt","revision":0,"content":"violet"}"#,
+        )
+        .unwrap();
+        assert_eq!(args, ["--json-stdin"]);
+        let value: Value = serde_json::from_slice(&wire).unwrap();
+        assert_eq!(value["apiVersion"], "celln.workspace/v1");
+        assert_eq!(value["body"]["content"], "violet");
+    }
+}

--- a/crates/celln-pilot/src/turn_worker.rs
+++ b/crates/celln-pilot/src/turn_worker.rs
@@ -1,0 +1,168 @@
+//! Native turn data is distinct from immutable host-selected model/tool policy.
+//! This module constructs arguments, never credentials, grants or executables.
+use crate::json_harness::{self, Config, Exchange};
+use anyhow::{ensure, Result};
+use celln_manifest::Hash;
+use serde::{Deserialize, Serialize};
+use warden::{parent_lease::ReservedTurn, parent_protocol::MAX_TASK_BYTES};
+
+pub const VERSION: &str = "celln.native-turn-template/v1";
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContextInput {
+    pub history: Vec<Exchange>,
+    pub message: String,
+}
+
+impl ContextInput {
+    pub fn decode(raw: &str) -> Result<Self> {
+        ensure!(
+            raw.len() <= MAX_TASK_BYTES,
+            "parent context exceeds worker contract"
+        );
+        let context: Self = serde_json::from_str(raw)?;
+        ensure!(
+            !context.message.trim().is_empty() && !context.message.contains('\0'),
+            "invalid turn message"
+        );
+        ensure!(
+            context.history.len() <= 16,
+            "parent history count exceeds limit"
+        );
+        for exchange in &context.history {
+            for text in [&exchange.user, &exchange.assistant] {
+                ensure!(
+                    !text.trim().is_empty() && !text.contains('\0'),
+                    "invalid parent history text"
+                );
+            }
+        }
+        Ok(context)
+    }
+}
+
+/// Construct once from independently admitted host policy, before user turns.
+/// The template has no task and contains no model credential or grant ID.
+pub struct Template {
+    config: Config,
+    binding: Hash,
+}
+
+impl Template {
+    pub fn new(mut config: Config) -> Result<Self> {
+        ensure!(
+            config.task.is_empty(),
+            "worker template must not contain a turn task"
+        );
+        config.task = "template validation".into();
+        json_harness::validate(&config)?;
+        config.task.clear();
+        // Struct serialization order is part of this explicitly versioned
+        // contract. Tool/schema strings remain exact bytes, including whitespace.
+        let binding = Hash::of(&serde_json::to_vec(&(VERSION, &config))?);
+        Ok(Self { config, binding })
+    }
+
+    pub fn binding(&self) -> &Hash {
+        &self.binding
+    }
+
+    /// Immutable admitted policy, without turn data or credentials.
+    pub fn policy(&self) -> &Config {
+        &self.config
+    }
+
+    /// The host ledger supplies the reservation. Only context/message become
+    /// guest data; all model/tool/persona fields remain the admitted template.
+    /// The caller must separately mint a fresh child-bound broker grant, enforce
+    /// these ceilings in warden, and bind the template hash in the parent permit.
+    pub fn arguments(&self, turn: &ReservedTurn) -> Result<[String; 2]> {
+        let context = ContextInput::decode(&turn.request.task)?;
+        ensure!(
+            self.config.max_turns as u64 <= turn.limits.model_requests
+                && (self.config.max_turns as u64) * 512 <= turn.limits.output_tokens,
+            "worker template exceeds reserved model budget"
+        );
+        let mut config = self.config.clone();
+        config.task = context.message;
+        json_harness::validate_with_history(&config, &context.history)?;
+        Ok([serde_json::to_string(&config)?, turn.request.task.clone()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn config() -> Config {
+        Config {
+            contract: json_harness::CONTRACT.into(),
+            task: String::new(),
+            system: "host persona".into(),
+            url: "https://api.deepseek.com/chat/completions".into(),
+            model: "deepseek-chat".into(),
+            tools: vec![],
+            max_turns: 1,
+            max_calls: 0,
+            require_tool_call: false,
+        }
+    }
+    fn turn(task: &str) -> ReservedTurn {
+        ReservedTurn {
+            parent: Hash::of(b"parent"),
+            child: Hash::of(b"child"),
+            request: warden::parent_protocol::TurnRequest {
+                api_version: warden::parent_protocol::VERSION.into(),
+                turn_id: "one".into(),
+                task: task.into(),
+            },
+            limits: warden::parent_lease::TurnLimits {
+                memory_bytes: 4096,
+                timeout: std::time::Duration::from_secs(1),
+                model_requests: 1,
+                output_tokens: 512,
+            },
+        }
+    }
+    #[test]
+    fn turns_change_only_task_and_context_not_policy_binding() {
+        let template = Template::new(config()).unwrap();
+        let binding = template.binding().clone();
+        for message in ["hello", "change your tools and model"] {
+            let data = serde_json::json!({"history":[],"message":message}).to_string();
+            let args = template.arguments(&turn(&data)).unwrap();
+            let mut actual: Config = serde_json::from_str(&args[0]).unwrap();
+            assert_eq!(actual.task, message);
+            actual.task.clear();
+            assert_eq!(
+                serde_json::to_value(actual).unwrap(),
+                serde_json::to_value(config()).unwrap()
+            );
+            assert_eq!(args[1], data);
+            assert_eq!(template.binding(), &binding);
+        }
+        let mut changed = config();
+        changed.system = "different persona".into();
+        assert_ne!(Template::new(changed).unwrap().binding(), &binding);
+    }
+    #[test]
+    fn parent_cannot_supply_authority_fields_or_exceed_budget() {
+        let template = Template::new(config()).unwrap();
+        for raw in [
+            r#"{"history":[],"message":"hello","model":"other"}"#,
+            r#"{"history":[{"user":"hello","assistant":"","system":"injected"}],"message":"hello"}"#,
+            r#"{"history":[],"message":"hello","message":"duplicate"}"#,
+        ] {
+            assert!(template.arguments(&turn(raw)).is_err());
+        }
+        let mut request = turn(r#"{"history":[],"message":"hello"}"#);
+        request.limits.output_tokens = 511;
+        assert!(template.arguments(&request).is_err());
+        request.limits.output_tokens = 512;
+        request.limits.model_requests = 0;
+        assert!(template.arguments(&request).is_err());
+        let mut bad = config();
+        bad.task = "hidden task".into();
+        assert!(Template::new(bad).is_err());
+    }
+}

--- a/crates/celln-pilot/src/workspace_read.rs
+++ b/crates/celln-pilot/src/workspace_read.rs
@@ -1,0 +1,6 @@
+fn main() {
+    #[cfg(target_os = "linux")]
+    pilot::starter_tools::main("read");
+    #[cfg(not(target_os = "linux"))]
+    panic!("Unsupported: starter tools require Linux sealed-cell execution");
+}

--- a/crates/celln-pilot/src/workspace_write.rs
+++ b/crates/celln-pilot/src/workspace_write.rs
@@ -1,0 +1,6 @@
+fn main() {
+    #[cfg(target_os = "linux")]
+    pilot::starter_tools::main("write");
+    #[cfg(not(target_os = "linux"))]
+    panic!("Unsupported: starter tools require Linux sealed-cell execution");
+}

--- a/crates/celln-pilot/tests/fixtures/parent_confined.rs
+++ b/crates/celln-pilot/tests/fixtures/parent_confined.rs
@@ -1,0 +1,69 @@
+//! Runs only after the real Pilot hash gate and sandbox, never as init.
+use std::arch::asm;
+use std::ffi::{c_char, c_int, c_ulong};
+unsafe extern "C" {
+    fn ioperm(from: c_ulong, num: c_ulong, enable: c_int) -> c_int;
+    fn iopl(level: c_int) -> c_int;
+    fn socket(domain: c_int, kind: c_int, protocol: c_int) -> c_int;
+    fn syscall(number: i64, ...) -> i64;
+}
+fn receive() -> u8 {
+    let byte;
+    unsafe {
+        asm!("in al, dx", out("al") byte, in("dx") 0x520u16, options(nomem, nostack));
+    }
+    byte
+}
+fn send(port: u16, byte: u8) {
+    unsafe {
+        asm!("out dx, al", in("al") byte, in("dx") port, options(nomem, nostack));
+    }
+}
+fn main() {
+    unsafe {
+        // No retained capabilities, including CAP_SYS_RAWIO, after exec.
+        let mut header = [0x20080522u32, 0];
+        let mut caps = [u32::MAX; 6];
+        assert_eq!(syscall(125, header.as_mut_ptr(), caps.as_mut_ptr()), 0);
+        assert_eq!(caps, [0; 6]);
+        for (start, count) in [(0x500, 3), (0x520, 4), (0x523, 1), (0x510, 1)] {
+            assert_eq!(ioperm(start, count, 1), -1);
+        }
+        assert_eq!(iopl(3), -1);
+        assert_eq!(socket(2, 1, 0), -1);
+        // Attempt to recreate a raw-I/O device (mknod, /dev/port).
+        assert_eq!(
+            syscall(
+                133,
+                c"/tmp/port".as_ptr() as *const c_char,
+                0o20600u32,
+                0x104u64
+            ),
+            -1
+        );
+    }
+    for path in ["/dev/port", "/dev/mem", "/dev/kmem"] {
+        assert!(std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .is_err());
+    }
+    assert!(std::fs::write("/parent", b"tamper").is_err());
+    let mut remembered = Vec::new();
+    for turn in 1..=3 {
+        let len = u32::from_le_bytes(std::array::from_fn(|_| receive())) as usize;
+        assert!((1..=8192).contains(&len));
+        let input: Vec<u8> = (0..len).map(|_| receive()).collect();
+        if let Some(value) = input.strip_prefix(b"remember:") {
+            remembered = value.to_vec();
+        } else {
+            assert_eq!(input, b"recall");
+        }
+        let response = format!("confined:{turn}:{}", String::from_utf8_lossy(&remembered));
+        for byte in response.bytes() {
+            send(0x521, byte);
+        }
+        send(0x522, 1);
+    }
+}

--- a/crates/celln-pilot/tests/fixtures/turn_echo.rs
+++ b/crates/celln-pilot/tests/fixtures/turn_echo.rs
@@ -1,0 +1,14 @@
+//! Deterministic worker fixture, not an LLM or a Harness emulator.
+fn main() {
+    let task = std::env::args().nth(1).expect("one task argument required");
+    assert!(task.len() <= 2048);
+    if task.contains("block-child") {
+        use std::io::Write;
+        println!("CHILD_BUSY_ENTERED");
+        std::io::stdout().flush().unwrap();
+        loop {
+            std::hint::spin_loop();
+        }
+    }
+    print!("{task}");
+}

--- a/crates/celln-spec/Cargo.toml
+++ b/crates/celln-spec/Cargo.toml
@@ -11,6 +11,7 @@ description = "The cell spec: what a user writes to describe an agent's cell."
 name = "celln_spec"
 
 [dependencies]
+celln-manifest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true

--- a/crates/celln-spec/src/configuration.rs
+++ b/crates/celln-spec/src/configuration.rs
@@ -1,0 +1,199 @@
+//! Versioned execution configuration fingerprint, not admission or authority.
+use crate::ExecutionRequest;
+use celln_manifest::Hash;
+use serde::Serialize;
+use serde_json::Value;
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ConfigurationRole {
+    OneShot,
+    Parent,
+    Worker,
+}
+
+impl ExecutionRequest {
+    /// Hash the complete normalized request with a protocol and role domain.
+    /// No identity, argument, input, model grant or authority field is removed.
+    /// Object keys sort lexically; arrays retain order; scalar encoding is JSON
+    /// as emitted by serde_json. This is not RFC 8785/JCS. Future changes to
+    /// normalization require a new protocol version and new operator approval.
+    /// Transport-specific size limits must be enforced before deserialization;
+    /// hashing adds no new size restriction to existing local execution paths.
+    ///
+    /// Worker grants/turn-specific arguments cannot be substituted under this
+    /// fingerprint: a future worker-template contract must separately define
+    /// its host-derived fields and bind the unchanged authority configuration.
+    pub fn configuration_binding(&self, role: ConfigurationRole) -> Result<Hash, String> {
+        if !self.problems().is_empty() {
+            return Err("invalid execution configuration".into());
+        }
+        let value = serde_json::to_value(("celln.execution-configuration/v1", role, self))
+            .map_err(|_| "invalid execution configuration")?;
+        let mut bytes = Vec::new();
+        canonical(&value, &mut bytes).map_err(|_| "invalid execution configuration")?;
+        Ok(Hash::of(&bytes))
+    }
+}
+
+fn canonical(value: &Value, bytes: &mut Vec<u8>) -> serde_json::Result<()> {
+    match value {
+        Value::Object(map) => {
+            bytes.push(b'{');
+            let mut entries: Vec<_> = map.iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(b.0));
+            for (index, (key, value)) in entries.into_iter().enumerate() {
+                if index != 0 {
+                    bytes.push(b',');
+                }
+                serde_json::to_writer(&mut *bytes, key)?;
+                bytes.push(b':');
+                canonical(value, bytes)?;
+            }
+            bytes.push(b'}');
+        }
+        Value::Array(values) => {
+            bytes.push(b'[');
+            for (index, value) in values.iter().enumerate() {
+                if index != 0 {
+                    bytes.push(b',');
+                }
+                canonical(value, bytes)?;
+            }
+            bytes.push(b']');
+        }
+        _ => serde_json::to_writer(bytes, value)?,
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn request() -> ExecutionRequest {
+        serde_json::from_value(serde_json::json!({
+            "apiVersion":"celln.dev/v1alpha1", "id":"run-one",
+            "workload":{"id":"run-one","caller":"tenant/one"},
+            "mote":{"hash":Hash::of(b"mote").0},
+            "tools":[{"alias":"/tools/run","hash":Hash::of(b"program").0}],
+            "invocation":{"alias":"/tools/run","args":["one","two"]},
+            "capabilities":{"workspace":"none","timeoutMs":1000,"memoryBytes":268435456,"outputBytes":1024},
+            "execution":{"lane":"agent","requireHardwareIsolation":true}
+        })).unwrap()
+    }
+    #[test]
+    fn direct_tool_has_no_harness_requirement_and_roles_cannot_be_swapped() {
+        let request = request();
+        assert!(request.harness.is_none());
+        let one = request
+            .configuration_binding(ConfigurationRole::OneShot)
+            .unwrap();
+        let parent = request
+            .configuration_binding(ConfigurationRole::Parent)
+            .unwrap();
+        let worker = request
+            .configuration_binding(ConfigurationRole::Worker)
+            .unwrap();
+        assert_ne!(one, parent);
+        assert_ne!(parent, worker);
+        assert_ne!(one, worker);
+    }
+    #[test]
+    fn identity_artifacts_arguments_and_authority_are_all_bound() {
+        let original = request();
+        let hash = original
+            .configuration_binding(ConfigurationRole::Worker)
+            .unwrap();
+        for pointer in [
+            "/id",
+            "/workload/id",
+            "/workload/caller",
+            "/mote/hash",
+            "/tools/0/hash",
+            "/invocation/args/0",
+            "/capabilities/timeoutMs",
+            "/capabilities/memoryBytes",
+            "/capabilities/outputBytes",
+        ] {
+            let mut value = serde_json::to_value(&original).unwrap();
+            let field = value.pointer_mut(pointer).unwrap();
+            *field = if pointer.ends_with("hash") {
+                serde_json::json!(Hash::of(b"other").0)
+            } else if field.is_string() {
+                serde_json::json!("changed")
+            } else {
+                serde_json::json!(field.as_u64().unwrap() + 1)
+            };
+            let changed: ExecutionRequest = serde_json::from_value(value).unwrap();
+            assert_ne!(
+                hash,
+                changed
+                    .configuration_binding(ConfigurationRole::Worker)
+                    .unwrap(),
+                "{pointer}"
+            );
+        }
+        let mut changed = original.clone();
+        changed.invocation.as_mut().unwrap().args.reverse();
+        assert_ne!(
+            hash,
+            changed
+                .configuration_binding(ConfigurationRole::Worker)
+                .unwrap()
+        );
+        changed = original;
+        changed.mote.as_mut().unwrap().hash = "latest".into();
+        assert!(changed
+            .configuration_binding(ConfigurationRole::Worker)
+            .is_err());
+    }
+    #[test]
+    fn immutable_inputs_and_workspace_are_bound() {
+        let mut request = request();
+        request.capabilities.workspace = crate::WorkspaceAccess::ReadOnly;
+        request.inputs.push(crate::ExecutionInput {
+            name: "facts".into(),
+            hash: Hash::of(b"data").0,
+            media_type: "text/plain".into(),
+            bytes: 4,
+        });
+        let original = request
+            .configuration_binding(ConfigurationRole::Worker)
+            .unwrap();
+        request.inputs[0].hash = Hash::of(b"next").0;
+        assert_ne!(
+            original,
+            request
+                .configuration_binding(ConfigurationRole::Worker)
+                .unwrap()
+        );
+        request.inputs[0].hash = Hash::of(b"data").0;
+        request.capabilities.workspace = crate::WorkspaceAccess::ReadWrite;
+        assert_ne!(
+            original,
+            request
+                .configuration_binding(ConfigurationRole::Worker)
+                .unwrap()
+        );
+    }
+    #[test]
+    fn canonical_json_sorts_nested_objects_but_preserves_arrays() {
+        let value: Value =
+            serde_json::from_str(r#"{"z":[2,1],"a":{"b":false,"a":"x\ny"}}"#).unwrap();
+        let mut bytes = Vec::new();
+        canonical(&value, &mut bytes).unwrap();
+        assert_eq!(bytes, br#"{"a":{"a":"x\ny","b":false},"z":[2,1]}"#);
+        let request = request();
+        let value = serde_json::to_value(&request).unwrap();
+        let reparsed: ExecutionRequest =
+            serde_json::from_str(&serde_json::to_string_pretty(&value).unwrap()).unwrap();
+        assert_eq!(
+            request
+                .configuration_binding(ConfigurationRole::Parent)
+                .unwrap(),
+            reparsed
+                .configuration_binding(ConfigurationRole::Parent)
+                .unwrap()
+        );
+    }
+}

--- a/crates/celln-spec/src/harness.rs
+++ b/crates/celln-spec/src/harness.rs
@@ -142,6 +142,42 @@ mod tests {
             "harness":{"contractVersion":"celln.reference-functions/v1","modelGrant":{"hash":hash},"model":"deepseek-chat","task":"use both tools","borrowedTools":[{"name":"add","path":"/add","hash":hash,"description":"add"},{"name":"multiply","path":"/multiply","hash":hash,"description":"multiply"}]}})
     }
     #[test]
+    fn configuration_binds_model_grant_closure_and_borrowed_tools() {
+        let original = wire();
+        let binding = |value| {
+            serde_json::from_value::<ExecutionRequest>(value)
+                .unwrap()
+                .configuration_binding(crate::ConfigurationRole::Worker)
+                .unwrap()
+        };
+        let expected = binding(original.clone());
+        for (pointer, replacement) in [
+            (
+                "/harness/modelGrant/hash",
+                json!(celln_manifest::Hash::of(b"other").0),
+            ),
+            (
+                "/tools/0/closure/hash",
+                json!(celln_manifest::Hash::of(b"other").0),
+            ),
+            (
+                "/harness/borrowedTools/0/hash",
+                json!(celln_manifest::Hash::of(b"other").0),
+            ),
+            (
+                "/harness/borrowedTools/0/description",
+                json!("changed description"),
+            ),
+            ("/harness/task", json!("another task")),
+            ("/harness/model", json!("another-model")),
+            ("/capabilities/egress/0", json!("https://api.example.com")),
+        ] {
+            let mut changed = original.clone();
+            *changed.pointer_mut(pointer).unwrap() = replacement;
+            assert_ne!(expected, binding(changed), "{pointer}");
+        }
+    }
+    #[test]
     fn versioned_binding_is_strict_and_bounded() {
         let value = wire();
         assert!(serde_json::from_value::<ExecutionRequest>(value.clone())

--- a/crates/celln-spec/src/lib.rs
+++ b/crates/celln-spec/src/lib.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+mod configuration;
 mod harness;
+pub use configuration::ConfigurationRole;
 pub use harness::{BorrowedTool, HarnessBinding, JsonHarnessOptions, JsonToolIo};
 
 /// A cell specification.

--- a/crates/celln-store/src/lib.rs
+++ b/crates/celln-store/src/lib.rs
@@ -8,6 +8,7 @@
 //! No KVM here — this is plain filesystem work and is fully tested.
 
 use celln_manifest::Hash;
+pub mod workspace;
 use std::fs;
 use std::io;
 use std::io::Read;

--- a/crates/celln-store/src/workspace.rs
+++ b/crates/celln-store/src/workspace.rs
@@ -1,0 +1,220 @@
+//! Bounded run-owned artifact data, not a host filesystem or execution grant.
+//! The owner retains this object across disposable turns. Broker admission must
+//! independently authorize each operation and bind its caller to the live child.
+//! This in-memory index does not claim process-crash durability.
+use celln_manifest::Hash;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Copy, Debug)]
+pub struct Limits {
+    pub files: usize,
+    pub file_bytes: usize,
+    pub total_bytes: usize,
+}
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum Error {
+    #[error("invalid workspace limits or artifact name")]
+    Invalid,
+    #[error("workspace belongs to another parent")]
+    WrongParent,
+    #[error("workspace revision changed; reconcile original write")]
+    StaleRevision,
+    #[error("workspace quota exceeded")]
+    Quota,
+    #[error("artifact not found")]
+    NotFound,
+}
+
+pub struct Workspace {
+    parent: Hash,
+    limits: Limits,
+    revision: u64,
+    bytes: usize,
+    artifacts: BTreeMap<String, Vec<u8>>,
+}
+
+impl Workspace {
+    pub fn new(parent: Hash, limits: Limits) -> Result<Self, Error> {
+        if limits.files == 0
+            || limits.files > 256
+            || limits.file_bytes == 0
+            || limits.file_bytes > 65536
+            || limits.total_bytes < limits.file_bytes
+            || limits.total_bytes > 1048576
+        {
+            return Err(Error::Invalid);
+        }
+        Ok(Self {
+            parent,
+            limits,
+            revision: 0,
+            bytes: 0,
+            artifacts: BTreeMap::new(),
+        })
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    fn check(&self, parent: &Hash, name: &str) -> Result<(), Error> {
+        if *parent != self.parent {
+            return Err(Error::WrongParent);
+        }
+        // Logical UTF-8 names are deliberately narrower than filesystem paths.
+        // No normalization aliases, absolute paths, backslashes or dot segments.
+        if name.is_empty()
+            || name.len() > 256
+            || name.split('/').any(|part| {
+                part.is_empty()
+                    || part == "."
+                    || part == ".."
+                    || part.len() > 64
+                    || !part
+                        .bytes()
+                        .all(|c| c.is_ascii_alphanumeric() || b"-_.".contains(&c))
+            })
+        {
+            return Err(Error::Invalid);
+        }
+        Ok(())
+    }
+
+    pub fn read(&self, parent: &Hash, name: &str) -> Result<&[u8], Error> {
+        self.check(parent, name)?;
+        self.artifacts
+            .get(name)
+            .map(Vec::as_slice)
+            .ok_or(Error::NotFound)
+    }
+
+    /// Atomic replacement with explicit optimistic concurrency. A lost reply
+    /// cannot silently repeat a write against a changed workspace. Reads permit
+    /// reconciliation; no operation changes the parent identity or grants exec.
+    pub fn write(
+        &mut self,
+        parent: &Hash,
+        expected_revision: u64,
+        name: &str,
+        data: &[u8],
+    ) -> Result<u64, Error> {
+        self.check(parent, name)?;
+        if expected_revision != self.revision {
+            return Err(Error::StaleRevision);
+        }
+        let old = self.artifacts.get(name);
+        let new_bytes = self.bytes - old.map_or(0, Vec::len);
+        let new_bytes = new_bytes.checked_add(data.len()).ok_or(Error::Quota)?;
+        if data.len() > self.limits.file_bytes
+            || new_bytes > self.limits.total_bytes
+            || (old.is_none() && self.artifacts.len() >= self.limits.files)
+        {
+            return Err(Error::Quota);
+        }
+        let revision = self.revision.checked_add(1).ok_or(Error::Quota)?;
+        self.artifacts.insert(name.into(), data.to_vec());
+        self.bytes = new_bytes;
+        self.revision = revision;
+        Ok(revision)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn workspace() -> (Hash, Workspace) {
+        let parent = Hash::of(b"parent");
+        let workspace = Workspace::new(
+            parent.clone(),
+            Limits {
+                files: 2,
+                file_bytes: 8,
+                total_bytes: 12,
+            },
+        )
+        .unwrap();
+        (parent, workspace)
+    }
+
+    #[test]
+    fn retains_data_across_borrowers_and_refuses_cross_parent_or_stale_writes() {
+        let (parent, mut workspace) = workspace();
+        assert_eq!(workspace.write(&parent, 0, "notes/a.txt", b"violet"), Ok(1));
+        assert_eq!(
+            workspace.read(&parent, "notes/a.txt"),
+            Ok(b"violet".as_slice())
+        );
+        let other = Hash::of(b"other");
+        assert_eq!(
+            workspace.read(&other, "notes/a.txt"),
+            Err(Error::WrongParent)
+        );
+        assert_eq!(
+            workspace.write(&other, 1, "notes/a.txt", b"orange"),
+            Err(Error::WrongParent)
+        );
+        assert_eq!(
+            workspace.write(&parent, 0, "notes/a.txt", b"orange"),
+            Err(Error::StaleRevision)
+        );
+        assert_eq!(workspace.revision(), 1);
+        assert_eq!(
+            workspace.read(&parent, "notes/a.txt"),
+            Ok(b"violet".as_slice())
+        );
+    }
+
+    #[test]
+    fn quota_failure_is_atomic_and_replacements_account_for_old_bytes() {
+        let (parent, mut workspace) = workspace();
+        workspace.write(&parent, 0, "a", b"12345678").unwrap();
+        assert_eq!(
+            workspace.write(&parent, 1, "b", b"12345"),
+            Err(Error::Quota)
+        );
+        assert_eq!(workspace.revision(), 1);
+        workspace.write(&parent, 1, "a", b"12").unwrap();
+        workspace.write(&parent, 2, "b", b"12345678").unwrap();
+        assert_eq!(workspace.write(&parent, 3, "c", b""), Err(Error::Quota));
+        assert_eq!(
+            workspace.write(&parent, 3, "a", b"123456789"),
+            Err(Error::Quota)
+        );
+        assert_eq!(workspace.read(&parent, "a"), Ok(b"12".as_slice()));
+    }
+
+    #[test]
+    fn artifact_names_never_resolve_to_host_paths() {
+        let (parent, mut workspace) = workspace();
+        for name in [
+            "",
+            "/etc/passwd",
+            "../secret",
+            "a/../b",
+            "a//b",
+            "a/",
+            "./a",
+            "a\\b",
+            "a\0b",
+            "%2e%2e/a",
+            "a:stream",
+        ] {
+            assert_eq!(
+                workspace.write(&parent, 0, name, b"x"),
+                Err(Error::Invalid),
+                "{name:?}"
+            );
+        }
+        assert_eq!(workspace.revision(), 0);
+        assert!(Workspace::new(
+            parent,
+            Limits {
+                files: 257,
+                file_bytes: 1,
+                total_bytes: 1
+            }
+        )
+        .is_err());
+    }
+}

--- a/crates/celln-warden/Cargo.toml
+++ b/crates/celln-warden/Cargo.toml
@@ -22,6 +22,7 @@ kvm = ["dep:kvm-ioctls", "dep:kvm-bindings", "dep:libc"]
 tempfile.workspace = true
 celln-control.workspace = true
 celln-manifest.workspace = true
+celln-store.workspace = true
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/celln-warden/src/egress.rs
+++ b/crates/celln-warden/src/egress.rs
@@ -11,6 +11,15 @@ use std::time::Duration;
 mod post;
 pub use post::JsonPostGrant;
 
+/// Independent credential-free GET authority for native starter tools.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GetGrant {
+    pub allow_hosts: Vec<String>,
+    pub max_requests: usize,
+    pub max_response_bytes: usize,
+    pub timeout: Duration,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HttpPolicy {
     /// Exact DNS names this cell may contact. Empty means no egress.
@@ -21,6 +30,11 @@ pub struct HttpPolicy {
     /// Additional operator-owned authority. A GET host grant never implies
     /// POST or access to provider credentials.
     pub json_posts: Vec<JsonPostGrant>,
+    /// Independent run-data authority; HTTPS/model grants never imply this.
+    pub workspace: Option<crate::workspace_broker::Grant>,
+    /// None preserves the legacy shared GET/model budget. Some uses an
+    /// independent GET budget; an empty allowlist explicitly denies all GETs.
+    pub get: Option<GetGrant>,
 }
 
 impl HttpPolicy {
@@ -31,6 +45,8 @@ impl HttpPolicy {
             max_response_bytes: 1 << 20,
             timeout: Duration::from_secs(10),
             json_posts: Vec::new(),
+            workspace: None,
+            get: None,
         }
     }
 }
@@ -56,6 +72,7 @@ pub enum FetchDenied {
 pub struct HttpBroker {
     policy: HttpPolicy,
     used: usize,
+    get_used: usize,
     post_output_reserved: std::collections::BTreeMap<String, u64>,
 }
 
@@ -64,6 +81,7 @@ impl HttpBroker {
         Self {
             policy,
             used: 0,
+            get_used: 0,
             post_output_reserved: Default::default(),
         }
     }
@@ -138,20 +156,67 @@ impl HttpBroker {
             ));
         }
         if raw.starts_with('{') {
+            let value: serde_json::Value = serde_json::from_str(raw)
+                .map_err(|_| FetchDenied::Fetch("invalid broker request".into()))?;
+            if value.get("apiVersion").and_then(|v| v.as_str()) == Some("celln.workspace/v1") {
+                return self
+                    .policy
+                    .workspace
+                    .as_ref()
+                    .ok_or_else(|| FetchDenied::Fetch("workspace access not granted".into()))?
+                    .request(raw)
+                    .map_err(FetchDenied::Fetch);
+            }
             return self.post_json(raw);
         }
         let mut url = raw.to_owned();
         for _ in 0..=5 {
-            if self.used >= self.policy.max_requests {
+            let (max_requests, max_response_bytes, timeout, used) = match &self.policy.get {
+                Some(grant) => (
+                    grant.max_requests,
+                    grant.max_response_bytes,
+                    grant.timeout,
+                    self.get_used,
+                ),
+                None => (
+                    self.policy.max_requests,
+                    self.policy.max_response_bytes,
+                    self.policy.timeout,
+                    self.used,
+                ),
+            };
+            if used >= max_requests {
                 return Err(FetchDenied::Budget);
+            }
+            // Validate the independent GET allowlist before any DNS or I/O.
+            if let Some(grant) = &self.policy.get {
+                let authority = url
+                    .strip_prefix("https://")
+                    .ok_or(FetchDenied::Scheme)?
+                    .split('/')
+                    .next()
+                    .unwrap_or_default();
+                let host = authority.split(':').next().unwrap_or_default();
+                if !grant
+                    .allow_hosts
+                    .iter()
+                    .any(|allowed| allowed.eq_ignore_ascii_case(host))
+                {
+                    return Err(FetchDenied::Host(host.into()));
+                }
             }
             let (host, ip) = self.authorize(&url)?;
             self.used += 1;
+            self.get_used += 1;
             let header =
                 tempfile::NamedTempFile::new().map_err(|e| FetchDenied::Fetch(e.to_string()))?;
             let out = celln_control::process::output_with_timeout(
                 Command::new("curl")
                     .args([
+                        "--disable",
+                        "--globoff",
+                        "--noproxy",
+                        "*",
                         "--silent",
                         "--show-error",
                         "--proto",
@@ -160,15 +225,15 @@ impl HttpBroker {
                         "0",
                     ])
                     .arg("--max-time")
-                    .arg(self.policy.timeout.as_secs().to_string())
+                    .arg(timeout.as_secs_f64().to_string())
                     .arg("--max-filesize")
-                    .arg(self.policy.max_response_bytes.to_string())
+                    .arg(max_response_bytes.to_string())
                     .arg("--resolve")
                     .arg(format!("{host}:443:{ip}"))
                     .arg("--dump-header")
                     .arg(header.path())
                     .arg(&url),
-                Some(self.policy.timeout),
+                Some(timeout),
             )
             .map_err(|e| FetchDenied::Fetch(e.to_string()))?;
             let headers = std::fs::read_to_string(header.path()).unwrap_or_default();
@@ -177,7 +242,7 @@ impl HttpBroker {
                     String::from_utf8_lossy(&out.stderr).trim().into(),
                 ));
             }
-            if out.stdout.len() > self.policy.max_response_bytes {
+            if out.stdout.len() > max_response_bytes {
                 return Err(FetchDenied::Fetch("response exceeded byte budget".into()));
             }
             let (status, location) = response_status_and_location(&headers)

--- a/crates/celln-warden/src/egress_post.rs
+++ b/crates/celln-warden/src/egress_post.rs
@@ -189,7 +189,12 @@ impl HttpBroker {
         let request = parse(raw)?;
         let grant = self.grant_for(&request)?.clone();
         let output_tokens = validate_chat(&request.body, &grant)?;
-        if self.used >= self.policy.max_requests {
+        let used = if self.policy.get.is_some() {
+            self.used - self.get_used
+        } else {
+            self.used
+        };
+        if used >= self.policy.max_requests {
             return Err(FetchDenied::Budget);
         }
         let reserved = self
@@ -290,6 +295,37 @@ mod tests {
     fn chat_body() -> serde_json::Value {
         serde_json::json!({"model":"approved","stream":false,"max_tokens":512,
             "messages":[{"role":"user","content":"hello"}]})
+    }
+
+    #[test]
+    fn independent_get_budget_cannot_buy_more_model_requests() {
+        let mut policy = model_policy();
+        policy.max_requests = 1;
+        policy.get = Some(crate::egress::GetGrant {
+            allow_hosts: vec!["fetch.invalid".into()],
+            max_requests: 3,
+            max_response_bytes: 1024,
+            timeout: std::time::Duration::from_secs(1),
+        });
+        let mut broker = HttpBroker::new(policy);
+        // Model allowance spent, GET allowance partially spent. Refusal must
+        // occur before DNS or credential access, regardless of GET headroom.
+        broker.used = 2;
+        broker.get_used = 1;
+        let request = serde_json::json!({"apiVersion":"celln.fetch/v1","method":"POST",
+            "url":"https://provider.invalid/chat","body":chat_body()})
+        .to_string();
+        assert_eq!(broker.fetch(&request), Err(FetchDenied::Budget));
+        assert_eq!(
+            broker.fetch("https://provider.invalid/chat"),
+            Err(FetchDenied::Host("provider.invalid".into()))
+        );
+        broker.get_used = 3;
+        broker.used = 4;
+        assert_eq!(
+            broker.fetch("https://fetch.invalid/file"),
+            Err(FetchDenied::Budget)
+        );
     }
 
     #[test]

--- a/crates/celln-warden/src/lib.rs
+++ b/crates/celln-warden/src/lib.rs
@@ -10,6 +10,14 @@
 //! feature-gated stub, because it needs bare metal.
 
 pub mod egress;
+pub mod parent_child_control;
+pub mod parent_journal;
+pub mod parent_lease;
+pub mod parent_mailbox;
+pub mod parent_owner;
+pub mod parent_permit;
+pub mod parent_protocol;
+pub mod parent_registry;
 pub mod ratchet;
 pub mod vmm;
 /// Maximum one-shot invocation data, including bounded immutable inputs.
@@ -136,3 +144,4 @@ mod tests {
         assert_eq!(cell.phase(), Phase::Dissolve);
     }
 }
+pub mod workspace_broker;

--- a/crates/celln-warden/src/parent_child_control.rs
+++ b/crates/celln-warden/src/parent_child_control.rs
@@ -1,0 +1,227 @@
+//! Exact-identity cancellation rendezvous for an admitted parent's child.
+//! Not admission, a durable journal, or proof of child teardown. The host owner
+//! authenticates callers, reserves/persists the turn before registration, and
+//! retains this slot until the actual child is joined and its result recorded.
+use crate::{parent_lease::ReservedTurn, parent_protocol::TurnRequest};
+use celln_control::Control;
+use celln_manifest::Hash;
+use std::{collections::BTreeSet, sync::Mutex};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Identity {
+    pub parent: Hash,
+    pub turn: String,
+    pub child: Hash,
+}
+
+struct Active {
+    identity: Identity,
+    control: Control,
+}
+
+#[derive(Default)]
+struct State {
+    active: Option<Active>,
+    seen: BTreeSet<String>,
+}
+
+pub struct ChildControlSlot {
+    parent: Hash,
+    control: Control,
+    state: Mutex<State>,
+}
+
+impl ChildControlSlot {
+    pub fn new(parent: Hash, control: Control) -> Self {
+        Self {
+            parent,
+            control,
+            state: Mutex::new(State::default()),
+        }
+    }
+
+    /// A registered identity is consumed for this owner even if work later
+    /// fails. Registration never resets the ledger or revives an old turn.
+    pub fn register(&self, turn: &ReservedTurn) -> Result<(Identity, Control), &'static str> {
+        let encoded = serde_json::to_vec(&turn.request).map_err(|_| "invalid turn")?;
+        TurnRequest::decode(&encoded).map_err(|_| "invalid turn")?;
+        let child = Hash::of(
+            &serde_json::to_vec(&(&self.parent.0, &turn.request.turn_id))
+                .map_err(|_| "invalid identity")?,
+        );
+        if turn.parent != self.parent || turn.child != child || turn.limits.timeout.is_zero() {
+            return Err("child control differs from reservation");
+        }
+        let mut state = self.state.lock().map_err(|_| "child control unavailable")?;
+        self.control.check().map_err(|_| "parent stopped")?;
+        if state.active.is_some()
+            || state.seen.len() >= 1024
+            || state.seen.contains(&turn.request.turn_id)
+        {
+            return Err("active, exhausted or repeated child identity");
+        }
+        let control = self
+            .control
+            .child(turn.limits.timeout)
+            .map_err(|_| "invalid child lifetime")?;
+        let identity = Identity {
+            parent: self.parent.clone(),
+            turn: turn.request.turn_id.clone(),
+            child,
+        };
+        state.seen.insert(identity.turn.clone());
+        state.active = Some(Active {
+            identity: identity.clone(),
+            control: control.clone(),
+        });
+        Ok((identity, control))
+    }
+
+    /// Signal only the exact registered child while holding the identity lock.
+    /// Repeated exact cancellation is harmless; stale/mismatched requests never
+    /// select another child. Success is NOT a teardown acknowledgement.
+    pub fn cancel(&self, expected: &Identity) -> Result<(), &'static str> {
+        let state = self.state.lock().map_err(|_| "child control unavailable")?;
+        let active = state.active.as_ref().ok_or("no registered child")?;
+        if active.identity != *expected {
+            return Err("child identity mismatch");
+        }
+        active.control.cancel();
+        Ok(())
+    }
+
+    /// Remove the rendezvous only after the caller has independently confirmed
+    /// child teardown and recorded its outcome. This method frees no capacity,
+    /// acknowledges no hardware property, and does not refund the seen identity.
+    pub fn retire(&self, expected: &Identity) -> Result<(), &'static str> {
+        let mut state = self.state.lock().map_err(|_| "child control unavailable")?;
+        if !state
+            .active
+            .as_ref()
+            .is_some_and(|active| active.identity == *expected)
+        {
+            return Err("child identity mismatch");
+        }
+        state.active = None;
+        Ok(())
+    }
+}
+
+impl Drop for ChildControlSlot {
+    fn drop(&mut self) {
+        // Exclusive destruction can still signal a poisoned slot's child.
+        // Its owning worker must independently join; this is not teardown.
+        let state = self
+            .state
+            .get_mut()
+            .unwrap_or_else(|error| error.into_inner());
+        if let Some(active) = &state.active {
+            active.control.cancel();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parent_lease::TurnLimits;
+    use std::{
+        sync::{Arc, Barrier},
+        time::Duration,
+    };
+
+    fn reservation(parent: &Hash, id: &str) -> ReservedTurn {
+        ReservedTurn {
+            parent: parent.clone(),
+            child: Hash::of(&serde_json::to_vec(&(&parent.0, id)).unwrap()),
+            request: TurnRequest {
+                api_version: crate::parent_protocol::VERSION.into(),
+                turn_id: id.into(),
+                task: "data".into(),
+            },
+            limits: TurnLimits {
+                memory_bytes: 4096,
+                timeout: Duration::from_secs(30),
+                model_requests: 1,
+                output_tokens: 32,
+            },
+        }
+    }
+
+    #[test]
+    fn exact_cancel_does_not_release_slot_refund_identity_or_stop_parent() {
+        let parent = Hash::of(b"parent");
+        let control = Control::new(Duration::from_secs(60)).unwrap();
+        let slot = ChildControlSlot::new(parent.clone(), control.clone());
+        let first = reservation(&parent, "first");
+        let (id, child) = slot.register(&first).unwrap();
+        slot.cancel(&id).unwrap();
+        slot.cancel(&id).unwrap();
+        assert!(child.check().is_err());
+        assert!(control.check().is_ok());
+        assert!(slot.register(&reservation(&parent, "next")).is_err());
+        slot.retire(&id).unwrap();
+        assert!(slot.register(&first).is_err());
+        assert!(slot.cancel(&id).is_err());
+        assert!(slot.register(&reservation(&parent, "next")).is_ok());
+    }
+
+    #[test]
+    fn late_cancel_and_retire_cannot_touch_the_next_child() {
+        let parent = Hash::of(b"parent");
+        let slot = Arc::new(ChildControlSlot::new(
+            parent.clone(),
+            Control::new(Duration::from_secs(60)).unwrap(),
+        ));
+        let (old, _) = slot.register(&reservation(&parent, "old")).unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+        let delayed = slot.clone();
+        let wait = barrier.clone();
+        let stale = old.clone();
+        let caller = std::thread::spawn(move || {
+            wait.wait();
+            assert!(delayed.cancel(&stale).is_err());
+            assert!(delayed.retire(&stale).is_err());
+        });
+        slot.retire(&old).unwrap();
+        let (next, child) = slot.register(&reservation(&parent, "next")).unwrap();
+        barrier.wait();
+        caller.join().unwrap();
+        assert!(child.check().is_ok());
+        slot.cancel(&next).unwrap();
+        assert!(child.check().is_err());
+    }
+
+    #[test]
+    fn changed_bindings_and_stopped_parent_refuse_registration() {
+        let parent = Hash::of(b"parent");
+        let control = Control::new(Duration::from_secs(60)).unwrap();
+        let slot = ChildControlSlot::new(parent.clone(), control.clone());
+        assert!(slot
+            .register(&reservation(&Hash::of(b"other"), "turn"))
+            .is_err());
+        let mut turn = reservation(&parent, "turn");
+        turn.child = Hash::of(b"injected");
+        assert!(slot.register(&turn).is_err());
+        let (identity, child) = slot.register(&reservation(&parent, "turn")).unwrap();
+        let mut wrong = identity.clone();
+        wrong.parent = Hash::of(b"other");
+        assert!(slot.cancel(&wrong).is_err());
+        assert!(child.check().is_ok());
+        control.cancel();
+        assert!(child.check().is_err());
+        slot.retire(&identity).unwrap();
+        assert!(slot.register(&reservation(&parent, "next")).is_err());
+    }
+
+    #[test]
+    fn losing_the_slot_signals_child_without_cancelling_parent() {
+        let parent = Hash::of(b"parent");
+        let control = Control::new(Duration::from_secs(60)).unwrap();
+        let slot = ChildControlSlot::new(parent.clone(), control.clone());
+        let (_, child) = slot.register(&reservation(&parent, "active")).unwrap();
+        drop(slot);
+        assert!(child.check().is_err());
+        assert!(control.check().is_ok());
+    }
+}

--- a/crates/celln-warden/src/parent_journal.rs
+++ b/crates/celln-warden/src/parent_journal.rs
@@ -1,0 +1,488 @@
+//! Durable parent incarnation tombstone and immutable turn stages. This is
+//! audit/replay prevention, NOT a guest checkpoint. Creation refuses an existing
+//! incarnation; after owner loss callers must report context loss, not resume.
+use crate::{parent_lease::ReservedTurn, parent_protocol::TurnRequest};
+use celln_manifest::Hash;
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+};
+
+pub struct ParentJournal {
+    directory: PathBuf,
+    parent: Hash,
+    reservations: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Reservation {
+    pub version: u8,
+    pub parent: Hash,
+    pub child: Hash,
+    pub request: TurnRequest,
+    pub memory_bytes: u64,
+    pub timeout_nanos: u128,
+    pub model_requests: u64,
+    pub output_tokens: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DestroyedRecord {
+    pub version: u8,
+    pub parent: Hash,
+    pub child: Hash,
+    pub turn_id: String,
+    pub succeeded: bool,
+    pub answer: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CommittedRecord {
+    version: u8,
+    parent: Hash,
+    child: Hash,
+    turn_id: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ParentRecord {
+    version: u8,
+    parent: Hash,
+    recovery: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OwnerRecord {
+    version: u8,
+    parent: Hash,
+    principal: String,
+}
+
+/// Authorize historical reads only. Never reconstruct an owner from this record
+/// or accept its principal from an unauthenticated request body.
+pub fn historical_owner(root: &Path, parent: &Hash, principal: &str) -> io::Result<bool> {
+    let directory = parent_directory(root, parent);
+    let identity: ParentRecord = read_record(&directory.join("parent.json"))?;
+    let owner: OwnerRecord = read_record(&directory.join("owner.json"))?;
+    if identity.version != 1
+        || identity.parent != *parent
+        || identity.recovery != "context-lost-without-live-owner"
+        || owner.version != 1
+        || owner.parent != *parent
+        || !valid_principal(&owner.principal)
+    {
+        return Err(invalid());
+    }
+    Ok(owner.principal == principal)
+}
+
+fn valid_principal(principal: &str) -> bool {
+    !principal.is_empty() && principal.len() <= 512 && !principal.chars().any(char::is_control)
+}
+
+/// Durable observations only. None of these stages proves that a live parent
+/// still exists or permits replay. Missing records are not permission to spawn.
+#[derive(Debug, Serialize)]
+#[serde(tag = "stage", content = "record", rename_all = "kebab-case")]
+pub enum TurnStatus {
+    Reserved(Reservation),
+    ChildDestroyed(DestroyedRecord),
+    ParentCommitted(DestroyedRecord),
+}
+
+fn read_record<T: serde::de::DeserializeOwned>(path: &Path) -> io::Result<T> {
+    let mut bytes = Vec::new();
+    fs::File::open(path)?.take(16385).read_to_end(&mut bytes)?;
+    if bytes.len() > 16384 {
+        return Err(invalid());
+    }
+    serde_json::from_slice(&bytes).map_err(|_| invalid())
+}
+
+fn parent_directory(root: &Path, parent: &Hash) -> PathBuf {
+    root.join(
+        Hash::of(parent.0.as_bytes())
+            .0
+            .trim_start_matches("blake3:"),
+    )
+}
+
+/// Inspect an old incarnation without reopening it for execution. The caller
+/// must independently consult its live-owner registry; absent that owner, report
+/// context loss even when this returns ParentCommitted. Reads concurrent with
+/// the owner can lag publication, so this is not a linearizable serving status.
+pub fn inspect_turn(root: &Path, parent: &Hash, turn: &str) -> io::Result<TurnStatus> {
+    let journal = ParentJournal {
+        directory: parent_directory(root, parent),
+        parent: parent.clone(),
+        reservations: 0,
+    };
+    let identity: ParentRecord = read_record(&journal.directory.join("parent.json"))?;
+    if identity.version != 1
+        || identity.parent != *parent
+        || identity.recovery != "context-lost-without-live-owner"
+    {
+        return Err(invalid());
+    }
+    let reservation = journal.reservation(turn)?;
+    let committed = match read_record::<CommittedRecord>(
+        &journal
+            .directory
+            .join(ParentJournal::filename(turn, "committed")),
+    ) {
+        Ok(record) => {
+            if record.version != 1
+                || record.parent != *parent
+                || record.child != reservation.child
+                || record.turn_id != turn
+            {
+                return Err(invalid());
+            }
+            true
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+        Err(error) => return Err(error),
+    };
+    match journal.destroyed(turn, &reservation.child) {
+        Ok(record) if committed => Ok(TurnStatus::ParentCommitted(record)),
+        Ok(record) => Ok(TurnStatus::ChildDestroyed(record)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound && !committed => {
+            Ok(TurnStatus::Reserved(reservation))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn invalid() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        "invalid parent journal identity or transition",
+    )
+}
+fn publish(directory: &Path, name: &str, value: &impl Serialize) -> io::Result<()> {
+    let bytes = serde_json::to_vec(value).map_err(|_| invalid())?;
+    if bytes.len() > 16384 {
+        return Err(invalid());
+    }
+    let mut file = tempfile::NamedTempFile::new_in(directory)?;
+    file.write_all(&bytes)?;
+    file.as_file().sync_all()?;
+    file.persist_noclobber(directory.join(name))
+        .map_err(|e| e.error)?;
+    fs::File::open(directory)?.sync_all()
+}
+
+impl ParentJournal {
+    /// Persist the independently authenticated owner before runtime creation.
+    /// A missing/partial record permits no historical access and no replay.
+    pub fn bind_owner(&self, principal: &str) -> io::Result<()> {
+        if !valid_principal(principal) {
+            return Err(invalid());
+        }
+        publish(
+            &self.directory,
+            "owner.json",
+            &OwnerRecord {
+                version: 1,
+                parent: self.parent.clone(),
+                principal: principal.into(),
+            },
+        )
+    }
+
+    /// Root is an operator-owned directory. Must complete before starting a
+    /// parent. A partially-created directory remains a fail-closed tombstone.
+    pub fn create(root: &Path, parent: Hash) -> io::Result<Self> {
+        fs::create_dir_all(root)?;
+        let directory = parent_directory(root, &parent);
+        fs::create_dir(&directory)?;
+        for ancestor in fs::canonicalize(&directory)?.ancestors() {
+            fs::File::open(ancestor)?.sync_all()?;
+        }
+        publish(
+            &directory,
+            "parent.json",
+            &serde_json::json!({"version":1,"parent":parent,"recovery":"context-lost-without-live-owner"}),
+        )?;
+        Ok(Self {
+            directory,
+            parent,
+            reservations: 0,
+        })
+    }
+
+    fn filename(turn_id: &str, stage: &str) -> String {
+        format!(
+            "{}.{stage}.json",
+            Hash::of(turn_id.as_bytes()).0.trim_start_matches("blake3:")
+        )
+    }
+
+    /// Caller must reserve in-memory authority first, then persist here, then
+    /// spawn. Any failure consumes the attempted reservation; never refund it.
+    pub fn reserve(&mut self, turn: &ReservedTurn) -> io::Result<()> {
+        let request = serde_json::to_vec(&turn.request).map_err(|_| invalid())?;
+        if self.reservations >= 1024
+            || turn.parent != self.parent
+            || TurnRequest::decode(&request).is_err()
+            || turn.child
+                != Hash::of(
+                    &serde_json::to_vec(&(&turn.parent.0, &turn.request.turn_id))
+                        .map_err(|_| invalid())?,
+                )
+        {
+            return Err(invalid());
+        }
+        self.reservations += 1;
+        publish(
+            &self.directory,
+            &Self::filename(&turn.request.turn_id, "reserved"),
+            &Reservation {
+                version: 1,
+                parent: turn.parent.clone(),
+                child: turn.child.clone(),
+                request: turn.request.clone(),
+                memory_bytes: turn.limits.memory_bytes,
+                timeout_nanos: turn.limits.timeout.as_nanos(),
+                model_requests: turn.limits.model_requests,
+                output_tokens: turn.limits.output_tokens,
+            },
+        )
+    }
+
+    fn reservation(&self, turn: &str) -> io::Result<Reservation> {
+        let record: Reservation =
+            read_record(&self.directory.join(Self::filename(turn, "reserved")))?;
+        if record.version != 1
+            || record.parent != self.parent
+            || record.request.turn_id != turn
+            || TurnRequest::decode(&serde_json::to_vec(&record.request).map_err(|_| invalid())?)
+                .is_err()
+            || record.child
+                != Hash::of(&serde_json::to_vec(&(&self.parent.0, turn)).map_err(|_| invalid())?)
+        {
+            return Err(invalid());
+        }
+        Ok(record)
+    }
+
+    fn destroyed(&self, turn: &str, child: &Hash) -> io::Result<DestroyedRecord> {
+        let record: DestroyedRecord =
+            read_record(&self.directory.join(Self::filename(turn, "destroyed")))?;
+        if record.version != 1
+            || record.parent != self.parent
+            || &record.child != child
+            || record.turn_id != turn
+            || record.answer.len() > 8192
+        {
+            return Err(invalid());
+        }
+        Ok(record)
+    }
+
+    /// Only after the actual owner has confirmed destruction. The journal
+    /// records that observation; it does not itself terminate a child VM.
+    pub fn child_destroyed(
+        &self,
+        turn: &str,
+        child: &Hash,
+        succeeded: bool,
+        answer: &str,
+    ) -> io::Result<()> {
+        let record = self.reservation(turn)?;
+        if &record.child != child || answer.len() > 8192 {
+            return Err(invalid());
+        }
+        publish(
+            &self.directory,
+            &Self::filename(turn, "destroyed"),
+            &serde_json::json!({
+                "version":1,"parent":self.parent,"child":child,"turnId":turn,"succeeded":succeeded,"answer":answer
+            }),
+        )
+    }
+
+    /// Acknowledgement from the same live guest parent, distinct from child
+    /// completion. A missing acknowledgement never authorizes replay.
+    pub fn parent_committed(&self, turn: &str, child: &Hash) -> io::Result<()> {
+        let record = self.reservation(turn)?;
+        if &record.child != child {
+            return Err(invalid());
+        }
+        self.destroyed(turn, child)?;
+        publish(
+            &self.directory,
+            &Self::filename(turn, "committed"),
+            &serde_json::json!({
+                "version":1,"parent":self.parent,"child":child,"turnId":turn
+            }),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn historical_owner_is_immutable_scoped_and_not_execution_authority() {
+        let root = tempfile::tempdir().unwrap();
+        let id = Hash::of(b"historical");
+        let journal = ParentJournal::create(root.path(), id.clone()).unwrap();
+        assert!(historical_owner(root.path(), &id, "tenant").is_err());
+        assert!(journal.bind_owner("bad\nprincipal").is_err());
+        journal.bind_owner("tenant").unwrap();
+        assert!(journal.bind_owner("other").is_err());
+        assert!(historical_owner(root.path(), &id, "tenant").unwrap());
+        assert!(!historical_owner(root.path(), &id, "other").unwrap());
+        drop(journal);
+        assert!(historical_owner(root.path(), &id, "tenant").unwrap());
+        assert!(ParentJournal::create(root.path(), id.clone()).is_err());
+        fs::write(parent_directory(root.path(), &id).join("owner.json"), b"{}").unwrap();
+        assert!(historical_owner(root.path(), &id, "tenant").is_err());
+        assert!(ParentJournal::create(root.path(), id).is_err());
+    }
+    use crate::parent_lease::{ParentLease, TurnLimits};
+    use std::time::Duration;
+    fn turn() -> ReservedTurn {
+        let mut lease = ParentLease::new(
+            Hash::of(b"incarnation"),
+            Duration::from_secs(60),
+            TurnLimits {
+                memory_bytes: 4096,
+                timeout: Duration::from_secs(1),
+                model_requests: 0,
+                output_tokens: 0,
+            },
+            1,
+            0,
+            0,
+        )
+        .unwrap();
+        lease
+            .reserve(br#"{"apiVersion":"celln.parent-turn/v1","turnId":"one","task":"hello"}"#)
+            .unwrap()
+    }
+    #[test]
+    fn durable_claim_blocks_recreation_and_duplicate_execution() {
+        let root = tempfile::tempdir().unwrap();
+        let turn = turn();
+        let mut journal = ParentJournal::create(root.path(), turn.parent.clone()).unwrap();
+        journal.reserve(&turn).unwrap();
+        assert!(journal.reserve(&turn).is_err());
+        assert_eq!(journal.reservation("one").unwrap().child, turn.child);
+        drop(journal);
+        assert!(ParentJournal::create(root.path(), turn.parent).is_err());
+    }
+    #[test]
+    fn teardown_and_parent_commit_are_distinct_immutable_stages() {
+        let root = tempfile::tempdir().unwrap();
+        let turn = turn();
+        let mut journal = ParentJournal::create(root.path(), turn.parent.clone()).unwrap();
+        journal.reserve(&turn).unwrap();
+        assert!(journal.parent_committed("one", &turn.child).is_err());
+        assert!(journal
+            .child_destroyed("one", &Hash::of(b"wrong"), true, "answer")
+            .is_err());
+        journal
+            .child_destroyed("one", &turn.child, true, "answer")
+            .unwrap();
+        assert!(journal
+            .child_destroyed("one", &turn.child, true, "changed")
+            .is_err());
+        journal.parent_committed("one", &turn.child).unwrap();
+        assert!(journal.parent_committed("one", &turn.child).is_err());
+    }
+
+    #[test]
+    fn inspection_survives_owner_loss_but_cannot_reopen_incarnation() {
+        let root = tempfile::tempdir().unwrap();
+        let turn = turn();
+        let mut journal = ParentJournal::create(root.path(), turn.parent.clone()).unwrap();
+        assert!(inspect_turn(root.path(), &turn.parent, "one").is_err());
+        journal.reserve(&turn).unwrap();
+        assert!(matches!(
+            inspect_turn(root.path(), &turn.parent, "one").unwrap(),
+            TurnStatus::Reserved(_)
+        ));
+        journal
+            .child_destroyed("one", &turn.child, false, "tool failed")
+            .unwrap();
+        assert!(
+            matches!(inspect_turn(root.path(), &turn.parent, "one").unwrap(), TurnStatus::ChildDestroyed(record) if !record.succeeded && record.answer == "tool failed")
+        );
+        journal.parent_committed("one", &turn.child).unwrap();
+        drop(journal);
+        assert!(
+            matches!(inspect_turn(root.path(), &turn.parent, "one").unwrap(), TurnStatus::ParentCommitted(record) if !record.succeeded)
+        );
+        assert!(ParentJournal::create(root.path(), turn.parent).is_err());
+    }
+
+    #[test]
+    fn corrupt_teardown_never_authorizes_commit_or_status() {
+        for corruption in [
+            ("version", serde_json::json!(2)),
+            ("child", serde_json::json!(Hash::of(b"other"))),
+            ("parent", serde_json::json!(Hash::of(b"other"))),
+            ("turnId", serde_json::json!("other")),
+            ("succeeded", serde_json::json!("true")),
+            ("answer", serde_json::json!("x".repeat(8193))),
+            ("extra", serde_json::json!(true)),
+        ] {
+            let root = tempfile::tempdir().unwrap();
+            let turn = turn();
+            let mut journal = ParentJournal::create(root.path(), turn.parent.clone()).unwrap();
+            journal.reserve(&turn).unwrap();
+            journal
+                .child_destroyed("one", &turn.child, true, "answer")
+                .unwrap();
+            let path = journal
+                .directory
+                .join(ParentJournal::filename("one", "destroyed"));
+            let mut value: serde_json::Value = read_record(&path).unwrap();
+            value[corruption.0] = corruption.1;
+            fs::write(path, serde_json::to_vec(&value).unwrap()).unwrap();
+            assert!(
+                journal.parent_committed("one", &turn.child).is_err(),
+                "{}",
+                corruption.0
+            );
+            assert!(
+                inspect_turn(root.path(), &turn.parent, "one").is_err(),
+                "{}",
+                corruption.0
+            );
+        }
+    }
+
+    #[test]
+    fn changed_reservation_child_and_orphan_commit_fail_closed() {
+        let root = tempfile::tempdir().unwrap();
+        let turn = turn();
+        let mut journal = ParentJournal::create(root.path(), turn.parent.clone()).unwrap();
+        journal.reserve(&turn).unwrap();
+        let path = journal
+            .directory
+            .join(ParentJournal::filename("one", "reserved"));
+        let original = fs::read(&path).unwrap();
+        let mut value: serde_json::Value = serde_json::from_slice(&original).unwrap();
+        let wrong = Hash::of(b"other");
+        value["child"] = serde_json::json!(wrong);
+        fs::write(&path, serde_json::to_vec(&value).unwrap()).unwrap();
+        assert!(journal
+            .child_destroyed("one", &wrong, true, "answer")
+            .is_err());
+        assert!(inspect_turn(root.path(), &turn.parent, "one").is_err());
+        fs::write(path, original).unwrap();
+        publish(&journal.directory, &ParentJournal::filename("one", "committed"),
+            &serde_json::json!({"version":1,"parent":turn.parent,"child":turn.child,"turnId":"one"})).unwrap();
+        assert!(inspect_turn(root.path(), &turn.parent, "one").is_err());
+    }
+}

--- a/crates/celln-warden/src/parent_lease.rs
+++ b/crates/celln-warden/src/parent_lease.rs
@@ -1,0 +1,279 @@
+//! Host-owned, in-memory parent turn ledger. Not an admission decision or a
+//! durable journal: the serving owner must persist reservations before spawn,
+//! recheck signed grants, and enforce the returned ceilings on the real child.
+//! A lost owner means context loss, never reconstruction of an empty ledger.
+
+use crate::parent_protocol::TurnRequest;
+use celln_manifest::Hash;
+use std::collections::BTreeSet;
+use std::time::{Duration, Instant};
+
+/// Fixed host-approved ceilings, reserved in full before each child launch.
+#[derive(Clone, Copy, Debug)]
+pub struct TurnLimits {
+    pub memory_bytes: u64,
+    pub timeout: Duration,
+    pub model_requests: u64,
+    pub output_tokens: u64,
+}
+
+#[derive(Debug)]
+pub struct ReservedTurn {
+    pub parent: Hash,
+    pub child: Hash,
+    pub request: TurnRequest,
+    pub limits: TurnLimits,
+}
+
+pub struct ParentLease {
+    parent: Hash,
+    deadline: Instant,
+    limits: TurnLimits,
+    turns_left: usize,
+    requests_left: u64,
+    tokens_left: u64,
+    seen: BTreeSet<String>,
+    active: Option<Hash>,
+    stopped: bool,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum LeaseError {
+    #[error("invalid parent lease configuration")]
+    Configuration,
+    #[error("invalid turn envelope")]
+    Protocol,
+    #[error("parent is stopped or expired")]
+    Stopped,
+    #[error("turn identity already reserved; reconcile original owner")]
+    Replay,
+    #[error("another child still owns the active turn")]
+    Busy,
+    #[error("aggregate parent budget exhausted")]
+    Budget,
+    #[error("completion does not match the active child owner")]
+    Owner,
+}
+
+impl ParentLease {
+    /// `parent` must identify a freshly admitted process incarnation, not just
+    /// a reusable Agent name. No guest field supplies this identity or limits.
+    pub fn new(
+        parent: Hash,
+        lifetime: Duration,
+        limits: TurnLimits,
+        max_turns: usize,
+        total_model_requests: u64,
+        total_output_tokens: u64,
+    ) -> Result<Self, LeaseError> {
+        let deadline = Instant::now()
+            .checked_add(lifetime)
+            .ok_or(LeaseError::Configuration)?;
+        if lifetime.is_zero()
+            || limits.timeout.is_zero()
+            || limits.memory_bytes == 0
+            || !(1..=1024).contains(&max_turns)
+            || (limits.model_requests == 0) != (limits.output_tokens == 0)
+            || limits.model_requests > total_model_requests
+            || limits.output_tokens > total_output_tokens
+        {
+            return Err(LeaseError::Configuration);
+        }
+        Ok(Self {
+            parent,
+            deadline,
+            limits,
+            turns_left: max_turns,
+            requests_left: total_model_requests,
+            tokens_left: total_output_tokens,
+            seen: BTreeSet::new(),
+            active: None,
+            stopped: false,
+        })
+    }
+
+    pub fn reserve(&mut self, bytes: &[u8]) -> Result<ReservedTurn, LeaseError> {
+        self.reserve_at(bytes, Instant::now())
+    }
+
+    fn reserve_at(&mut self, bytes: &[u8], now: Instant) -> Result<ReservedTurn, LeaseError> {
+        if now >= self.deadline {
+            self.stopped = true;
+        }
+        if self.stopped {
+            return Err(LeaseError::Stopped);
+        }
+        let request = TurnRequest::decode(bytes).map_err(|_| LeaseError::Protocol)?;
+        if self.seen.contains(&request.turn_id) {
+            return Err(LeaseError::Replay);
+        }
+        if self.active.is_some() {
+            return Err(LeaseError::Busy);
+        }
+        if self.turns_left == 0
+            || self.requests_left < self.limits.model_requests
+            || self.tokens_left < self.limits.output_tokens
+        {
+            return Err(LeaseError::Budget);
+        }
+        // JSON tuple framing avoids delimiter collisions in the identity.
+        let child = Hash::of(&serde_json::to_vec(&(&self.parent.0, &request.turn_id)).unwrap());
+        self.turns_left -= 1;
+        self.requests_left -= self.limits.model_requests;
+        self.tokens_left -= self.limits.output_tokens;
+        self.seen.insert(request.turn_id.clone());
+        self.active = Some(child.clone());
+        let mut limits = self.limits;
+        limits.timeout = limits.timeout.min(self.deadline.duration_since(now));
+        Ok(ReservedTurn {
+            parent: self.parent.clone(),
+            child,
+            request,
+            limits,
+        })
+    }
+
+    /// Only call after the actual child owner confirms destruction. Failure,
+    /// cancellation and uncertain model charges never refund a reservation.
+    pub fn confirm_child_destroyed(&mut self, child: &Hash) -> Result<(), LeaseError> {
+        if self.active.as_ref() != Some(child) {
+            return Err(LeaseError::Owner);
+        }
+        self.active = None;
+        Ok(())
+    }
+
+    /// Close admission immediately. Retain the active owner until confirmed
+    /// destroyed; returning its identity is a cleanup instruction, not proof.
+    pub fn stop(&mut self) -> Option<Hash> {
+        self.stopped = true;
+        self.active.clone()
+    }
+
+    /// The serving owner must drive this from its lease watchdog even while
+    /// idle, and kill both VMs on expiry. Polling this ledger does not kill VMs.
+    pub fn expired(&mut self) -> bool {
+        if Instant::now() >= self.deadline {
+            self.stopped = true;
+        }
+        self.stopped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn lease() -> ParentLease {
+        ParentLease::new(
+            Hash::of(b"parent-incarnation"),
+            Duration::from_secs(60),
+            TurnLimits {
+                memory_bytes: 128 << 20,
+                timeout: Duration::from_secs(30),
+                model_requests: 3,
+                output_tokens: 1536,
+            },
+            4,
+            6,
+            3072,
+        )
+        .unwrap()
+    }
+    fn request(id: &str) -> Vec<u8> {
+        serde_json::to_vec(
+            &serde_json::json!({"apiVersion":crate::parent_protocol::VERSION,
+            "turnId":id,"task":"hello"}),
+        )
+        .unwrap()
+    }
+    fn error(result: Result<ReservedTurn, LeaseError>) -> LeaseError {
+        result.unwrap_err()
+    }
+
+    #[test]
+    fn serial_turns_bind_parent_child_and_never_replay() {
+        let mut owner = lease();
+        let first = owner.reserve(&request("one")).unwrap();
+        assert_eq!(first.parent, owner.parent);
+        assert_eq!(error(owner.reserve(&request("one"))), LeaseError::Replay);
+        assert_eq!(error(owner.reserve(&request("two"))), LeaseError::Busy);
+        assert_eq!(
+            owner.confirm_child_destroyed(&Hash::of(b"impostor")),
+            Err(LeaseError::Owner)
+        );
+        owner.confirm_child_destroyed(&first.child).unwrap();
+        assert_eq!(error(owner.reserve(&request("one"))), LeaseError::Replay);
+        let second = owner.reserve(&request("two")).unwrap();
+        assert_ne!(first.child, second.child);
+        owner.confirm_child_destroyed(&second.child).unwrap();
+        assert_eq!(error(owner.reserve(&request("three"))), LeaseError::Budget);
+    }
+
+    #[test]
+    fn stop_retains_cleanup_owner_and_does_not_refund() {
+        let mut owner = lease();
+        let turn = owner.reserve(&request("one")).unwrap();
+        assert_eq!(owner.stop(), Some(turn.child.clone()));
+        assert_eq!(owner.stop(), Some(turn.child.clone()));
+        assert_eq!(error(owner.reserve(&request("two"))), LeaseError::Stopped);
+        owner.confirm_child_destroyed(&turn.child).unwrap();
+        assert_eq!(owner.stop(), None);
+        assert_eq!(error(owner.reserve(&request("three"))), LeaseError::Stopped);
+        assert_eq!(owner.requests_left, 3);
+    }
+
+    #[test]
+    fn expiry_caps_child_time_and_permanently_closes_admission() {
+        let mut owner = lease();
+        let near_end = owner.deadline - Duration::from_millis(7);
+        let turn = owner.reserve_at(&request("one"), near_end).unwrap();
+        assert_eq!(turn.limits.timeout, Duration::from_millis(7));
+        owner.confirm_child_destroyed(&turn.child).unwrap();
+        assert_eq!(
+            error(owner.reserve_at(&request("two"), owner.deadline)),
+            LeaseError::Stopped
+        );
+        assert_eq!(
+            error(owner.reserve_at(&request("two"), near_end)),
+            LeaseError::Stopped
+        );
+    }
+
+    #[test]
+    fn invalid_guest_input_spends_nothing_and_new_parent_has_distinct_identity() {
+        let mut owner = lease();
+        assert_eq!(error(owner.reserve(b"{}")), LeaseError::Protocol);
+        assert_eq!(owner.turns_left, 4);
+        let mut other = lease();
+        other.parent = Hash::of(b"different-incarnation");
+        assert_ne!(
+            owner.reserve(&request("one")).unwrap().child,
+            other.reserve(&request("one")).unwrap().child
+        );
+    }
+
+    #[test]
+    fn model_free_work_still_has_bounded_turn_count() {
+        let mut owner = ParentLease::new(
+            Hash::of(b"direct-worker"),
+            Duration::from_secs(1),
+            TurnLimits {
+                memory_bytes: 4096,
+                timeout: Duration::from_millis(10),
+                model_requests: 0,
+                output_tokens: 0,
+            },
+            1,
+            0,
+            0,
+        )
+        .unwrap();
+        let turn = owner.reserve(&request("one")).unwrap();
+        owner.confirm_child_destroyed(&turn.child).unwrap();
+        assert_eq!(error(owner.reserve(&request("two"))), LeaseError::Budget);
+        assert_eq!(
+            owner.confirm_child_destroyed(&turn.child),
+            Err(LeaseError::Owner)
+        );
+    }
+}

--- a/crates/celln-warden/src/parent_mailbox.rs
+++ b/crates/celln-warden/src/parent_mailbox.rs
@@ -1,0 +1,176 @@
+//! Optional parent transport v1. This transports untrusted data, not authority.
+//! RX returns a u32 LE length then payload (0xff bytes when empty); TX accumulates a response; COMMIT
+//! accepts exactly one byte equal to 1 and yields the VM to its host owner.
+//! A protocol violation permanently poisons the mailbox. No implicit reset or
+//! overwrite can hide a malformed request or replay an unfinished exchange.
+
+use std::collections::VecDeque;
+
+pub const RX: u16 = 0x520;
+pub const TX: u16 = 0x521;
+pub const COMMIT: u16 = 0x522;
+pub const MAX_FRAME_BYTES: usize = 8192;
+
+#[derive(Debug, Default)]
+pub struct ParentMailbox {
+    input: VecDeque<u8>,
+    output: Vec<u8>,
+    active: bool,
+    committed: bool,
+    poisoned: bool,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[error("invalid parent mailbox state or frame")]
+pub struct MailboxError;
+
+impl ParentMailbox {
+    /// Host delivery; rejects busy/invalid input without changing the exchange.
+    pub fn deliver(&mut self, bytes: &[u8]) -> Result<(), MailboxError> {
+        if self.poisoned || self.active || bytes.is_empty() || bytes.len() > MAX_FRAME_BYTES {
+            return Err(MailboxError);
+        }
+        self.input.extend((bytes.len() as u32).to_le_bytes());
+        self.input.extend(bytes);
+        self.active = true;
+        Ok(())
+    }
+
+    pub fn read(&mut self, data: &mut [u8]) {
+        for b in data {
+            *b = if self.poisoned {
+                None
+            } else {
+                self.input.pop_front()
+            }
+            .unwrap_or(0xff);
+        }
+    }
+
+    pub fn write(&mut self, data: &[u8]) {
+        if self.poisoned
+            || !self.active
+            || self.committed
+            || !self.input.is_empty()
+            || data.len() > MAX_FRAME_BYTES.saturating_sub(self.output.len())
+        {
+            self.poisoned = true;
+            return;
+        }
+        self.output.extend_from_slice(data);
+    }
+
+    /// Always yields, including on malformed commit. The owner must inspect
+    /// take_response before resuming; poisoned exchanges never produce data.
+    pub fn commit(&mut self, data: &[u8]) {
+        if data != [1]
+            || !self.active
+            || self.committed
+            || !self.input.is_empty()
+            || self.output.is_empty()
+        {
+            self.poisoned = true;
+        }
+        self.committed = true;
+    }
+
+    pub fn take_response(&mut self) -> Result<Option<Vec<u8>>, MailboxError> {
+        if self.poisoned {
+            return Err(MailboxError);
+        }
+        if !self.committed {
+            return Ok(None);
+        }
+        self.active = false;
+        self.committed = false;
+        Ok(Some(std::mem::take(&mut self.output)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ready() -> ParentMailbox {
+        let mut m = ParentMailbox::default();
+        m.deliver(b"hi").unwrap();
+        let mut frame = [0; 6];
+        m.read(&mut frame);
+        assert_eq!(&frame, b"\x02\0\0\0hi");
+        m
+    }
+
+    #[test]
+    fn idle_word_poll_does_not_consume_a_later_frame_prefix() {
+        let mut mailbox = ParentMailbox::default();
+        let mut word = [0; 2];
+        mailbox.read(&mut word);
+        assert_eq!(word, [0xff; 2]);
+        mailbox.deliver(b"hello").unwrap();
+        mailbox.read(&mut word);
+        assert_eq!(u16::from_le_bytes(word), 5);
+        mailbox.read(&mut word);
+        assert_eq!(word, [0; 2]);
+        let mut payload = [0; 5];
+        mailbox.read(&mut payload);
+        assert_eq!(&payload, b"hello");
+    }
+    #[test]
+    fn serial_exchanges_do_not_overwrite_or_replay() {
+        let mut m = ready();
+        assert!(m.deliver(b"overwrite").is_err());
+        assert_eq!(m.take_response().unwrap(), None);
+        m.write(b"one");
+        m.commit(&[1]);
+        assert!(m.deliver(b"overwrite").is_err());
+        assert_eq!(m.take_response().unwrap().unwrap(), b"one");
+        assert_eq!(m.take_response().unwrap(), None);
+        m.deliver(b"two").unwrap();
+        m.read(&mut [0; 7]);
+        m.write(b"second");
+        m.commit(&[1]);
+        assert_eq!(m.take_response().unwrap().unwrap(), b"second");
+    }
+
+    #[test]
+    fn overflow_cannot_execute_a_valid_prefix() {
+        let mut m = ready();
+        m.write(&[b'x'; MAX_FRAME_BYTES]);
+        m.write(b"x");
+        m.commit(&[1]);
+        assert_eq!(m.output.len(), MAX_FRAME_BYTES);
+        assert_eq!(m.take_response(), Err(MailboxError));
+        assert!(m.deliver(b"retry").is_err());
+    }
+
+    #[test]
+    fn malformed_and_premature_commits_poison_permanently() {
+        for bytes in [&[][..], &[0][..], &[1, 1][..]] {
+            let mut m = ready();
+            m.write(b"valid prefix");
+            m.commit(bytes);
+            assert_eq!(m.take_response(), Err(MailboxError));
+        }
+        let mut m = ParentMailbox::default();
+        m.deliver(b"unread").unwrap();
+        m.write(b"premature");
+        m.commit(&[1]);
+        assert_eq!(m.take_response(), Err(MailboxError));
+        let mut m = ready();
+        m.commit(&[1]);
+        assert_eq!(m.take_response(), Err(MailboxError));
+    }
+
+    #[test]
+    fn host_input_bounds_and_duplicate_commit() {
+        let mut m = ParentMailbox::default();
+        assert!(m.deliver(b"").is_err());
+        assert!(m.deliver(&[0; MAX_FRAME_BYTES + 1]).is_err());
+        m.deliver(&[0; MAX_FRAME_BYTES]).unwrap();
+        let mut m = ready();
+        m.write(b"ok");
+        m.commit(&[1]);
+        m.commit(&[1]);
+        assert_eq!(m.take_response(), Err(MailboxError));
+    }
+}

--- a/crates/celln-warden/src/parent_owner.rs
+++ b/crates/celln-warden/src/parent_owner.rs
@@ -1,0 +1,380 @@
+//! Bounded serving-thread owner for a persistent runtime. Its handler must own
+//! all VM resources and use the scoped celln-control-aware KVM/broker paths.
+//! This is not a force-kill mechanism for arbitrary uncooperative callbacks.
+use celln_control::Control;
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    },
+    thread,
+    time::Duration,
+};
+
+type Reply = Result<Vec<u8>, String>;
+struct Command {
+    bytes: Vec<u8>,
+    reply: mpsc::SyncSender<Reply>,
+}
+
+pub struct ParentOwner {
+    sender: mpsc::SyncSender<Command>,
+    control: Control,
+    busy: Arc<AtomicBool>,
+    initialized: Arc<AtomicBool>,
+    thread: Option<thread::JoinHandle<()>>,
+    children: Option<Arc<crate::parent_child_control::ChildControlSlot>>,
+}
+
+impl ParentOwner {
+    /// Construct the runtime on its owning thread; VM state need not migrate
+    /// between threads. Preparation and every exchange share one deadline.
+    pub fn spawn<F, H>(lifetime: Duration, initialize: F) -> std::io::Result<Self>
+    where
+        F: FnOnce() -> Result<H, String> + Send + 'static,
+        H: FnMut(&[u8]) -> Reply + 'static,
+    {
+        let control = Control::new(lifetime)?;
+        Self::spawn_controlled(control, initialize, None)
+    }
+
+    /// Share one child rendezvous between the owning runtime and authenticated
+    /// routing. It inherits this owner's control; no independently extended lease.
+    pub fn spawn_with_children<F, H>(
+        parent: celln_manifest::Hash,
+        lifetime: Duration,
+        initialize: F,
+    ) -> std::io::Result<Self>
+    where
+        F: FnOnce(Arc<crate::parent_child_control::ChildControlSlot>) -> Result<H, String>
+            + Send
+            + 'static,
+        H: FnMut(&[u8]) -> Reply + 'static,
+    {
+        let control = Control::new(lifetime)?;
+        let children = Arc::new(crate::parent_child_control::ChildControlSlot::new(
+            parent,
+            control.clone(),
+        ));
+        let runtime_children = children.clone();
+        Self::spawn_controlled(
+            control,
+            move || initialize(runtime_children),
+            Some(children),
+        )
+    }
+
+    fn spawn_controlled<F, H>(
+        control: Control,
+        initialize: F,
+        children: Option<Arc<crate::parent_child_control::ChildControlSlot>>,
+    ) -> std::io::Result<Self>
+    where
+        F: FnOnce() -> Result<H, String> + Send + 'static,
+        H: FnMut(&[u8]) -> Reply + 'static,
+    {
+        let (sender, receiver) = mpsc::sync_channel::<Command>(1);
+        let busy = Arc::new(AtomicBool::new(false));
+        let initialized = Arc::new(AtomicBool::new(false));
+        let owner_initialized = initialized.clone();
+        let owner_control = control.clone();
+        let owner_busy = busy.clone();
+        let thread = thread::Builder::new()
+            .name("celln-parent-owner".into())
+            .spawn(move || {
+                owner_control.scope(|| {
+                    if owner_control.check().is_err() {
+                        return;
+                    }
+                    let Ok(mut runtime) = initialize() else {
+                        owner_control.cancel();
+                        return;
+                    };
+                    // The admitted constructor returns only after the native
+                    // parent's protected execution acknowledgement. Publish
+                    // startup completion separately from queue availability.
+                    owner_initialized.store(true, Ordering::Release);
+                    loop {
+                        if owner_control.check().is_err() {
+                            break;
+                        }
+                        let command = match receiver
+                            .recv_timeout(Duration::from_millis(20).min(owner_control.remaining()))
+                        {
+                            Ok(command) => command,
+                            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                        };
+                        let result = owner_control
+                            .check()
+                            .map_err(|e| e.to_string())
+                            .and_then(|_| runtime(&command.bytes))
+                            .and_then(|output| {
+                                owner_control.check().map_err(|e| e.to_string())?;
+                                if output.len() > crate::parent_mailbox::MAX_FRAME_BYTES {
+                                    Err("parent response exceeds owner bound".into())
+                                } else {
+                                    Ok(output)
+                                }
+                            });
+                        let failed = result.is_err();
+                        if failed {
+                            owner_control.cancel();
+                        }
+                        // Publish readiness before acknowledgement: once the
+                        // client observes completion it may submit the next turn.
+                        // Failed handlers already cancelled admission above.
+                        owner_busy.store(false, Ordering::Release);
+                        let _ = command.reply.send(result);
+                        // A handler failure can mean lost live context. Never
+                        // accept another turn against an implicitly reset runtime.
+                        if failed {
+                            break;
+                        }
+                    }
+                    drop(runtime); // release parent and any handler-owned child
+                });
+                owner_control.cancel();
+                owner_busy.store(false, Ordering::Release);
+            })?;
+        Ok(Self {
+            sender,
+            control,
+            busy,
+            initialized,
+            thread: Some(thread),
+            children,
+        })
+    }
+
+    /// At most one accepted exchange, including one waiting for initialization.
+    /// The receiver is an acknowledgement, not a retry token: losing it never
+    /// authorizes replay. Durable IDs remain the journal/ledger's responsibility.
+    pub fn submit(&self, bytes: &[u8]) -> Result<mpsc::Receiver<Reply>, String> {
+        self.control.check().map_err(|e| e.to_string())?;
+        if bytes.is_empty() || bytes.len() > crate::parent_mailbox::MAX_FRAME_BYTES {
+            return Err("parent input exceeds owner bound".into());
+        }
+        self.busy
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| "parent exchange already active")?;
+        let (reply, receiver) = mpsc::sync_channel(1);
+        if self
+            .sender
+            .try_send(Command {
+                bytes: bytes.into(),
+                reply,
+            })
+            .is_err()
+        {
+            self.busy.store(false, Ordering::Release);
+            return Err("parent owner unavailable".into());
+        }
+        Ok(receiver)
+    }
+
+    pub fn cancel(&self) {
+        self.control.cancel();
+    }
+
+    /// Exact child cancellation request, never a parent stop or join receipt.
+    pub fn cancel_child(
+        &self,
+        identity: &crate::parent_child_control::Identity,
+    ) -> Result<(), String> {
+        self.control.check().map_err(|error| error.to_string())?;
+        self.children
+            .as_ref()
+            .ok_or("owner has no child cancellation contract")?
+            .cancel(identity)
+            .map_err(str::to_owned)
+    }
+
+    /// Live observation, not a reservation or guarantee a later submit succeeds.
+    pub fn status(&self) -> OwnerStatus {
+        if self.is_finished() {
+            OwnerStatus::ContextLost
+        } else if self.control.check().is_err() {
+            OwnerStatus::Stopping
+        } else if !self.initialized.load(Ordering::Acquire) {
+            OwnerStatus::Initializing
+        } else if self.busy.load(Ordering::Acquire) {
+            OwnerStatus::TurnActive
+        } else {
+            OwnerStatus::Ready
+        }
+    }
+
+    /// Observation only: join is still required to confirm teardown and reclaim
+    /// host reservations. A finished thread never implies resumable context.
+    pub fn is_finished(&self) -> bool {
+        self.thread
+            .as_ref()
+            .map_or(true, |thread| thread.is_finished())
+    }
+
+    /// Confirm owner exit, not just cancellation requested. Only a successful
+    /// join proves the handler and its owned resources have been dropped.
+    pub fn stop_and_join(mut self) -> Result<(), String> {
+        self.cancel();
+        self.thread
+            .take()
+            .unwrap()
+            .join()
+            .map_err(|_| "parent owner panicked; reconcile context loss".into())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OwnerStatus {
+    Initializing,
+    Ready,
+    TurnActive,
+    Stopping,
+    ContextLost,
+}
+
+impl Drop for ParentOwner {
+    fn drop(&mut self) {
+        self.control.cancel();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn readiness_tracks_constructor_active_turn_and_cancellation() {
+        let (initialize, initialization) = mpsc::sync_channel(1);
+        let (started, active) = mpsc::sync_channel(1);
+        let (release, work) = mpsc::sync_channel(1);
+        let owner = ParentOwner::spawn(Duration::from_secs(10), move || {
+            initialization.recv().unwrap();
+            Ok(move |_: &[u8]| {
+                started.send(()).unwrap();
+                work.recv().unwrap();
+                Ok(vec![1])
+            })
+        })
+        .unwrap();
+        assert_eq!(owner.status(), OwnerStatus::Initializing);
+        initialize.send(()).unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while owner.status() != OwnerStatus::Ready {
+            assert!(std::time::Instant::now() < deadline);
+            thread::yield_now();
+        }
+        let response = owner.submit(b"turn").unwrap();
+        active.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert_eq!(owner.status(), OwnerStatus::TurnActive);
+        owner.cancel();
+        assert_eq!(owner.status(), OwnerStatus::Stopping);
+        release.send(()).unwrap();
+        assert!(response
+            .recv_timeout(Duration::from_secs(2))
+            .unwrap()
+            .is_err());
+        owner.stop_and_join().unwrap();
+    }
+
+    #[test]
+    fn failed_initialization_never_reports_ready() {
+        type Handler = fn(&[u8]) -> Reply;
+        let owner = ParentOwner::spawn(Duration::from_secs(2), || -> Result<Handler, String> {
+            Err("admitted runtime failed to start".into())
+        })
+        .unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            match owner.status() {
+                OwnerStatus::ContextLost => break,
+                OwnerStatus::Initializing | OwnerStatus::Stopping => {}
+                status => panic!("failed initialization reported {status:?}"),
+            }
+            assert!(std::time::Instant::now() < deadline);
+            thread::yield_now();
+        }
+        assert!(owner.submit(b"turn").is_err());
+        owner.stop_and_join().unwrap();
+    }
+    struct Resource(mpsc::SyncSender<()>);
+    impl Drop for Resource {
+        fn drop(&mut self) {
+            let _ = self.0.send(());
+        }
+    }
+
+    #[test]
+    fn acknowledged_turn_is_ready_for_immediate_next_submission() {
+        let owner = ParentOwner::spawn(Duration::from_secs(10), || {
+            Ok(|bytes: &[u8]| Ok(bytes.to_vec()))
+        })
+        .unwrap();
+        for _ in 0..1000 {
+            let reply = owner.submit(b"turn").unwrap();
+            assert_eq!(
+                reply.recv_timeout(Duration::from_secs(2)).unwrap().unwrap(),
+                b"turn"
+            );
+        }
+        owner.stop_and_join().unwrap();
+    }
+    #[test]
+    fn idle_expiry_drops_retained_runtime_without_another_request() {
+        let (dropped, observe) = mpsc::sync_channel(1);
+        let owner = ParentOwner::spawn(Duration::from_millis(40), move || {
+            let resource = Resource(dropped);
+            Ok(move |_: &[u8]| {
+                let _ = &resource;
+                Ok(vec![1])
+            })
+        })
+        .unwrap();
+        observe.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(owner.submit(b"stale").is_err());
+        owner.stop_and_join().unwrap();
+    }
+
+    #[test]
+    fn cancellation_interrupts_active_control_aware_work_and_confirms_drop() {
+        let (started, ready) = mpsc::sync_channel(1);
+        let (dropped, observe) = mpsc::sync_channel(1);
+        let owner = ParentOwner::spawn(Duration::from_secs(10), move || {
+            let resource = Resource(dropped);
+            Ok(move |_: &[u8]| {
+                let _ = &resource;
+                started.send(()).unwrap();
+                loop {
+                    celln_control::check().map_err(|e| e.to_string())?;
+                    thread::yield_now();
+                }
+            })
+        })
+        .unwrap();
+        let reply = owner.submit(b"work").unwrap();
+        ready.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(owner.submit(b"overlap").is_err());
+        owner.cancel();
+        assert!(reply.recv_timeout(Duration::from_secs(2)).unwrap().is_err());
+        owner.stop_and_join().unwrap();
+        observe.recv_timeout(Duration::from_secs(2)).unwrap();
+    }
+
+    #[test]
+    fn handler_failure_does_not_recreate_context() {
+        let owner = ParentOwner::spawn(Duration::from_secs(1), || {
+            Ok(|_: &[u8]| Err("context lost".into()))
+        })
+        .unwrap();
+        assert_eq!(
+            owner
+                .submit(b"work")
+                .unwrap()
+                .recv_timeout(Duration::from_secs(2))
+                .unwrap()
+                .unwrap_err(),
+            "context lost"
+        );
+        owner.stop_and_join().unwrap();
+    }
+}

--- a/crates/celln-warden/src/parent_permit.rs
+++ b/crates/celln-warden/src/parent_permit.rs
@@ -1,0 +1,868 @@
+//! Explicit operator authority for a parent incarnation. Artifact signatures
+//! alone do not grant mailbox access or permission to spawn children.
+//!
+//! The serving layer supplies an independently authenticated principal and
+//! hashes of its complete admitted parent/worker configurations (including
+//! closure, borrowed tools, inputs, model policy and execution restrictions).
+//! This does not perform artifact admission, tenant authentication, node RAM
+//! reservation or VM launch. Those checks remain mandatory before launch.
+use crate::parent_lease::{ParentLease, TurnLimits};
+use celln_manifest::Hash;
+use serde::{Deserialize, Serialize};
+use std::{
+    io::{self, Read, Write},
+    path::Path,
+    time::Duration,
+};
+
+pub const VERSION: &str = "celln.parent-permit/v1";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Binding {
+    pub principal: String,
+    /// Unique run/process incarnation, never a reusable agent name.
+    pub incarnation: Hash,
+    pub parent_configuration: Hash,
+    pub worker_configuration: Hash,
+    pub parent_memory_bytes: u64,
+    pub child_memory_bytes: u64,
+    pub lifetime_ms: u64,
+    pub turn_timeout_ms: u64,
+    pub max_turns: usize,
+    pub turn_model_requests: u64,
+    pub turn_output_tokens: u64,
+    pub total_model_requests: u64,
+    pub total_output_tokens: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Permit {
+    pub api_version: String,
+    pub binding: Binding,
+    pub boot_id: String,
+    pub issued_at_boottime_ms: u64,
+    pub expires_at_boottime_ms: u64,
+}
+
+/// Host observation, not accepted from a client. Exposed for local operator
+/// issuance; validation always reads the current clock itself.
+pub struct HostClock {
+    pub boot_id: String,
+    pub boottime_ms: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RunIssuance {
+    api_version: String,
+    scope: String,
+    run_uid: String,
+    intent: Hash,
+    admission_window_ms: u64,
+    permit: Permit,
+}
+
+/// Scope is a stable operator-selected cluster/issuer identity; run_uid is an
+/// immutable run UID, never a reusable run name. Intent does not influence this
+/// identity: changing intent must fail against the original issuance record.
+pub fn run_incarnation(scope: &str, run_uid: &str) -> io::Result<Hash> {
+    if scope.is_empty()
+        || scope.len() > 512
+        || run_uid.is_empty()
+        || run_uid.len() > 128
+        || scope.chars().chain(run_uid.chars()).any(char::is_control)
+    {
+        return Err(invalid(
+            "bounded operator scope and immutable run UID required",
+        ));
+    }
+    let raw = serde_json::to_vec(&("celln.parent-run-incarnation/v1", scope, run_uid))
+        .map_err(|_| invalid("run incarnation serialization failed"))?;
+    Ok(Hash::of(&raw))
+}
+
+/// Pin one exact permit to an independently authorized run intent. Recovery
+/// returns the original unexpired permit; it never renews timestamps, replaces
+/// an incarnation or dispatches work. All issuers for a scope must share this
+/// pre-existing operator-owned parent-issuance directory, including on restart.
+pub fn issue_for_run(
+    root: &Path,
+    scope: &str,
+    run_uid: &str,
+    intent: &Hash,
+    binding: Binding,
+    window: Duration,
+) -> io::Result<Permit> {
+    let permit = issue_for_run_at(
+        root,
+        scope,
+        run_uid,
+        intent,
+        binding,
+        window,
+        &host_clock()?,
+    )?;
+    permit.validate(&permit.binding, &permit.binding.principal, &host_clock()?)?;
+    Ok(permit)
+}
+
+fn issue_for_run_at(
+    root: &Path,
+    scope: &str,
+    run_uid: &str,
+    intent: &Hash,
+    binding: Binding,
+    window: Duration,
+    now: &HostClock,
+) -> io::Result<Permit> {
+    let incarnation = run_incarnation(scope, run_uid)?;
+    if !root.is_absolute() || !valid_hash(intent) || binding.incarnation != incarnation {
+        return Err(invalid("run issuance root, intent or incarnation mismatch"));
+    }
+    let permit = Permit::issue_at(binding.clone(), window, now)?;
+    let candidate = RunIssuance {
+        api_version: "celln.parent-run-issuance/v1".into(),
+        scope: scope.into(),
+        run_uid: run_uid.into(),
+        intent: intent.clone(),
+        admission_window_ms: window.as_millis() as u64,
+        permit,
+    };
+    let directory = root.join("parent-issuance");
+    let dir = std::fs::File::open(&directory)?;
+    if !dir.metadata()?.is_dir() {
+        return Err(invalid("operator issuance directory required"));
+    }
+    let path = directory.join(format!("{}.json", &incarnation.0[7..]));
+    let bytes =
+        serde_json::to_vec(&candidate).map_err(|_| invalid("run issuance serialization failed"))?;
+    if bytes.len() > 16384 {
+        return Err(invalid("run issuance exceeds bound"));
+    }
+    let mut temporary = tempfile::NamedTempFile::new_in(&directory)?;
+    temporary.write_all(&bytes)?;
+    temporary.as_file().sync_all()?;
+    if let Err(error) = temporary.persist_noclobber(&path) {
+        if error.error.kind() != io::ErrorKind::AlreadyExists {
+            return Err(error.error);
+        }
+    }
+    // Read the winner, not this attempt's freshly constructed timestamps.
+    let mut saved = Vec::new();
+    std::fs::File::open(&path)?
+        .take(16385)
+        .read_to_end(&mut saved)?;
+    if saved.len() > 16384 {
+        return Err(invalid("stored run issuance exceeds bound"));
+    }
+    let saved: RunIssuance = serde_json::from_slice(&saved)
+        .map_err(|_| invalid("stored run issuance corrupt; preserve original record"))?;
+    if saved.api_version != candidate.api_version
+        || saved.scope != scope
+        || saved.run_uid != run_uid
+        || saved.intent != *intent
+        || saved.admission_window_ms != candidate.admission_window_ms
+        || saved.permit.binding != binding
+        || saved
+            .permit
+            .expires_at_boottime_ms
+            .checked_sub(saved.permit.issued_at_boottime_ms)
+            != Some(saved.admission_window_ms)
+    {
+        return Err(invalid("run issuance differs; preserve original permit"));
+    }
+    dir.sync_all()?;
+    saved.permit.validate(&binding, &binding.principal, now)?;
+    Ok(saved.permit)
+}
+
+fn invalid(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+fn valid_hash(hash: &Hash) -> bool {
+    hash.0.strip_prefix("blake3:").is_some_and(|s| {
+        s.len() == 64
+            && s.bytes()
+                .all(|c| c.is_ascii_digit() || (b'a'..=b'f').contains(&c))
+    })
+}
+
+fn valid_boot(id: &str) -> bool {
+    id.len() == 36
+        && id.bytes().enumerate().all(|(i, c)| {
+            if [8, 13, 18, 23].contains(&i) {
+                c == b'-'
+            } else {
+                c.is_ascii_digit() || (b'a'..=b'f').contains(&c)
+            }
+        })
+}
+
+pub fn host_clock() -> io::Result<HostClock> {
+    #[cfg(all(target_os = "linux", feature = "kvm"))]
+    {
+        let mut boot_id = String::new();
+        std::fs::File::open("/proc/sys/kernel/random/boot_id")?
+            .take(128)
+            .read_to_string(&mut boot_id)?;
+        let boot_id = boot_id.trim().to_owned();
+        let mut time = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        // SAFETY: time is initialized writable timespec storage.
+        if unsafe { libc::clock_gettime(libc::CLOCK_BOOTTIME, &mut time) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if !valid_boot(&boot_id) || time.tv_sec < 0 || !(0..1_000_000_000).contains(&time.tv_nsec) {
+            return Err(invalid("invalid host boot clock"));
+        }
+        let boottime_ms = (time.tv_sec as u64)
+            .checked_mul(1000)
+            .and_then(|t| t.checked_add(time.tv_nsec as u64 / 1_000_000))
+            .ok_or_else(|| invalid("host boot clock overflow"))?;
+        Ok(HostClock {
+            boot_id,
+            boottime_ms,
+        })
+    }
+    #[cfg(not(all(target_os = "linux", feature = "kvm")))]
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "parent permits require Linux KVM host clock support",
+    ))
+}
+
+impl Binding {
+    fn lease(&self) -> io::Result<ParentLease> {
+        if self.principal.is_empty()
+            || self.principal.len() > 512
+            || self.principal.chars().any(char::is_control)
+            || !valid_hash(&self.incarnation)
+            || !valid_hash(&self.parent_configuration)
+            || !valid_hash(&self.worker_configuration)
+            || self.parent_memory_bytes == 0
+            || self
+                .parent_memory_bytes
+                .checked_add(self.child_memory_bytes)
+                .is_none()
+            || !(1..=86_400_000).contains(&self.lifetime_ms)
+            || self.turn_timeout_ms > self.lifetime_ms
+            || self.total_model_requests > 6144
+            || self.total_output_tokens > 3_145_728
+        {
+            return Err(invalid("invalid parent permit limits or identity"));
+        }
+        ParentLease::new(
+            self.incarnation.clone(),
+            Duration::from_millis(self.lifetime_ms),
+            TurnLimits {
+                memory_bytes: self.child_memory_bytes,
+                timeout: Duration::from_millis(self.turn_timeout_ms),
+                model_requests: self.turn_model_requests,
+                output_tokens: self.turn_output_tokens,
+            },
+            self.max_turns,
+            self.total_model_requests,
+            self.total_output_tokens,
+        )
+        .map_err(|_| invalid("invalid parent permit lease"))
+    }
+}
+
+impl Permit {
+    /// Construct a bounded permit from explicitly trusted local operator input.
+    /// Time is observed on this host, never supplied by a remote caller. This
+    /// neither publishes authority nor claims/launches an incarnation. The
+    /// caller must separately authorize the complete binding and durably pin
+    /// issuance to its run; calling again is not a renewal or replay mechanism.
+    pub fn issue(binding: Binding, admission_window: Duration) -> io::Result<Self> {
+        Self::issue_at(binding, admission_window, &host_clock()?)
+    }
+
+    /// Durably publish this exact local operator permit without replacement.
+    /// The protected root and trusted-parent-permits directory must exist.
+    /// A publication failure never authorizes issuing a replacement identity;
+    /// callers must recover their pinned permit. This does not claim or launch.
+    pub fn publish(&self, root: &Path) -> io::Result<Hash> {
+        let hash = self.publish_at(root, &host_clock()?)?;
+        // Publication can consume the remaining admission window. Preserve the
+        // record, but do not return a now-expired permit as usable authority.
+        self.validate(&self.binding, &self.binding.principal, &host_clock()?)?;
+        Ok(hash)
+    }
+
+    fn publish_at(&self, root: &Path, now: &HostClock) -> io::Result<Hash> {
+        self.validate(&self.binding, &self.binding.principal, now)?;
+        if !root.is_absolute() {
+            return Err(invalid("absolute operator root required"));
+        }
+        let directory = root.join("trusted-parent-permits");
+        let dir = std::fs::File::open(&directory)?;
+        if !dir.metadata()?.is_dir() {
+            return Err(invalid("operator permit directory required"));
+        }
+        let bytes = serde_json::to_vec(self).map_err(|_| invalid("permit serialization failed"))?;
+        if bytes.len() > 16384 {
+            return Err(invalid("permit exceeds bound"));
+        }
+        let hash = Hash::of(&bytes);
+        let path = directory.join(format!("{}.json", &hash.0[7..]));
+        let mut temporary = tempfile::NamedTempFile::new_in(&directory)?;
+        temporary.write_all(&bytes)?;
+        temporary.as_file().sync_all()?;
+        if let Err(error) = temporary.persist_noclobber(&path) {
+            if error.error.kind() != io::ErrorKind::AlreadyExists {
+                return Err(error.error);
+            }
+            let mut existing = Vec::new();
+            std::fs::File::open(&path)?
+                .take(16385)
+                .read_to_end(&mut existing)?;
+            if existing != bytes {
+                return Err(invalid(
+                    "existing permit differs; preserve uncertain publication",
+                ));
+            }
+        }
+        dir.sync_all()?;
+        Ok(hash)
+    }
+
+    fn issue_at(binding: Binding, admission_window: Duration, now: &HostClock) -> io::Result<Self> {
+        let millis = admission_window.as_millis();
+        if !(1..=300_000).contains(&millis) || admission_window.subsec_nanos() % 1_000_000 != 0 {
+            return Err(invalid(
+                "permit admission window must be 1..=300000 whole milliseconds",
+            ));
+        }
+        let expires = now
+            .boottime_ms
+            .checked_add(millis as u64)
+            .ok_or_else(|| invalid("permit admission clock overflow"))?;
+        let permit = Self {
+            api_version: VERSION.into(),
+            binding,
+            boot_id: now.boot_id.clone(),
+            issued_at_boottime_ms: now.boottime_ms,
+            expires_at_boottime_ms: expires,
+        };
+        permit.validate(&permit.binding, &permit.binding.principal, now)?;
+        Ok(permit)
+    }
+
+    fn validate(
+        &self,
+        expected: &Binding,
+        principal: &str,
+        now: &HostClock,
+    ) -> io::Result<ParentLease> {
+        if self.api_version != VERSION
+            || self.binding != *expected
+            || principal != self.binding.principal
+            || !valid_boot(&self.boot_id)
+            || self.boot_id != now.boot_id
+            || !matches!(
+                self.expires_at_boottime_ms
+                    .checked_sub(self.issued_at_boottime_ms),
+                Some(1..=300_000)
+            )
+            || now.boottime_ms < self.issued_at_boottime_ms
+            || now.boottime_ms >= self.expires_at_boottime_ms
+        {
+            return Err(invalid(
+                "parent permit binding or admission expiry mismatch",
+            ));
+        }
+        self.binding.lease()
+    }
+}
+
+/// Read ONLY from the operator-owned permit directory, never an upload store.
+/// Recheck immediately before claiming the incarnation and starting its owner.
+/// A successful check is NOT a replay claim: the serving owner must create the
+/// durable ParentJournal tombstone before any VM launch. Admission expiry is
+/// distinct from the lifetime enforced by ParentOwner and ParentLease.
+pub fn authorize(
+    root: &Path,
+    permit_hash: &Hash,
+    expected: &Binding,
+    principal: &str,
+) -> io::Result<ParentLease> {
+    if !valid_hash(permit_hash) {
+        return Err(invalid("invalid parent permit hash"));
+    }
+    let mut bytes = Vec::new();
+    std::fs::File::open(
+        root.join("trusted-parent-permits")
+            .join(format!("{}.json", &permit_hash.0[7..])),
+    )?
+    .take(16385)
+    .read_to_end(&mut bytes)?;
+    if bytes.len() > 16384 || Hash::of(&bytes) != *permit_hash {
+        return Err(invalid("parent permit revision mismatch"));
+    }
+    let permit: Permit =
+        serde_json::from_slice(&bytes).map_err(|_| invalid("invalid parent permit"))?;
+    permit.validate(expected, principal, &host_clock()?)
+}
+
+/// Final admission and durable one-use claim, before starting either VM.
+/// Never remove the tombstone after a failed launch: retrying the same
+/// incarnation could duplicate uncertain work or falsely restore context.
+pub fn claim(
+    root: &Path,
+    permit_hash: &Hash,
+    expected: &Binding,
+    principal: &str,
+) -> io::Result<(ParentLease, crate::parent_journal::ParentJournal)> {
+    let lease = authorize(root, permit_hash, expected, principal)?;
+    let journal = crate::parent_journal::ParentJournal::create(
+        &root.join("parent-journal"),
+        expected.incarnation.clone(),
+    )?;
+    journal.bind_owner(principal)?;
+    Ok((lease, journal))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn permit() -> Permit {
+        Permit {
+            api_version: VERSION.into(),
+            boot_id: "01234567-89ab-cdef-0123-456789abcdef".into(),
+            issued_at_boottime_ms: 100,
+            expires_at_boottime_ms: 200,
+            binding: Binding {
+                principal: "namespace/run-uid".into(),
+                incarnation: Hash::of(b"incarnation"),
+                parent_configuration: Hash::of(b"parent"),
+                worker_configuration: Hash::of(b"worker"),
+                parent_memory_bytes: 4096,
+                child_memory_bytes: 4096,
+                lifetime_ms: 60000,
+                turn_timeout_ms: 1000,
+                max_turns: 2,
+                turn_model_requests: 0,
+                turn_output_tokens: 0,
+                total_model_requests: 0,
+                total_output_tokens: 0,
+            },
+        }
+    }
+    #[test]
+    fn binds_every_configuration_field_and_authenticated_principal() {
+        let permit = permit();
+        let now = HostClock {
+            boot_id: permit.boot_id.clone(),
+            boottime_ms: 150,
+        };
+        assert!(permit
+            .validate(&permit.binding, &permit.binding.principal, &now)
+            .is_ok());
+        assert!(permit
+            .validate(&permit.binding, "another-tenant", &now)
+            .is_err());
+        let fields = serde_json::to_value(&permit.binding).unwrap();
+        for (key, value) in fields.as_object().unwrap() {
+            let mut changed = fields.clone();
+            changed[key] = if value.is_string() {
+                serde_json::json!(format!("{}-changed", value.as_str().unwrap()))
+            } else {
+                serde_json::json!(value.as_u64().unwrap() + 1)
+            };
+            let binding = serde_json::from_value(changed).unwrap();
+            assert!(
+                permit
+                    .validate(&binding, &permit.binding.principal, &now)
+                    .is_err(),
+                "{key}"
+            );
+        }
+    }
+    #[test]
+    fn admission_is_exclusive_and_boot_specific() {
+        let mut permit = permit();
+        for (time, valid) in [(99, false), (100, true), (199, true), (200, false)] {
+            let now = HostClock {
+                boot_id: permit.boot_id.clone(),
+                boottime_ms: time,
+            };
+            assert_eq!(
+                permit
+                    .validate(&permit.binding, &permit.binding.principal, &now)
+                    .is_ok(),
+                valid
+            );
+        }
+        let now = HostClock {
+            boot_id: permit.boot_id.clone(),
+            boottime_ms: 150,
+        };
+        permit.boot_id = "11234567-89ab-cdef-0123-456789abcdef".into();
+        assert!(permit
+            .validate(&permit.binding, &permit.binding.principal, &now)
+            .is_err());
+    }
+    #[test]
+    fn invalid_limits_cannot_become_a_lease() {
+        let fields = serde_json::to_value(permit().binding).unwrap();
+        for (field, value) in [
+            ("parentMemoryBytes", 0),
+            ("childMemoryBytes", 0),
+            ("parentMemoryBytes", u64::MAX),
+            ("lifetimeMs", 0),
+            ("lifetimeMs", 86_400_001),
+            ("turnTimeoutMs", 0),
+            ("turnTimeoutMs", 60_001),
+            ("maxTurns", 1025),
+            ("turnModelRequests", 1),
+            ("turnOutputTokens", 1),
+            ("totalModelRequests", 6145),
+            ("totalOutputTokens", 3_145_729),
+        ] {
+            let mut changed = fields.clone();
+            changed[field] = serde_json::json!(value);
+            let binding: Binding = serde_json::from_value(changed).unwrap();
+            assert!(binding.lease().is_err(), "{field}={value}");
+        }
+    }
+
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "kvm"))]
+    fn operator_file_is_required_hash_bound_and_revocable() {
+        let root = tempfile::tempdir().unwrap();
+        let mut permit = permit();
+        let now = host_clock().unwrap();
+        permit.boot_id = now.boot_id;
+        permit.issued_at_boottime_ms = now.boottime_ms;
+        permit.expires_at_boottime_ms = now.boottime_ms + 60_000;
+        let bytes = serde_json::to_vec(&permit).unwrap();
+        let hash = Hash::of(&bytes);
+        let check = || {
+            authorize(
+                root.path(),
+                &hash,
+                &permit.binding,
+                &permit.binding.principal,
+            )
+        };
+        assert!(check().is_err());
+        let directory = root.path().join("trusted-parent-permits");
+        std::fs::create_dir(&directory).unwrap();
+        let path = directory.join(format!("{}.json", &hash.0[7..]));
+        std::fs::write(&path, &bytes).unwrap();
+        assert!(check().is_ok());
+        assert!(authorize(root.path(), &hash, &permit.binding, "impostor").is_err());
+        // Authentication failure must not consume the legitimate incarnation.
+        assert!(claim(root.path(), &hash, &permit.binding, "impostor").is_err());
+        let claimed = claim(
+            root.path(),
+            &hash,
+            &permit.binding,
+            &permit.binding.principal,
+        )
+        .unwrap();
+        drop(claimed);
+        // A freshly issued permit cannot renew an already consumed incarnation.
+        let reissued = Permit::issue(permit.binding.clone(), Duration::from_secs(30)).unwrap();
+        let reissued_bytes = serde_json::to_vec(&reissued).unwrap();
+        let reissued_hash = Hash::of(&reissued_bytes);
+        assert_ne!(reissued_hash, hash);
+        std::fs::write(
+            directory.join(format!("{}.json", &reissued_hash.0[7..])),
+            reissued_bytes,
+        )
+        .unwrap();
+        assert!(authorize(
+            root.path(),
+            &reissued_hash,
+            &permit.binding,
+            &permit.binding.principal
+        )
+        .is_ok());
+        assert!(claim(
+            root.path(),
+            &reissued_hash,
+            &permit.binding,
+            &permit.binding.principal
+        )
+        .is_err());
+        assert!(claim(
+            root.path(),
+            &hash,
+            &permit.binding,
+            &permit.binding.principal
+        )
+        .is_err());
+        std::fs::write(&path, b"{}").unwrap();
+        assert!(check().is_err());
+        std::fs::remove_file(&path).unwrap();
+        assert!(check().is_err());
+        assert!(authorize(
+            root.path(),
+            &Hash("../../outside".into()),
+            &permit.binding,
+            &permit.binding.principal
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn issuance_preserves_binding_and_refuses_invalid_clock_window_or_limits() {
+        let binding = permit().binding;
+        let now = HostClock {
+            boot_id: permit().boot_id,
+            boottime_ms: 400,
+        };
+        for window in [1, 120_000, 300_000] {
+            let issued =
+                Permit::issue_at(binding.clone(), Duration::from_millis(window), &now).unwrap();
+            assert_eq!(issued.binding, binding);
+            assert_eq!(issued.issued_at_boottime_ms, 400);
+            assert_eq!(issued.expires_at_boottime_ms, 400 + window);
+            assert_eq!(issued.boot_id, now.boot_id);
+            assert!(issued.validate(&binding, &binding.principal, &now).is_ok());
+        }
+        for window in [
+            Duration::ZERO,
+            Duration::from_millis(300_001),
+            Duration::from_nanos(1_000_001),
+        ] {
+            assert!(Permit::issue_at(binding.clone(), window, &now).is_err());
+        }
+        for bad in [
+            HostClock {
+                boot_id: "client-clock".into(),
+                boottime_ms: 400,
+            },
+            HostClock {
+                boot_id: now.boot_id.clone(),
+                boottime_ms: u64::MAX,
+            },
+        ] {
+            assert!(Permit::issue_at(binding.clone(), Duration::from_secs(1), &bad).is_err());
+        }
+        let mut invalid = binding;
+        invalid.max_turns = 1025;
+        assert!(Permit::issue_at(invalid, Duration::from_secs(1), &now).is_err());
+    }
+
+    #[test]
+    fn publication_is_bounded_nonreplacing_and_recovers_only_identical_bytes() {
+        let root = tempfile::tempdir().unwrap();
+        let permit = permit();
+        let now = HostClock {
+            boot_id: permit.boot_id.clone(),
+            boottime_ms: 150,
+        };
+        assert!(permit.publish_at(root.path(), &now).is_err());
+        assert!(permit.publish_at(Path::new("."), &now).is_err());
+        let directory = root.path().join("trusted-parent-permits");
+        assert!(!directory.exists());
+        std::fs::create_dir(&directory).unwrap();
+        let hash = permit.publish_at(root.path(), &now).unwrap();
+        assert_eq!(permit.publish_at(root.path(), &now).unwrap(), hash);
+        let path = directory.join(format!("{}.json", &hash.0[7..]));
+        let raw = std::fs::read(&path).unwrap();
+        assert_eq!(Hash::of(&raw), hash);
+        assert_eq!(std::fs::read_dir(&directory).unwrap().count(), 1);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        std::fs::write(&path, b"partial").unwrap();
+        assert!(permit.publish_at(root.path(), &now).is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), b"partial");
+        assert_eq!(std::fs::read_dir(&directory).unwrap().count(), 1);
+        let expired = HostClock {
+            boot_id: now.boot_id,
+            boottime_ms: 200,
+        };
+        assert!(permit.publish_at(root.path(), &expired).is_err());
+    }
+
+    #[test]
+    fn concurrent_identical_publication_preserves_one_record() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = root.path().join("trusted-parent-permits");
+        std::fs::create_dir(&directory).unwrap();
+        let permit = permit();
+        let now = HostClock {
+            boot_id: permit.boot_id.clone(),
+            boottime_ms: 150,
+        };
+        std::thread::scope(|scope| {
+            let first = scope.spawn(|| permit.publish_at(root.path(), &now).unwrap());
+            let second = scope.spawn(|| permit.publish_at(root.path(), &now).unwrap());
+            assert_eq!(first.join().unwrap(), second.join().unwrap());
+        });
+        assert_eq!(std::fs::read_dir(&directory).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn run_issuance_recovers_original_permit_without_renewal_or_changed_intent() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = root.path().join("parent-issuance");
+        let mut binding = permit().binding;
+        binding.incarnation = run_incarnation("cluster-a", "run-uid").unwrap();
+        let intent = Hash::of(b"complete authorized intent");
+        let now = HostClock {
+            boot_id: permit().boot_id,
+            boottime_ms: 100,
+        };
+        let issue = |at: &HostClock, intent: &Hash, binding: Binding| {
+            issue_for_run_at(
+                root.path(),
+                "cluster-a",
+                "run-uid",
+                intent,
+                binding,
+                Duration::from_millis(100),
+                at,
+            )
+        };
+        assert!(issue(&now, &intent, binding.clone()).is_err());
+        assert!(!directory.exists());
+        std::fs::create_dir(&directory).unwrap();
+        let first = issue(&now, &intent, binding.clone()).unwrap();
+        let later = HostClock {
+            boot_id: now.boot_id.clone(),
+            boottime_ms: 150,
+        };
+        let recovered = issue(&later, &intent, binding.clone()).unwrap();
+        assert_eq!(
+            serde_json::to_vec(&first).unwrap(),
+            serde_json::to_vec(&recovered).unwrap()
+        );
+        assert!(issue(&later, &Hash::of(b"changed intent"), binding.clone()).is_err());
+        let mut changed = binding.clone();
+        changed.max_turns -= 1;
+        assert!(issue(&later, &intent, changed).is_err());
+        assert!(issue_for_run_at(
+            root.path(),
+            "cluster-a",
+            "run-uid",
+            &intent,
+            binding.clone(),
+            Duration::from_millis(200),
+            &later
+        )
+        .is_err());
+        let expired = HostClock {
+            boot_id: now.boot_id,
+            boottime_ms: 200,
+        };
+        assert!(issue(&expired, &intent, binding.clone()).is_err());
+        assert_eq!(std::fs::read_dir(&directory).unwrap().count(), 1);
+        let path = directory.join(format!("{}.json", &binding.incarnation.0[7..]));
+        let record: RunIssuance = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(record.permit.expires_at_boottime_ms, 200);
+        std::fs::write(&path, b"partial").unwrap();
+        assert!(issue(&later, &intent, binding).is_err());
+        assert_eq!(std::fs::read(path).unwrap(), b"partial");
+        assert_ne!(
+            run_incarnation("cluster-a", "run-uid").unwrap(),
+            run_incarnation("cluster-b", "run-uid").unwrap()
+        );
+        assert_ne!(
+            run_incarnation("cluster-a", "run-uid").unwrap(),
+            run_incarnation("cluster-a", "new-uid").unwrap()
+        );
+    }
+
+    #[test]
+    fn competing_run_issuers_cannot_replace_the_winning_intent() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("parent-issuance")).unwrap();
+        let mut binding = permit().binding;
+        binding.incarnation = run_incarnation("cluster", "uid").unwrap();
+        let now = HostClock {
+            boot_id: permit().boot_id,
+            boottime_ms: 100,
+        };
+        let results = std::thread::scope(|scope| {
+            let first = scope.spawn(|| {
+                issue_for_run_at(
+                    root.path(),
+                    "cluster",
+                    "uid",
+                    &Hash::of(b"first intent"),
+                    binding.clone(),
+                    Duration::from_secs(1),
+                    &now,
+                )
+            });
+            let second = scope.spawn(|| {
+                issue_for_run_at(
+                    root.path(),
+                    "cluster",
+                    "uid",
+                    &Hash::of(b"second intent"),
+                    binding.clone(),
+                    Duration::from_secs(1),
+                    &now,
+                )
+            });
+            [first.join().unwrap(), second.join().unwrap()]
+        });
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            std::fs::read_dir(root.path().join("parent-issuance"))
+                .unwrap()
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "kvm"))]
+    fn local_issuance_uses_current_host_clock() {
+        let before = host_clock().unwrap();
+        let issued = Permit::issue(permit().binding, Duration::from_secs(60)).unwrap();
+        let after = host_clock().unwrap();
+        assert_eq!(issued.boot_id, before.boot_id);
+        assert_eq!(issued.boot_id, after.boot_id);
+        assert!(
+            issued.issued_at_boottime_ms >= before.boottime_ms
+                && issued.issued_at_boottime_ms <= after.boottime_ms
+        );
+        assert_eq!(
+            issued.expires_at_boottime_ms - issued.issued_at_boottime_ms,
+            60_000
+        );
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("trusted-parent-permits")).unwrap();
+        let hash = issued.publish(root.path()).unwrap();
+        assert!(authorize(
+            root.path(),
+            &hash,
+            &issued.binding,
+            &issued.binding.principal
+        )
+        .is_ok());
+        assert_eq!(issued.publish(root.path()).unwrap(), hash);
+    }
+    #[test]
+    fn model_free_parent_permit_produces_bounded_lease() {
+        let permit = permit();
+        let mut lease = permit.binding.lease().unwrap();
+        for id in ["one", "two"] {
+            let bytes = serde_json::to_vec(&serde_json::json!({"apiVersion":crate::parent_protocol::VERSION,"turnId":id,"task":"tool input"})).unwrap();
+            let turn = lease.reserve(&bytes).unwrap();
+            assert_eq!(turn.limits.model_requests, 0);
+            lease.confirm_child_destroyed(&turn.child).unwrap();
+        }
+        assert!(lease
+            .reserve(br#"{"apiVersion":"celln.parent-turn/v1","turnId":"three","task":"input"}"#)
+            .is_err());
+    }
+}

--- a/crates/celln-warden/src/parent_protocol.rs
+++ b/crates/celln-warden/src/parent_protocol.rs
@@ -1,0 +1,147 @@
+//! Bounded data protocol for a future persistent Harness parent's turn worker.
+//!
+//! This is a parser, NOT spawn authority or an implemented persistent VM path.
+//! The host must bind every accepted request to an admitted parent, lease,
+//! monotonic turn record, worker and narrowed grants before creating a child.
+//! No executable hashes, credentials, endpoints or resource grants come from
+//! this untrusted guest request. Existing invocation/HTTPS PIO ABIs are unchanged.
+
+use serde::{Deserialize, Serialize};
+
+pub const VERSION: &str = "celln.parent-turn/v1";
+pub const MAX_REQUEST_BYTES: usize = 8192;
+pub const MAX_TASK_BYTES: usize = 2048;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct TurnRequest {
+    pub api_version: String,
+    /// Idempotency data, scoped by the host to this parent identity. This is
+    /// never sufficient to select another parent's execution owner.
+    pub turn_id: String,
+    /// Input to the admitted native turn worker, not a host command.
+    pub task: String,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ProtocolError {
+    #[error("parent turn request exceeds its encoded bound or is empty")]
+    Size,
+    #[error("invalid parent turn JSON envelope")]
+    Envelope,
+    #[error("unsupported parent turn protocol version")]
+    Version,
+    #[error("invalid parent-scoped turn identity")]
+    Identity,
+    #[error("turn task is empty, contains NUL, or exceeds worker input bound")]
+    Task,
+}
+
+impl TurnRequest {
+    pub fn decode(bytes: &[u8]) -> Result<Self, ProtocolError> {
+        if bytes.is_empty() || bytes.len() > MAX_REQUEST_BYTES {
+            return Err(ProtocolError::Size);
+        }
+        let request: Self = serde_json::from_slice(bytes).map_err(|_| ProtocolError::Envelope)?;
+        if request.api_version != VERSION {
+            return Err(ProtocolError::Version);
+        }
+        if request.turn_id.is_empty()
+            || request.turn_id.len() > 64
+            || !request
+                .turn_id
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+        {
+            return Err(ProtocolError::Identity);
+        }
+        if request.task.trim().is_empty()
+            || request.task.len() > MAX_TASK_BYTES
+            || request.task.contains('\0')
+        {
+            return Err(ProtocolError::Task);
+        }
+        Ok(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn envelope(task: &str) -> serde_json::Value {
+        serde_json::json!({"apiVersion": VERSION, "turnId": "turn-1", "task": task})
+    }
+
+    #[test]
+    fn accepts_bounded_task_data_without_authority_fields() {
+        let value = envelope("Use the approved worker to answer the next message.");
+        let request = TurnRequest::decode(&serde_json::to_vec(&value).unwrap()).unwrap();
+        assert_eq!(request.turn_id, "turn-1");
+    }
+
+    #[test]
+    fn refuses_guest_supplied_authority_and_duplicate_or_trailing_fields() {
+        for name in [
+            "parentId",
+            "childId",
+            "executable",
+            "toolRefs",
+            "token",
+            "endpoint",
+            "memoryBytes",
+            "lease",
+        ] {
+            let mut value = envelope("hello");
+            value[name] = serde_json::json!("untrusted");
+            assert_eq!(
+                TurnRequest::decode(&serde_json::to_vec(&value).unwrap()),
+                Err(ProtocolError::Envelope)
+            );
+        }
+        assert_eq!(TurnRequest::decode(br#"{"apiVersion":"celln.parent-turn/v1","turnId":"a","turnId":"b","task":"hello"}"#), Err(ProtocolError::Envelope));
+        let mut bytes = serde_json::to_vec(&envelope("hello")).unwrap();
+        bytes.extend(b"{}");
+        assert_eq!(TurnRequest::decode(&bytes), Err(ProtocolError::Envelope));
+    }
+
+    #[test]
+    fn refuses_unknown_versions_and_unsafe_identities() {
+        let mut value = envelope("hello");
+        value["apiVersion"] = serde_json::json!("celln.parent-turn/v2");
+        assert_eq!(
+            TurnRequest::decode(&serde_json::to_vec(&value).unwrap()),
+            Err(ProtocolError::Version)
+        );
+        for id in ["", "../other-parent", "other/turn", "with space"] {
+            let mut value = envelope("hello");
+            value["turnId"] = serde_json::json!(id);
+            assert_eq!(
+                TurnRequest::decode(&serde_json::to_vec(&value).unwrap()),
+                Err(ProtocolError::Identity)
+            );
+        }
+    }
+
+    #[test]
+    fn enforces_encoded_and_utf8_byte_bounds() {
+        assert_eq!(TurnRequest::decode(&[]), Err(ProtocolError::Size));
+        assert_eq!(
+            TurnRequest::decode(&vec![b' '; MAX_REQUEST_BYTES + 1]),
+            Err(ProtocolError::Size)
+        );
+        for task in [
+            String::new(),
+            "\0".into(),
+            "x".repeat(MAX_TASK_BYTES + 1),
+            "é".repeat(1025),
+        ] {
+            assert_eq!(
+                TurnRequest::decode(&serde_json::to_vec(&envelope(&task)).unwrap()),
+                Err(ProtocolError::Task)
+            );
+        }
+        TurnRequest::decode(&serde_json::to_vec(&envelope(&"x".repeat(MAX_TASK_BYTES))).unwrap())
+            .unwrap();
+    }
+}

--- a/crates/celln-warden/src/parent_registry.rs
+++ b/crates/celln-warden/src/parent_registry.rs
@@ -1,0 +1,608 @@
+//! Caller-scoped live-owner routing. Authentication and durable permit claims
+//! precede this boundary; a caller string from an HTTP body is NOT authentication.
+//! Entries are never replaced, including after owner loss. Durable tombstones
+//! additionally prevent replay across registry/process restarts.
+use crate::parent_owner::{OwnerStatus, ParentOwner};
+use celln_manifest::Hash;
+use std::{
+    collections::BTreeMap,
+    sync::{mpsc, Mutex},
+    time::Duration,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Status {
+    Initializing,
+    Ready,
+    TurnActive,
+    ContextLost,
+    Stopping,
+    Stopped,
+    TeardownUncertain,
+}
+
+struct Entry {
+    principal: String,
+    owner: Option<ParentOwner>,
+    status: Status,
+    reserved_bytes: u64,
+}
+struct State {
+    entries: BTreeMap<String, Entry>,
+    reserved_bytes: u64,
+}
+pub struct ParentRegistry {
+    state: Mutex<State>,
+    max_entries: usize,
+    memory_bytes: u64,
+}
+
+/// Includes stopping and teardown-uncertain owners until a confirmed join.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReservedCapacity {
+    pub owners: u32,
+    pub memory_bytes: u64,
+}
+
+impl ParentRegistry {
+    /// Join only already-finished owners. Never cancel live work or wait for
+    /// an active handler. Keep identities and context-loss status after release;
+    /// a reclaimed reservation is not permission to recreate this incarnation.
+    pub fn reap_finished(&self) -> Result<usize, String> {
+        let finished = {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| "parent registry unavailable")?;
+            state
+                .entries
+                .iter_mut()
+                .filter_map(|(id, entry)| {
+                    if entry.owner.as_ref().is_some_and(ParentOwner::is_finished) {
+                        entry.status = Status::Stopping;
+                        Some((id.clone(), entry.owner.take().unwrap()))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+        };
+        let mut released = 0;
+        for (id, owner) in finished {
+            // Even an observed thread exit is not a successful join: panic
+            // remains teardown-uncertain and conservatively charged.
+            let joined = owner.stop_and_join().is_ok();
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| "parent registry unavailable")?;
+            let entry = state.entries.get_mut(&id).unwrap();
+            if joined {
+                entry.status = Status::ContextLost;
+                let bytes = std::mem::take(&mut entry.reserved_bytes);
+                state.reserved_bytes -= bytes;
+                released += 1;
+            } else {
+                entry.status = Status::TeardownUncertain;
+            }
+        }
+        Ok(released)
+    }
+
+    pub fn reserved_capacity(&self) -> Result<ReservedCapacity, String> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| "parent registry unavailable")?;
+        Ok(ReservedCapacity {
+            owners: state
+                .entries
+                .values()
+                .filter(|entry| entry.reserved_bytes != 0)
+                .count() as u32,
+            memory_bytes: state.reserved_bytes,
+        })
+    }
+    /// Budget must include parent, child and retained warm-mote memory as
+    /// measured/accounted by the serving layer. This is logical reservation,
+    /// not a claim about physical residency or a hardware RAM limit.
+    pub fn new(max_entries: usize, memory_bytes: u64) -> Result<Self, String> {
+        if !(1..=1024).contains(&max_entries) || memory_bytes == 0 {
+            return Err("invalid parent registry capacity".into());
+        }
+        Ok(Self {
+            state: Mutex::new(State {
+                entries: BTreeMap::new(),
+                reserved_bytes: 0,
+            }),
+            max_entries,
+            memory_bytes,
+        })
+    }
+
+    /// Call only after independent admission and durable incarnation claim.
+    /// Initialization runs on the owner thread, not under the registry lock.
+    /// A failed initialization keeps its identity occupied; it cannot be retried.
+    pub fn spawn_admitted<F, H>(
+        &self,
+        principal: &str,
+        incarnation: &Hash,
+        lifetime: Duration,
+        reserved_bytes: u64,
+        initialize: F,
+    ) -> Result<(), String>
+    where
+        F: FnOnce() -> Result<H, String> + Send + 'static,
+        H: FnMut(&[u8]) -> Result<Vec<u8>, String> + 'static,
+    {
+        self.insert_admitted(principal, incarnation, reserved_bytes, || {
+            ParentOwner::spawn(lifetime, initialize)
+        })
+    }
+
+    /// Native runtimes explicitly opt in to exact child cancellation. Legacy
+    /// owners keep their existing contract and cannot masquerade as supporting it.
+    pub fn spawn_admitted_with_children<F, H>(
+        &self,
+        principal: &str,
+        incarnation: &Hash,
+        lifetime: Duration,
+        reserved_bytes: u64,
+        initialize: F,
+    ) -> Result<(), String>
+    where
+        F: FnOnce(
+                std::sync::Arc<crate::parent_child_control::ChildControlSlot>,
+            ) -> Result<H, String>
+            + Send
+            + 'static,
+        H: FnMut(&[u8]) -> Result<Vec<u8>, String> + 'static,
+    {
+        self.insert_admitted(principal, incarnation, reserved_bytes, || {
+            ParentOwner::spawn_with_children(incarnation.clone(), lifetime, initialize)
+        })
+    }
+
+    fn insert_admitted(
+        &self,
+        principal: &str,
+        incarnation: &Hash,
+        reserved_bytes: u64,
+        spawn: impl FnOnce() -> std::io::Result<ParentOwner>,
+    ) -> Result<(), String> {
+        if principal.is_empty() || principal.len() > 512 || reserved_bytes == 0 {
+            return Err("invalid admitted owner binding".into());
+        }
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "parent registry unavailable")?;
+        if state.entries.contains_key(&incarnation.0) {
+            return Err("parent incarnation already claimed; reconcile original owner".into());
+        }
+        let total = state
+            .reserved_bytes
+            .checked_add(reserved_bytes)
+            .ok_or("parent memory capacity exhausted")?;
+        if state.entries.len() >= self.max_entries || total > self.memory_bytes {
+            return Err("parent registry capacity exhausted".into());
+        }
+        let owner = spawn().map_err(|e| e.to_string())?;
+        state.reserved_bytes = total;
+        state.entries.insert(
+            incarnation.0.clone(),
+            Entry {
+                principal: principal.into(),
+                owner: Some(owner),
+                status: Status::Initializing,
+                reserved_bytes,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn submit(
+        &self,
+        principal: &str,
+        incarnation: &Hash,
+        bytes: &[u8],
+    ) -> Result<mpsc::Receiver<Result<Vec<u8>, String>>, String> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| "parent registry unavailable")?;
+        let entry = scoped(&state, principal, incarnation)?;
+        entry
+            .owner
+            .as_ref()
+            .ok_or("parent owner unavailable; context lost")?
+            .submit(bytes)
+    }
+
+    pub fn status(&self, principal: &str, incarnation: &Hash) -> Result<Status, String> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| "parent registry unavailable")?;
+        let entry = scoped(&state, principal, incarnation)?;
+        Ok(match entry.owner.as_ref().map(ParentOwner::status) {
+            Some(OwnerStatus::Initializing) => Status::Initializing,
+            Some(OwnerStatus::Ready) => Status::Ready,
+            Some(OwnerStatus::TurnActive) => Status::TurnActive,
+            Some(OwnerStatus::Stopping) => Status::Stopping,
+            Some(OwnerStatus::ContextLost) => Status::ContextLost,
+            None => entry.status,
+        })
+    }
+
+    /// Request cancellation only. Resources remain charged until stop joins.
+    pub fn cancel(&self, principal: &str, incarnation: &Hash) -> Result<(), String> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| "parent registry unavailable")?;
+        let entry = scoped(&state, principal, incarnation)?;
+        if let Some(owner) = &entry.owner {
+            owner.cancel();
+        }
+        Ok(())
+    }
+
+    /// Signal a caller-scoped exact child without waiting on its running handler.
+    /// Parent ownership and capacity remain charged; this is not joined teardown.
+    pub fn cancel_child(
+        &self,
+        principal: &str,
+        identity: &crate::parent_child_control::Identity,
+    ) -> Result<(), String> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| "parent registry unavailable")?;
+        let entry = scoped(&state, principal, &identity.parent)?;
+        entry
+            .owner
+            .as_ref()
+            .ok_or("original parent owner unavailable")?
+            .cancel_child(identity)
+    }
+
+    /// Cancellation + confirmed join, without holding the registry lock across
+    /// guest teardown. Concurrent stop observes Stopping, never false success.
+    /// A panicked owner remains conservatively charged as teardown uncertain.
+    pub fn stop(&self, principal: &str, incarnation: &Hash) -> Result<(), String> {
+        let owner = {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| "parent registry unavailable")?;
+            scoped(&state, principal, incarnation)?;
+            let entry = state.entries.get_mut(&incarnation.0).unwrap();
+            if entry.status == Status::Stopped
+                || (entry.status == Status::ContextLost && entry.reserved_bytes == 0)
+            {
+                return Ok(());
+            }
+            let owner = entry
+                .owner
+                .take()
+                .ok_or("parent teardown pending or uncertain")?;
+            entry.status = Status::Stopping;
+            owner
+        };
+        let result = owner.stop_and_join();
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "parent registry unavailable")?;
+        let entry = state.entries.get_mut(&incarnation.0).unwrap();
+        if result.is_ok() {
+            entry.status = Status::Stopped;
+            let released = std::mem::take(&mut entry.reserved_bytes);
+            state.reserved_bytes -= released;
+        } else {
+            entry.status = Status::TeardownUncertain;
+        }
+        result
+    }
+}
+
+fn scoped<'a>(state: &'a State, principal: &str, incarnation: &Hash) -> Result<&'a Entry, String> {
+    state
+        .entries
+        .get(&incarnation.0)
+        .filter(|e| e.principal == principal)
+        .ok_or_else(|| "parent owner not found".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn spawn(registry: &ParentRegistry, id: &Hash) -> Result<(), String> {
+        registry.spawn_admitted("tenant-one", id, Duration::from_secs(10), 100, || {
+            Ok(|bytes: &[u8]| Ok(bytes.to_vec()))
+        })
+    }
+    #[test]
+    fn tenant_scope_applies_to_submit_status_and_stop() {
+        let registry = ParentRegistry::new(4, 200).unwrap();
+        let id = Hash::of(b"one");
+        spawn(&registry, &id).unwrap();
+        assert!(registry.submit("tenant-two", &id, b"input").is_err());
+        assert!(registry.stop("tenant-two", &id).is_err());
+        assert!(registry.cancel("tenant-two", &id).is_err());
+        assert_eq!(
+            registry.status("tenant-two", &id).unwrap_err(),
+            registry
+                .status("tenant-two", &Hash::of(b"missing"))
+                .unwrap_err()
+        );
+        let response = registry.submit("tenant-one", &id, b"input").unwrap();
+        assert_eq!(
+            response
+                .recv_timeout(Duration::from_secs(2))
+                .unwrap()
+                .unwrap(),
+            b"input"
+        );
+        registry.stop("tenant-one", &id).unwrap();
+        assert_eq!(registry.status("tenant-one", &id).unwrap(), Status::Stopped);
+        assert!(spawn(&registry, &id).is_err());
+        registry.stop("tenant-one", &id).unwrap();
+    }
+    #[test]
+    fn capacity_is_retained_until_join_and_identity_never_reused() {
+        let registry = ParentRegistry::new(2, 100).unwrap();
+        let one = Hash::of(b"one");
+        let two = Hash::of(b"two");
+        spawn(&registry, &one).unwrap();
+        assert!(spawn(&registry, &two).is_err());
+        registry.stop("tenant-one", &one).unwrap();
+        spawn(&registry, &two).unwrap();
+        registry.stop("tenant-one", &two).unwrap();
+        assert!(spawn(&registry, &Hash::of(b"three")).is_err());
+    }
+    #[test]
+    fn reaping_releases_expired_owner_but_preserves_context_loss_and_identity() {
+        let registry = ParentRegistry::new(3, 200).unwrap();
+        let expired = Hash::of(b"expired");
+        let live = Hash::of(b"live");
+        registry
+            .spawn_admitted(
+                "tenant-one",
+                &expired,
+                Duration::from_millis(20),
+                100,
+                || Ok(|bytes: &[u8]| Ok(bytes.to_vec())),
+            )
+            .unwrap();
+        spawn(&registry, &live).unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while registry.reap_finished().unwrap() == 0 {
+            assert!(std::time::Instant::now() < deadline);
+            std::thread::yield_now();
+        }
+        assert_eq!(
+            registry.status("tenant-one", &expired).unwrap(),
+            Status::ContextLost
+        );
+        assert_eq!(
+            registry.reserved_capacity().unwrap(),
+            ReservedCapacity {
+                owners: 1,
+                memory_bytes: 100
+            }
+        );
+        assert!(registry.submit("tenant-one", &expired, b"retry").is_err());
+        assert!(spawn(&registry, &expired).is_err());
+        assert!(registry.status("tenant-two", &expired).is_err());
+        registry.stop("tenant-one", &expired).unwrap();
+        assert_eq!(
+            registry.status("tenant-one", &expired).unwrap(),
+            Status::ContextLost
+        );
+        assert_eq!(registry.reap_finished().unwrap(), 0);
+        assert_eq!(
+            registry
+                .submit("tenant-one", &live, b"still alive")
+                .unwrap()
+                .recv_timeout(Duration::from_secs(2))
+                .unwrap()
+                .unwrap(),
+            b"still alive"
+        );
+        registry.stop("tenant-one", &live).unwrap();
+    }
+
+    #[test]
+    fn reaping_panicked_owner_never_releases_capacity() {
+        let registry = ParentRegistry::new(2, 100).unwrap();
+        let id = Hash::of(b"reap-panic");
+        registry
+            .spawn_admitted("tenant-one", &id, Duration::from_secs(10), 100, || {
+                Ok(|_: &[u8]| -> Result<Vec<u8>, String> { panic!("test panic") })
+            })
+            .unwrap();
+        assert!(registry
+            .submit("tenant-one", &id, b"panic")
+            .unwrap()
+            .recv_timeout(Duration::from_secs(2))
+            .is_err());
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            assert_eq!(registry.reap_finished().unwrap(), 0);
+            if registry.status("tenant-one", &id).unwrap() == Status::TeardownUncertain {
+                break;
+            }
+            assert!(std::time::Instant::now() < deadline);
+            std::thread::yield_now();
+        }
+        assert_eq!(
+            registry.reserved_capacity().unwrap(),
+            ReservedCapacity {
+                owners: 1,
+                memory_bytes: 100
+            }
+        );
+        assert!(registry.stop("tenant-one", &id).is_err());
+        assert!(spawn(&registry, &Hash::of(b"replacement")).is_err());
+    }
+    #[test]
+    fn failed_owner_reports_context_loss_and_panicked_join_retains_capacity() {
+        let registry = ParentRegistry::new(2, 100).unwrap();
+        let id = Hash::of(b"panic");
+        registry
+            .spawn_admitted("tenant-one", &id, Duration::from_secs(10), 100, || {
+                Ok(|_: &[u8]| -> Result<Vec<u8>, String> { panic!("test owner panic") })
+            })
+            .unwrap();
+        let response = registry.submit("tenant-one", &id, b"input").unwrap();
+        assert!(response.recv_timeout(Duration::from_secs(2)).is_err());
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while registry.status("tenant-one", &id).unwrap() != Status::ContextLost {
+            assert!(std::time::Instant::now() < deadline);
+            std::thread::yield_now();
+        }
+        assert!(registry.stop("tenant-one", &id).is_err());
+        assert_eq!(
+            registry.status("tenant-one", &id).unwrap(),
+            Status::TeardownUncertain
+        );
+        assert_eq!(
+            registry.reserved_capacity().unwrap(),
+            ReservedCapacity {
+                owners: 1,
+                memory_bytes: 100
+            }
+        );
+        assert!(spawn(&registry, &Hash::of(b"new")).is_err());
+        assert!(spawn(&registry, &id).is_err());
+    }
+    #[test]
+    fn teardown_does_not_lock_other_owners_and_stop_is_not_early_success() {
+        let registry = std::sync::Arc::new(ParentRegistry::new(3, 300).unwrap());
+        let one = Hash::of(b"one");
+        let two = Hash::of(b"two");
+        let (started, ready) = mpsc::sync_channel(1);
+        let (release, wait) = mpsc::sync_channel(1);
+        registry
+            .spawn_admitted(
+                "tenant-one",
+                &one,
+                Duration::from_secs(10),
+                100,
+                move || {
+                    Ok(move |_: &[u8]| {
+                        started.send(()).unwrap();
+                        wait.recv().unwrap();
+                        Ok(vec![1])
+                    })
+                },
+            )
+            .unwrap();
+        let reply = registry.submit("tenant-one", &one, b"input").unwrap();
+        ready.recv_timeout(Duration::from_secs(2)).unwrap();
+        let other = registry.clone();
+        let stop_id = one.clone();
+        let stopper = std::thread::spawn(move || other.stop("tenant-one", &stop_id));
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while registry.status("tenant-one", &one).unwrap() != Status::Stopping {
+            assert!(std::time::Instant::now() < deadline);
+            std::thread::yield_now();
+        }
+        assert!(registry.stop("tenant-one", &one).is_err());
+        spawn(&registry, &two).unwrap();
+        registry.stop("tenant-one", &two).unwrap();
+        release.send(()).unwrap();
+        stopper.join().unwrap().unwrap();
+        assert!(reply.recv_timeout(Duration::from_secs(2)).unwrap().is_err());
+    }
+
+    #[test]
+    fn scoped_child_cancel_routes_while_handler_runs_and_never_retargets() {
+        // Real owner thread/control routing, synthetic worker: no VM guarantee.
+        use crate::{
+            parent_lease::{ReservedTurn, TurnLimits},
+            parent_protocol::TurnRequest,
+        };
+        let registry = ParentRegistry::new(2, 8192).unwrap();
+        let parent = Hash::of(b"scoped-parent");
+        let bound = parent.clone();
+        let (entered, ready) = mpsc::sync_channel(1);
+        registry
+            .spawn_admitted_with_children(
+                "tenant",
+                &parent,
+                Duration::from_secs(30),
+                4096,
+                move |children| {
+                    Ok(move |bytes: &[u8]| {
+                        let turn = String::from_utf8(bytes.to_vec()).map_err(|e| e.to_string())?;
+                        let reserved = ReservedTurn {
+                            parent: bound.clone(),
+                            child: Hash::of(&serde_json::to_vec(&(&bound.0, &turn)).unwrap()),
+                            request: TurnRequest {
+                                api_version: crate::parent_protocol::VERSION.into(),
+                                turn_id: turn,
+                                task: "data".into(),
+                            },
+                            limits: TurnLimits {
+                                memory_bytes: 4096,
+                                timeout: Duration::from_secs(5),
+                                model_requests: 0,
+                                output_tokens: 0,
+                            },
+                        };
+                        let (identity, child) = children.register(&reserved)?;
+                        entered.send(identity.clone()).map_err(|e| e.to_string())?;
+                        child.scope(|| {
+                            while celln_control::check().is_ok() {
+                                std::thread::sleep(Duration::from_millis(1));
+                            }
+                        });
+                        celln_control::check().map_err(|e| e.to_string())?;
+                        children.retire(&identity)?;
+                        Ok(b"cancelled-child-only".to_vec())
+                    })
+                },
+            )
+            .unwrap();
+        let first = registry.submit("tenant", &parent, b"first").unwrap();
+        let old = ready.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(registry.cancel_child("other-tenant", &old).is_err());
+        assert_eq!(
+            registry.status("tenant", &parent).unwrap(),
+            Status::TurnActive
+        );
+        registry.cancel_child("tenant", &old).unwrap();
+        assert_eq!(
+            first.recv_timeout(Duration::from_secs(2)).unwrap().unwrap(),
+            b"cancelled-child-only"
+        );
+        assert_eq!(registry.status("tenant", &parent).unwrap(), Status::Ready);
+        assert_eq!(registry.reserved_capacity().unwrap().memory_bytes, 4096);
+        let second = registry.submit("tenant", &parent, b"second").unwrap();
+        let next = ready.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(registry.cancel_child("tenant", &old).is_err());
+        assert_eq!(
+            registry.status("tenant", &parent).unwrap(),
+            Status::TurnActive
+        );
+        registry.cancel_child("tenant", &next).unwrap();
+        assert!(second.recv_timeout(Duration::from_secs(2)).unwrap().is_ok());
+        registry.stop("tenant", &parent).unwrap();
+        assert!(registry.cancel_child("tenant", &next).is_err());
+        assert_eq!(registry.reserved_capacity().unwrap().memory_bytes, 0);
+
+        let legacy = Hash::of(b"legacy-parent");
+        registry
+            .spawn_admitted("tenant", &legacy, Duration::from_secs(30), 4096, || {
+                Ok(|_: &[u8]| Ok(vec![]))
+            })
+            .unwrap();
+        let mut unsupported = next;
+        unsupported.parent = legacy.clone();
+        assert!(registry.cancel_child("tenant", &unsupported).is_err());
+        registry.stop("tenant", &legacy).unwrap();
+    }
+}

--- a/crates/celln-warden/src/vmm/boot.rs
+++ b/crates/celln-warden/src/vmm/boot.rs
@@ -223,9 +223,9 @@ pub enum BootEnd {
     TimedOut,
     /// The vCPU halted with nothing left to wake it.
     Halted,
-    /// The guest printed the marker set by
-    /// [`LinuxCell::stop_when_guest_prints`]. The vCPU is at a clean exit
-    /// boundary and can be parked with [`LinuxCell::park`].
+    /// The guest reached a configured marker/live signal or committed a parent
+    /// mailbox response. A parent must resume this same VM; it cannot be made
+    /// into a reusable mote. Inspect `take_parent_response` for mailbox data.
     Parked,
 }
 
@@ -838,6 +838,8 @@ pub struct LinuxCell {
     fetch_response: VecDeque<u8>,
     /// Per-cell, one-shot invocation data. Never captured in a mote.
     invocation: Option<VecDeque<u8>>,
+    /// Live parent data is never captured into a reusable mote.
+    parent_mailbox: Option<crate::parent_mailbox::ParentMailbox>,
     /// The PCI configuration address latch (port 0xcf8).
     ///
     /// We emulate no PCI devices, but the kernel must still *detect* a type-1
@@ -984,6 +986,7 @@ impl LinuxCell {
             fetch_activity: (0, 0, 0),
             fetch_response: VecDeque::new(),
             invocation: None,
+            parent_mailbox: None,
             pci_cf8: 0,
             revoke_trigger: None,
             stop_marker: None,
@@ -1053,6 +1056,32 @@ impl LinuxCell {
         Ok(())
     }
 
+    /// Enable the optional parent data transport once. Admission, lease and
+    /// child authorization remain the owner's responsibility.
+    pub fn enable_parent_mailbox(&mut self) -> Result<(), VmmError> {
+        if self.parent_mailbox.is_some() {
+            return Err(VmmError::Backend("parent mailbox already enabled".into()));
+        }
+        self.parent_mailbox = Some(Default::default());
+        Ok(())
+    }
+
+    pub fn deliver_parent_message(&mut self, bytes: &[u8]) -> Result<(), VmmError> {
+        self.parent_mailbox
+            .as_mut()
+            .ok_or_else(|| VmmError::Backend("parent mailbox disabled".into()))?
+            .deliver(bytes)
+            .map_err(|e| VmmError::Backend(e.to_string()))
+    }
+
+    pub fn take_parent_response(&mut self) -> Result<Option<Vec<u8>>, VmmError> {
+        self.parent_mailbox
+            .as_mut()
+            .ok_or_else(|| VmmError::Backend("parent mailbox disabled".into()))?
+            .take_response()
+            .map_err(|e| VmmError::Backend(e.to_string()))
+    }
+
     pub fn set_timeout(&mut self, timeout: Duration) {
         self.cfg.timeout = timeout;
     }
@@ -1105,14 +1134,19 @@ impl LinuxCell {
         self.stop_marker = Some(marker.as_bytes().to_vec());
     }
 
+    /// Resume without re-triggering a completed host-selected startup marker.
+    pub fn clear_stop_marker(&mut self) {
+        self.stop_marker = None;
+    }
+
     /// Park this booted guest as a [`Mote`] that cells can be forked from.
     ///
     /// Call after a run that stopped at a marker, so the vCPU is at an
     /// instruction boundary with no I/O completion outstanding.
     pub fn park(&self) -> Result<Mote, VmmError> {
-        if self.invocation.is_some() || self.http.is_some() {
+        if self.invocation.is_some() || self.http.is_some() || self.parent_mailbox.is_some() {
             return Err(VmmError::Backend(
-                "cannot park per-cell invocation or egress authority".into(),
+                "cannot park per-cell invocation, parent mailbox or egress authority".into(),
             ));
         }
         let vcpu = &self.vcpu;
@@ -1350,6 +1384,7 @@ impl LinuxCell {
                 fetch_activity: (0, 0, 0),
                 fetch_response: VecDeque::new(),
                 invocation: None,
+                parent_mailbox: None,
                 pci_cf8: 0,
                 revoke_trigger: None,
                 stop_marker: None,
@@ -1486,6 +1521,17 @@ impl LinuxCell {
                                         }
                                     }
                                 }
+                            } else if port == crate::parent_mailbox::TX {
+                                if let Some(mailbox) = self.parent_mailbox.as_mut() {
+                                    mailbox.write(data);
+                                }
+                            } else if port == crate::parent_mailbox::COMMIT {
+                                if let Some(mailbox) = self.parent_mailbox.as_mut() {
+                                    mailbox.commit(data);
+                                    // Resume this same vCPU, never snapshot it:
+                                    // KVM completes the pending OUT on re-entry.
+                                    stop_at_marker = true;
+                                }
                             } else if port == PILOT_FETCH_TX {
                                 // Bounded before allocation: a malicious cell
                                 // cannot make the host buffer an unbounded URL.
@@ -1522,6 +1568,12 @@ impl LinuxCell {
                                         .as_mut()
                                         .and_then(|q| q.pop_front())
                                         .unwrap_or(0xff);
+                                }
+                            } else if port == crate::parent_mailbox::RX {
+                                if let Some(mailbox) = self.parent_mailbox.as_mut() {
+                                    mailbox.read(data);
+                                } else {
+                                    data.fill(0xff);
                                 }
                             } else if port == PILOT_FETCH_RX {
                                 for b in data.iter_mut() {
@@ -1738,6 +1790,202 @@ fn set_long_mode(vcpu: &VcpuFd) -> Result<(), VmmError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parent_owner_cancels_real_guest_and_joins_vm_owner() {
+        let Some(kernel) = kernel_or_skip() else {
+            return;
+        };
+        let Some(initrd) = std::env::var_os("CELLN_PARENT_PROBE_INITRD") else {
+            eprintln!("skipping: explicit parent probe initrd required");
+            return;
+        };
+        let (entered, observe) = std::sync::mpsc::sync_channel(1);
+        let owner = crate::parent_owner::ParentOwner::spawn(Duration::from_secs(30), move || {
+            let prepare = || -> Result<LinuxCell, VmmError> {
+                let mut template =
+                    LinuxCell::boot(BootConfig::new(kernel).with_initrd(PathBuf::from(initrd)))?;
+                template.stop_when_guest_prints("CELLN:parent_fixture=parked");
+                if template.run()?.end != BootEnd::Parked {
+                    return Err(VmmError::Backend("template failed".into()));
+                }
+                let mote = template.park()?;
+                drop(template);
+                let mut cell = LinuxCell::fork_from(&mote)?;
+                cell.enable_parent_mailbox()?;
+                Ok(cell)
+            };
+            let mut cell = prepare().map_err(|e| e.to_string())?;
+            Ok(move |bytes: &[u8]| {
+                cell.deliver_parent_message(bytes)
+                    .map_err(|e| e.to_string())?;
+                cell.stop_when_guest_prints("CELLN:parent_busy=entered");
+                let report = cell.run().map_err(|e| e.to_string())?;
+                if report.end != BootEnd::Parked
+                    || !report.console.contains("CELLN:parent_busy=entered")
+                {
+                    return Err("guest did not reach busy probe".into());
+                }
+                entered.send(()).map_err(|e| e.to_string())?;
+                cell.stop_when_guest_prints("CELLN:never-emitted-after-busy");
+                let result = cell.run().map_err(|e| e.to_string());
+                match result {
+                    Ok(report) if report.end == BootEnd::TimedOut => {
+                        Err("guest execution cancelled".into())
+                    }
+                    Err(error) => Err(error),
+                    Ok(report) => Err(format!(
+                        "unexpected guest termination {:?}: {}",
+                        report.end,
+                        report.tail(10)
+                    )),
+                }
+            })
+        })
+        .unwrap();
+        let reply = owner.submit(b"busy").unwrap();
+        observe
+            .recv_timeout(Duration::from_secs(20))
+            .expect("real guest busy marker");
+        // Let the owner re-enter KVM. The assertion below requires its run
+        // report, so cancellation before entry cannot masquerade as this proof.
+        std::thread::sleep(Duration::from_millis(20));
+        owner.cancel();
+        let result = reply
+            .recv_timeout(Duration::from_secs(2))
+            .expect("KVM stopped promptly");
+        assert_eq!(result.unwrap_err(), "guest execution cancelled");
+        owner.stop_and_join().unwrap();
+        eprintln!("parent owner proof: guest reached busy code, cancellation returned, VM-owning thread joined");
+    }
+
+    /// Real guest heap and instruction continuation, not a host transcript.
+    /// This fixture proves transport/state retention only, not Harness admission.
+    #[test]
+    fn child_cancellation_preserves_live_parent_guest_context() {
+        let Some(kernel) = kernel_or_skip() else {
+            return;
+        };
+        let Some(initrd) = std::env::var_os("CELLN_PARENT_PROBE_INITRD") else {
+            eprintln!("skipping: explicit parent probe initrd required");
+            return;
+        };
+        let control = celln_control::Control::new(Duration::from_secs(60)).unwrap();
+        control.scope(|| {
+            let mut template = LinuxCell::boot(BootConfig::new(kernel).with_initrd(PathBuf::from(initrd))).unwrap();
+            template.stop_when_guest_prints("CELLN:parent_fixture=parked");
+            assert_eq!(template.run().unwrap().end, BootEnd::Parked);
+            let mote = template.park().unwrap();
+            drop(template);
+            let mut parent = LinuxCell::fork_from(&mote).unwrap();
+            parent.enable_parent_mailbox().unwrap();
+            parent.deliver_parent_message(b"remember:survives-child-cancel").unwrap();
+            let report = parent.run().unwrap();
+            assert_eq!(report.end, BootEnd::Parked);
+            assert!(!report.console.contains("Linux version"));
+            assert_eq!(parent.take_parent_response().unwrap().unwrap(), b"1:survives-child-cancel");
+
+            let child_control = control.child(Duration::from_secs(30)).unwrap();
+            let mut child = LinuxCell::fork_from(&mote).unwrap();
+            child.enable_parent_mailbox().unwrap();
+            child.deliver_parent_message(b"busy").unwrap();
+            child.stop_when_guest_prints("CELLN:parent_busy=entered");
+            let entered = child_control.scope(|| child.run()).unwrap();
+            assert_eq!(entered.end, BootEnd::Parked);
+            assert!(entered.console.contains("CELLN:parent_busy=entered"));
+            assert!(!entered.console.contains("Linux version"));
+            child.stop_when_guest_prints("CELLN:never-emitted-after-busy");
+            let cancel = child_control.clone();
+            let canceller = std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(20));
+                cancel.cancel();
+            });
+            let started = std::time::Instant::now();
+            let stopped = child_control.scope(|| child.run());
+            canceller.join().unwrap();
+            assert_eq!(stopped.unwrap().end, BootEnd::TimedOut);
+            assert!(started.elapsed() < Duration::from_secs(3));
+            drop(child); // Actual VM owner gone before parent continuation.
+            assert!(control.check().is_ok());
+            parent.deliver_parent_message(b"recall").unwrap();
+            let report = parent.run().unwrap();
+            assert_eq!(report.end, BootEnd::Parked);
+            assert!(!report.console.contains("Linux version"));
+            assert_eq!(parent.take_parent_response().unwrap().unwrap(), b"2:survives-child-cancel");
+
+            let mut next = LinuxCell::fork_from(&mote).unwrap();
+            next.enable_parent_mailbox().unwrap();
+            next.deliver_parent_message(b"recall").unwrap();
+            let next_control = control.child(Duration::from_secs(10)).unwrap();
+            assert_eq!(next_control.scope(|| next.run()).unwrap().end, BootEnd::Parked);
+            assert_eq!(next.take_parent_response().unwrap().unwrap(), b"1:");
+            drop(next);
+            drop(parent);
+            eprintln!("child cancellation proof: real busy child stopped/destroyed; original parent recalled private guest context; fresh child executed with independent state");
+        });
+    }
+
+    /// Real guest heap and instruction continuation, not a host transcript.
+    /// This fixture proves transport/state retention only, not Harness admission.
+    #[test]
+    fn parent_guest_retains_heap_across_mailbox_turns() {
+        let Some(kernel) = kernel_or_skip() else {
+            return;
+        };
+        let Some(initrd) = std::env::var_os("CELLN_PARENT_PROBE_INITRD") else {
+            eprintln!(
+                "skipping: build scripts/mkparent-probe.sh and set CELLN_PARENT_PROBE_INITRD"
+            );
+            return;
+        };
+        let mut template =
+            LinuxCell::boot(BootConfig::new(kernel).with_initrd(PathBuf::from(initrd))).unwrap();
+        template.stop_when_guest_prints("CELLN:parent_fixture=parked");
+        let boot = template.run().unwrap();
+        assert_eq!(boot.end, BootEnd::Parked, "{}", boot.tail(20));
+        let mote = template.park().unwrap();
+        let mut parent = LinuxCell::fork_from(&mote).unwrap();
+        parent.enable_parent_mailbox().unwrap();
+        for (input, expected) in [
+            (
+                &b"remember:guest-private-context"[..],
+                &b"1:guest-private-context"[..],
+            ),
+            (&b"recall"[..], &b"2:guest-private-context"[..]),
+            (&b"recall"[..], &b"3:guest-private-context"[..]),
+        ] {
+            parent.deliver_parent_message(input).unwrap();
+            let report = parent.run().unwrap();
+            assert_eq!(report.end, BootEnd::Parked, "{}", report.tail(20));
+            assert!(!report.console.contains("Linux version"));
+            assert_eq!(parent.take_parent_response().unwrap().unwrap(), expected);
+            assert!(parent.park().is_err());
+        }
+        let mut other = LinuxCell::fork_from(&mote).unwrap();
+        other.enable_parent_mailbox().unwrap();
+        other.deliver_parent_message(b"recall").unwrap();
+        let report = other.run().unwrap();
+        assert_eq!(report.end, BootEnd::Parked, "{}", report.tail(20));
+        assert_eq!(other.take_parent_response().unwrap().unwrap(), b"1:");
+        eprintln!(
+            "parent proof: 3 turns, retained guest heap, independent warm fork has no context"
+        );
+    }
+
+    #[test]
+    fn parent_mailbox_cannot_be_reenabled_or_captured_in_a_mote() {
+        let Some(kernel) = kernel_or_skip() else {
+            return;
+        };
+        let mut cell = LinuxCell::boot(BootConfig::new(kernel)).unwrap();
+        assert!(cell.deliver_parent_message(b"hello").is_err());
+        assert!(cell.take_parent_response().is_err());
+        cell.enable_parent_mailbox().unwrap();
+        assert!(cell.enable_parent_mailbox().is_err());
+        assert!(cell.park().is_err());
+        cell.deliver_parent_message(b"hello").unwrap();
+        assert!(cell.deliver_parent_message(b"overwrite").is_err());
+    }
 
     #[test]
     fn invocation_is_bounded_one_shot_and_cannot_be_parked() {

--- a/crates/celln-warden/src/workspace_broker.rs
+++ b/crates/celln-warden/src/workspace_broker.rs
@@ -1,0 +1,352 @@
+//! Run-owned data over the existing bounded broker channel, never a host mount.
+//! Only host admission can mint a grant. A guest cannot choose its parent or
+//! child identity. Dropping the turn lease revokes every copy of that grant.
+use crate::parent_lease::ReservedTurn;
+use celln_control::Control;
+use celln_manifest::Hash;
+use celln_store::workspace::{Limits, Workspace};
+use serde::Deserialize;
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex, Weak};
+
+pub struct Owner {
+    parent: Hash,
+    data: Arc<Mutex<Workspace>>,
+    claimed: BTreeSet<String>,
+    active: Weak<Mutex<Authority>>,
+}
+
+impl Drop for Owner {
+    fn drop(&mut self) {
+        if let Some(active) = self.active.upgrade() {
+            if let Ok(mut authority) = active.lock() {
+                authority.active = false;
+            }
+        }
+    }
+}
+
+struct Authority {
+    active: bool,
+    remaining: usize,
+    read: bool,
+    write: bool,
+    control: Control,
+}
+
+/// Host-only lease: keep alive until the child VM has been joined/destroyed.
+/// Revocation itself does not constitute proof of VM teardown.
+pub struct Lease(Arc<Mutex<Authority>>);
+impl Drop for Lease {
+    fn drop(&mut self) {
+        if let Ok(mut authority) = self.0.lock() {
+            authority.active = false;
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Grant {
+    parent: Hash,
+    data: Arc<Mutex<Workspace>>,
+    authority: Arc<Mutex<Authority>>,
+}
+impl std::fmt::Debug for Grant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("WorkspaceGrant(<host-owned>)")
+    }
+}
+impl PartialEq for Grant {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.authority, &other.authority)
+    }
+}
+impl Eq for Grant {}
+
+impl Owner {
+    pub fn new(parent: Hash, limits: Limits) -> Result<Self, String> {
+        let data = Workspace::new(parent.clone(), limits).map_err(|e| e.to_string())?;
+        Ok(Self {
+            parent,
+            data: Arc::new(Mutex::new(data)),
+            claimed: BTreeSet::new(),
+            active: Weak::new(),
+        })
+    }
+
+    /// Call only after independent admission and durable turn reservation.
+    /// This binds existing authority; it does not establish admission by itself.
+    pub fn begin(
+        &mut self,
+        turn: &ReservedTurn,
+        read: bool,
+        write: bool,
+        max_operations: usize,
+        control: Control,
+    ) -> Result<(Lease, Grant), String> {
+        let child = Hash::of(
+            &serde_json::to_vec(&(&self.parent.0, &turn.request.turn_id))
+                .map_err(|_| "invalid workspace child identity")?,
+        );
+        if turn.parent != self.parent
+            || turn.child != child
+            || (!read && !write)
+            || !(1..=64).contains(&max_operations)
+            || self.claimed.len() >= 1024
+            || self.claimed.contains(&turn.child.0)
+        {
+            return Err("workspace grant does not match reserved child or bounds".into());
+        }
+        control.check().map_err(|e| e.to_string())?;
+        if let Some(active) = self.active.upgrade() {
+            if active
+                .lock()
+                .map_err(|_| "workspace authority unavailable")?
+                .active
+            {
+                return Err("workspace already has an active child".into());
+            }
+        }
+        self.claimed.insert(turn.child.0.clone());
+        let authority = Arc::new(Mutex::new(Authority {
+            active: true,
+            remaining: max_operations,
+            read,
+            write,
+            control,
+        }));
+        self.active = Arc::downgrade(&authority);
+        Ok((
+            Lease(authority.clone()),
+            Grant {
+                parent: self.parent.clone(),
+                data: self.data.clone(),
+                authority,
+            },
+        ))
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "operation", rename_all = "camelCase", deny_unknown_fields)]
+enum Operation {
+    Read {
+        name: String,
+    },
+    Write {
+        name: String,
+        revision: u64,
+        content: String,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Request {
+    api_version: String,
+    body: Operation,
+}
+
+impl Grant {
+    pub(crate) fn request(&self, raw: &str) -> Result<Vec<u8>, String> {
+        let mut authority = self
+            .authority
+            .lock()
+            .map_err(|_| "workspace authority unavailable")?;
+        authority.control.check().map_err(|e| e.to_string())?;
+        if !authority.active || authority.remaining == 0 {
+            return Err("workspace grant revoked or exhausted".into());
+        }
+        // Malformed and denied operations spend their grant budget too.
+        authority.remaining -= 1;
+        if raw.len() > 8192 {
+            return Err("workspace request exceeds broker wire budget".into());
+        }
+        let request: Request =
+            serde_json::from_str(raw).map_err(|_| "invalid workspace request")?;
+        if request.api_version != "celln.workspace/v1" {
+            return Err("unsupported workspace request version".into());
+        }
+        let mut data = self.data.lock().map_err(|_| "workspace unavailable")?;
+        let response = match request.body {
+            Operation::Read { name } if authority.read => {
+                let bytes = data.read(&self.parent, &name).map_err(|e| e.to_string())?;
+                let content = std::str::from_utf8(bytes).map_err(|_| "artifact is not text")?;
+                serde_json::json!({"revision":data.revision(), "content":content})
+            }
+            Operation::Write {
+                name,
+                revision,
+                content,
+            } if authority.write => {
+                let revision = data
+                    .write(&self.parent, revision, &name, content.as_bytes())
+                    .map_err(|e| e.to_string())?;
+                serde_json::json!({"revision":revision})
+            }
+            _ => return Err("workspace operation not granted".into()),
+        };
+        serde_json::to_vec(&response).map_err(|_| "workspace response encoding failed".into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::egress::{HttpBroker, HttpPolicy};
+    use crate::{parent_lease::TurnLimits, parent_protocol::TurnRequest};
+    use serde_json::json;
+    use std::time::Duration;
+
+    fn turn(parent: &Hash, id: &str) -> ReservedTurn {
+        ReservedTurn {
+            parent: parent.clone(),
+            child: Hash::of(&serde_json::to_vec(&(&parent.0, id)).unwrap()),
+            request: TurnRequest {
+                api_version: crate::parent_protocol::VERSION.into(),
+                turn_id: id.into(),
+                task: "test".into(),
+            },
+            limits: TurnLimits {
+                memory_bytes: 4096,
+                timeout: Duration::from_secs(30),
+                model_requests: 1,
+                output_tokens: 32,
+            },
+        }
+    }
+    fn control() -> Control {
+        Control::new(Duration::from_secs(30)).unwrap()
+    }
+    fn owner(parent: &Hash) -> Owner {
+        Owner::new(
+            parent.clone(),
+            Limits {
+                files: 2,
+                file_bytes: 16,
+                total_bytes: 24,
+            },
+        )
+        .unwrap()
+    }
+    fn wire(body: serde_json::Value) -> String {
+        json!({"apiVersion":"celln.workspace/v1", "body":body}).to_string()
+    }
+    fn broker(grant: Grant) -> HttpBroker {
+        let mut policy = HttpPolicy::new(vec![]);
+        policy.workspace = Some(grant);
+        HttpBroker::new(policy)
+    }
+
+    #[test]
+    fn cross_turn_data_with_revocation_and_no_replay() {
+        let parent = Hash::of(b"parent");
+        let mut owner = owner(&parent);
+        let first = turn(&parent, "one");
+        let (lease, grant) = owner.begin(&first, true, true, 4, control()).unwrap();
+        let mut first_broker = broker(grant);
+        assert!(first_broker
+            .fetch(&wire(
+                json!({"operation":"write","name":"note.txt","revision":0,"content":"violet"})
+            ))
+            .is_ok());
+        let second = turn(&parent, "two");
+        assert!(owner.begin(&second, true, false, 4, control()).is_err());
+        drop(lease);
+        assert!(first_broker
+            .fetch(&wire(json!({"operation":"read","name":"note.txt"})))
+            .is_err());
+        assert!(owner.begin(&first, true, true, 4, control()).is_err());
+        let (_lease, grant) = owner.begin(&second, true, false, 4, control()).unwrap();
+        let mut next = broker(grant);
+        let value: serde_json::Value = serde_json::from_slice(
+            &next
+                .fetch(&wire(json!({"operation":"read","name":"note.txt"})))
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(value, json!({"revision":1,"content":"violet"}));
+        assert!(next
+            .fetch(&wire(
+                json!({"operation":"write","name":"note.txt","revision":1,"content":"orange"})
+            ))
+            .is_err());
+    }
+
+    #[test]
+    fn authority_is_explicit_bound_bounded_and_cancelled() {
+        let parent = Hash::of(b"parent");
+        let mut owner = owner(&parent);
+        assert!(owner
+            .begin(&turn(&Hash::of(b"other"), "one"), true, true, 4, control())
+            .is_err());
+        let mut forged = turn(&parent, "one");
+        forged.child = Hash::of(b"forged");
+        assert!(owner.begin(&forged, true, true, 4, control()).is_err());
+        let read = wire(json!({"operation":"read","name":"note.txt"}));
+        assert!(HttpBroker::new(HttpPolicy::new(vec![]))
+            .fetch(&read)
+            .is_err());
+        let stop = control();
+        let (_lease, grant) = owner
+            .begin(&turn(&parent, "one"), true, true, 2, stop.clone())
+            .unwrap();
+        let mut active = broker(grant.clone());
+        assert!(active
+            .fetch(&wire(
+                json!({"operation":"write","name":"note.txt","revision":0,"content":"violet"})
+            ))
+            .is_ok());
+        stop.cancel();
+        assert!(active.fetch(&read).is_err());
+        assert!(broker(grant).fetch(&read).is_err());
+    }
+
+    #[test]
+    fn malformed_requests_quota_and_stale_writes_do_not_mutate() {
+        let parent = Hash::of(b"parent");
+        let mut owner = owner(&parent);
+        let (_lease, grant) = owner
+            .begin(&turn(&parent, "one"), true, true, 10, control())
+            .unwrap();
+        let mut active = broker(grant);
+        for body in [
+            json!({"operation":"write","name":"../escape","revision":0,"content":"x"}),
+            json!({"operation":"write","name":"note.txt","revision":0,"content":"too large for the quota"}),
+            json!({"operation":"write","name":"note.txt","revision":0,"content":"x","parent":"other"}),
+        ] {
+            assert!(active.fetch(&wire(body)).is_err());
+        }
+        assert!(active
+            .fetch(&wire(
+                json!({"operation":"write","name":"note.txt","revision":0,"content":"violet"})
+            ))
+            .is_ok());
+        assert!(active
+            .fetch(&wire(
+                json!({"operation":"write","name":"note.txt","revision":0,"content":"orange"})
+            ))
+            .is_err());
+        let read = wire(json!({"operation":"read","name":"note.txt"}));
+        for _ in 0..5 {
+            assert!(active.fetch(&read).is_ok());
+        }
+        assert!(active.fetch(&read).is_err());
+    }
+
+    #[test]
+    fn losing_parent_owner_revokes_even_a_retained_turn_lease() {
+        let parent = Hash::of(b"parent");
+        let mut owner = owner(&parent);
+        let (_lease, grant) = owner
+            .begin(&turn(&parent, "one"), true, true, 4, control())
+            .unwrap();
+        let mut broker = broker(grant);
+        drop(owner);
+        assert!(broker
+            .fetch(&wire(
+                json!({"operation":"write","name":"note.txt","revision":0,"content":"x"})
+            ))
+            .is_err());
+    }
+}

--- a/docs/JSON_TOOL_HARNESS.md
+++ b/docs/JSON_TOOL_HARNESS.md
@@ -20,6 +20,21 @@ Host configuration is one bounded JSON argument (at most 64 KiB) containing:
 
 - `contract: celln.json-tools/v1`, `task`, `system`, `url`, `model`.
 - `max_turns` (1–6), `max_calls` (0–16) and `tools` (0–16 entries).
+- Optional `require_tool_call: true` requires at least one actual tool execution
+  before reporting successful completion. It requires a nonempty selected tool
+  list, at least one call and at least two model turns. The first request uses
+  `tool_choice: required`; after execution the model can return a final answer.
+  A provider response that skips the required call fails locally without an
+  automatic retry or a fabricated successful result. Only already-lent tools
+  remain callable. This does not require every selected tool or a particular tool.
+  Omission/false preserves the previous optional-call behaviour and serialized
+  template bytes. Enabling it changes the immutable native turn-template binding
+  and therefore requires fresh corresponding host approval; it cannot be toggled
+  through turn message data. Older binaries refuse the new field rather than
+  silently ignoring it. Sympozium's enduring-run development integration maps
+  explicit `enduring.requireToolCall` intent through matching prepared parent
+  registration. The one-shot catalogue issuer is unchanged.
+  Provider semantics: [DeepSeek chat completions](https://api-docs.deepseek.com/api/create-chat-completion/).
 - Each tool has `name`, canonical absolute `path`, executable BLAKE3 `hash`,
   `description`, `input_schema`, `output_schema`, `input_bytes`, `output_bytes`
   and `timeout_ms`.

--- a/docs/PARENT_PROVISIONING.md
+++ b/docs/PARENT_PROVISIONING.md
@@ -1,0 +1,80 @@
+# Local persistent-parent provisioning
+
+`celln --root /absolute/operator/state parent-provision /absolute/plan.json
+--principal authenticated-operator-principal` publishes a run-specific permit
+and launch profile. It does **not** launch a VM, warm a mote, read a model key,
+grant catalogue tools or approve a Kubernetes run. This command is an
+operator-local authority boundary; do not expose it as a tenant upload API.
+
+The caller must independently authorize the complete run intent and resolved
+Agent/runtime/tool/grant snapshot before preparing the plan. Its `intentSHA256`
+must identify that complete authorized intent, not just a task or runtime name.
+The CLI validates its format, not the upstream Kubernetes authorization.
+
+## Plan contract
+
+Input is strict JSON, at most 64 KiB, with these fields:
+
+| Field | Meaning |
+| --- | --- |
+| `apiVersion` | `celln.parent-provision-plan/v1` |
+| `scope` | Stable operator-controlled cluster/issuer identity |
+| `runUid` | Immutable run UID; never a reusable object name |
+| `intentSHA256` | `sha256:` plus 64 lowercase hexadecimal digits |
+| `admissionWindowMs` | 1–300000; time to admit, not the parent lease |
+| `parent`, `worker` | Complete independently selected `ExecutionRequest` objects |
+| `template` | Native JSON-harness configuration, including persona and required-tool policy |
+| `modelProfile` | Hash of an independently published host model profile |
+| `reservedMemoryBytes` | Logical host reservation including retained motes, both cells and overhead; not measured RSS |
+| `maxTurns` | Parent's total turn ceiling |
+| `turnModelRequests`, `turnOutputTokens` | Per-child model ceilings |
+| `totalModelRequests`, `totalOutputTokens` | Aggregate parent model ceilings |
+
+Both requests' callers must equal `--principal`. Parent/child memory and time
+limits come from their respective requests. Configuration fingerprints and the
+worker's template/model binding are calculated locally, not accepted as caller
+assertions. Startup still performs artifact admission, replay prevention,
+capacity reservation and warm preparation before execution.
+
+The operator must provision and protect these directories under the root:
+`parent-issuance`, `trusted-parent-permits`, `trusted-parent-launches`, and the
+existing `trusted-parent-models` policy store. All issuers for one scope must
+share and retain the issuance directory across process restarts. The command
+does not create authority directories or replace conflicting records.
+
+## Recovery and output
+
+The incarnation depends only on scope and immutable run UID. The issuance
+record pins a domain-separated BLAKE3 hash of the entire typed plan, including
+the upstream SHA256 intent identity. This avoids requiring Go and Rust to
+produce identical JSON bytes. Plan formatting and field order do not matter;
+changed semantic values, including the logical memory reservation, do.
+
+Success prints one JSON object with `apiVersion: celln.parent-provisioned/v1`,
+`launchProfile` and `incarnation` hashes. Repeating an identical plan recovers
+the original unexpired permit and exact launch hash. Expiry, a new host boot,
+changed intent or a corrupt record refuse; retry never renews authority.
+Failures after issuance retain its record. Never delete the journal, change
+scope or invent a replacement UID to make a failed run retry.
+
+The command is a local provisioning primitive. Automatic Sympozium plan
+construction, trusted host invocation and per-run registration remain separate
+integration work. It does not establish production TLS/RBAC or a running demo.
+
+## Optional private worker audit
+
+By default, production does not retain raw native worker output at the turn
+boundary. An operator may explicitly create a real `parent-audit` directory
+under the state root, with no group/other permissions (normally mode 0700).
+Symlinks and non-private directories are refused. The path is fixed by the host,
+not accepted from an AgentRun, turn or HTTP request.
+
+When enabled, each completed worker produces a bounded, synced, non-replacing
+mode-0600 `worker-proof-<child-hash>.json` file containing actual guest events,
+execution identity and host broker counts. These files can contain sensitive
+conversation/tool data. They are evidence only, never authorization to replay.
+The operator owns retention, storage sizing and deletion policy; there is no
+automatic expiry. Do not publish the directory or mount it into guest workloads.
+An audit failure refuses result commitment after the child is destroyed; it
+does not refund the turn or make it retryable. Disable retention by removing the
+opt-in directory only when stopped, after handling any retained files explicitly.

--- a/docs/STARTER_TOOLBOX.md
+++ b/docs/STARTER_TOOLBOX.md
@@ -1,0 +1,110 @@
+# Native parent starter toolbox
+
+Implementation status: native and combined Sympozium system acceptance passed
+on 2026-09-09, including UI starter selection, file continuity, HTTPS, cancel/
+continue, refresh and teardown. The system proof installs actual signed fixture
+catalogue revisions and independent grants. This is **not yet a merged release
+or a long-running environment handoff**. Python is deferred.
+
+## Guest programs
+
+Build `celln-workspace-read`, `celln-workspace-write` and `celln-https-fetch` from
+`celln-pilot` for `x86_64-unknown-linux-musl`. Publish them as signed, sealed
+JSON-stdio tools with `/pilot-fetch` as an admitted dependency. Publishing a
+tool does not grant its effects. The native template and operator-owned model
+profile are independently pinned by the parent permit.
+
+| Selected name | JSON input | Successful JSON result |
+| --- | --- | --- |
+| `workspace-read` | `{"name":"notes.txt"}` | `{"revision":1,"content":"violet"}` |
+| `workspace-write` | `{"name":"notes.txt","revision":0,"content":"violet"}` | `{"revision":1}` |
+| `https-fetch` | `{"url":"https://example.com/"}` | `{"content":"..."}` |
+
+Errors return `{"error":"..."}` and do not authorize automatic retries.
+Workspace revisions apply to the entire workspace, not individual files. The
+first write uses revision zero; subsequent writes must use the latest observed
+revision. A stale write refuses without mutation.
+
+## Host authority
+
+The content-hash-pinned `celln.parent-model-profile/v1` supports optional
+`workspace` and `fetch` objects. Omission denies the corresponding starter
+effects. These are host-owned grants, **not tenant-uploadable policy**.
+
+```json
+{
+  "workspace": {
+    "read": true,
+    "write": true,
+    "maxOperations": 16,
+    "maxFiles": 32,
+    "maxFileBytes": 4096,
+    "maxTotalBytes": 65536
+  },
+  "fetch": {
+    "allowHosts": ["example.com"],
+    "maxRequests": 4,
+    "maxResponseBytes": 16384,
+    "timeoutMs": 10000
+  }
+}
+```
+
+Workspace data is host-memory-backed logical artifact data retained by the live
+parent owner. It is not a host mount, executable filesystem, checkpoint, or
+process-crash-durable store. Names reject absolute paths, dot segments and
+normalization aliases. Grants are bound to a reserved child, one active child
+at a time; copies share the operation budget. Cancellation, lease revocation
+and parent-owner loss deny further access. Revocation is not proof of teardown.
+
+Writes acknowledged before cancellation remain written; cancellation does not
+roll back external effects. The parent answer/history commit remains separate.
+Data is lost on parent-owner destruction; no transparent recreation is allowed.
+
+Workspace operations use `celln.workspace/v1` JSON over the existing bounded
+PIO broker channel, with a strict `body` tagged by `operation`. Requests are
+at most 8192 encoded bytes, including JSON escaping. This keeps the existing
+wire ABI and gives the guest neither network sockets nor filesystem authority.
+
+GET authority has its own exact-host allowlist, request/response/time limits,
+and counter, separate from credential-bearing model POSTs. Every redirect is
+reauthorized and public IPv4 DNS results are pinned. GET ignores curl startup
+configuration, URL globbing and ambient proxies. It never receives the model
+credential. Both budgets are bounded again by the child lifetime.
+
+Current tests cover host protocol, quota atomicity, stale writes, cross-turn
+data, parent/child binding, cancellation/revocation, and independent GET/model
+budgets. These host tests do not substitute for the required hostile-guest or
+real-model E2E evidence.
+
+## Native real-model evidence — 2026-09-09
+
+`native_parent_starter_cross_turn_live` passed with no skips in 13.28 seconds.
+It ran a retained native parent cell and three disposable worker cells with
+real DeepSeek requests. Actual guest tool events prove `workspace-write` stored
+`violet` in `notes.txt` at revision 1, `workspace-read` returned those bytes on
+the next turn, and `https-fetch` returned the Example Domain page from the
+allowlisted `https://example.com/`. All three broker audits reported zero
+denials. Session destruction dropped the parent/worker owners at test exit.
+
+Local evidence: `target/starter-live-2052225-1788939482308025817/`. This includes
+conversation/tool data and is not an installation artifact or replay authority.
+
+```sh
+CELLN_PARENT_MODEL_KEY_FROM_ZSHRC=/home/axjns/.zshrc CARGO_TARGET_DIR=target/validation cargo test -p celln-cli native_parent_starter_cross_turn_live -- --ignored --nocapture --test-threads=1
+```
+
+This native proof does not exercise Kubernetes/UI admission, cancellation or
+refresh, and is not a substitute for the combined release acceptance suite.
+
+## Combined system evidence
+
+The same test with `CELLN_INTEROP_STARTER=true` and the full external-process
+configuration passed in 108.77 seconds, no skips. It exported the signed starter
+catalogue, let Sympozium install actual CRs and grant documents, then exercised
+UI selection, cross-turn write/read, HTTPS fetch, cancel/continue and refresh.
+All three parent incarnations subsequently confirmed teardown, restored zero
+live cells/full logical capacity, refused replay and reported historical
+context loss after dispatcher restart. Private evidence is under
+`target/starter-live-2066148-1788940479379564452/`; Sympozium's
+`docs/evidence/celln-starter-system-2026-09-09.md` records the complete scope.

--- a/guest/probes/parent-mailbox.rs
+++ b/guest/probes/parent-mailbox.rs
@@ -1,0 +1,84 @@
+//! Hardware-only transport fixture, NOT an admitted Harness or production init.
+//! A heap allocation lives across VM yields. The host sends the remembered
+//! value only once; later messages cannot reconstruct it.
+use std::arch::asm;
+use std::ffi::{c_char, c_int, c_ulong, c_void};
+use std::io::Write;
+
+unsafe extern "C" {
+    fn mount(
+        src: *const c_char,
+        dst: *const c_char,
+        fs: *const c_char,
+        flags: c_ulong,
+        data: *const c_void,
+    ) -> c_int;
+    fn open(path: *const c_char, flags: c_int, ...) -> c_int;
+    fn dup2(old: c_int, new: c_int) -> c_int;
+    fn ioperm(from: c_ulong, num: c_ulong, enable: c_int) -> c_int;
+}
+
+fn receive() -> u8 {
+    let byte: u8;
+    unsafe {
+        asm!("in al, dx", out("al") byte, in("dx") 0x520u16, options(nomem, nostack));
+    }
+    byte
+}
+
+fn send(port: u16, byte: u8) {
+    unsafe {
+        asm!("out dx, al", in("al") byte, in("dx") port, options(nomem, nostack));
+    }
+}
+
+fn main() {
+    unsafe {
+        assert_eq!(
+            mount(
+                c"devtmpfs".as_ptr(),
+                c"/dev".as_ptr(),
+                c"devtmpfs".as_ptr(),
+                0,
+                std::ptr::null()
+            ),
+            0
+        );
+        let console = open(c"/dev/console".as_ptr(), 2);
+        assert!(console >= 0);
+        assert_eq!(dup2(console, 1), 1);
+        assert_eq!(dup2(console, 2), 2);
+    }
+    println!("CELLN:mote=parked");
+    println!("CELLN:parent_fixture=parked");
+    std::io::stdout().flush().unwrap();
+    // The warm fork resumes here. Only this test init gets the probe ports.
+    unsafe {
+        assert_eq!(ioperm(0x520, 3, 1), 0);
+    }
+    let mut remembered = Vec::new();
+    let mut turns = 0u64;
+    loop {
+        let size = u32::from_le_bytes(std::array::from_fn(|_| receive())) as usize;
+        assert!((1..=8192).contains(&size));
+        let input: Vec<u8> = (0..size).map(|_| receive()).collect();
+        if input == b"busy" {
+            println!("CELLN:parent_busy=entered");
+            std::io::stdout().flush().unwrap();
+            loop {
+                std::hint::spin_loop();
+            }
+        }
+        turns += 1;
+        if let Some(value) = input.strip_prefix(b"remember:") {
+            remembered = value.to_vec();
+        } else {
+            assert_eq!(input, b"recall");
+        }
+        let response = format!("{turns}:{}", String::from_utf8_lossy(&remembered));
+        for byte in response.bytes() {
+            send(0x521, byte);
+        }
+        send(0x522, 1);
+    }
+}

--- a/scripts/mkparent-probe.sh
+++ b/scripts/mkparent-probe.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Separate hardware fixture: never packed into normal celln guest assets.
+set -euo pipefail
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+out="${1:?usage: bash scripts/mkparent-probe.sh /absolute/output.cpio}"
+[[ "$out" = /* ]] || { echo 'output must be absolute' >&2; exit 1; }
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+chmod 0755 "$work"
+mkdir "$work/dev"
+rustc --edition=2021 --target x86_64-unknown-linux-musl -C opt-level=2 \
+  "$root/guest/probes/parent-mailbox.rs" -o "$work/init"
+(cd "$work" && find . -print0 | cpio --null -o -H newc --owner=0:0 > "$out")


### PR DESCRIPTION
Implements the Celln half of the native harness release candidate for sympozium-ai/sympozium#464 and sympozium-ai/sympozium#467.

Persistent native parent context, independently admitted disposable workers, bounded parent/child leases and journals, exact child cancellation, asynchronous submissions, host-mediated run artifacts, and credential-free bounded HTTPS starter tools. Authority remains pinned and only shrinks; no host filesystem mounts or guest network stack.

Validation: make ci passed. Combined real DeepSeek/KVM + Kind/API/UI/controller/TLS E2E passed in 108.77 seconds with starter selection, cross-turn files, fetch, cancel/continue, refresh, three-parent teardown, zero live cells and post-restart replay refusals. Scope and evidence are in docs/STARTER_TOOLBOX.md and the companion Sympozium evidence document.

Deferred: Python, pause/resume, checkpoints, arbitrary harness compatibility, and performance tuning. Run artifacts are live-owner memory, not crash-durable storage. Companion integration: sympozium-ai/sympozium#463.