### PR TITLE
feat(egress): opt-in HTTP and self-signed model endpoints

### DIFF
--- a/crates/celln-cli/src/dispatch_harness.rs
+++ b/crates/celln-cli/src/dispatch_harness.rs
@@ -18,6 +18,8 @@ pub(crate) use issuer::prove_issuance;
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Grant {
+    #[serde(default)]
+    protocol: warden::egress::ModelProtocol,
     api_version: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     issuer: Option<issuer::Binding>,
@@ -36,6 +38,9 @@ struct Grant {
     max_requests: usize,
     max_output_tokens: u64,
     max_total_output_tokens: u64,
+    /// Operator opt-in for an HTTP or self-signed private model endpoint.
+    #[serde(default)]
+    allow_insecure: bool,
 }
 pub struct Resolved {
     pub policy: warden::egress::HttpPolicy,
@@ -107,7 +112,10 @@ fn resolve_bytes(
         return Err("Harness identity is not authorized by operator grant".into());
     }
     let origin = &request.capabilities.egress[0];
-    if grant.url != format!("{origin}/chat/completions")
+    let target = warden::egress::model_endpoint_target(&grant.url, grant.allow_insecure)
+        .map_err(|_| "invalid Harness model endpoint")?;
+    if target.origin != *origin
+        || request.capabilities.allow_insecure != grant.allow_insecure
         || grant.model.is_empty()
         || grant.model.len() > 128
         || !grant.credential_file.is_absolute()
@@ -174,13 +182,14 @@ fn resolve_bytes(
     } else {
         serde_json::json!({"task":binding.task,"url":grant.url,"model":grant.model,"tools":binding.borrowed_tools}).to_string()
     };
-    let mut policy =
-        warden::egress::HttpPolicy::new(vec![origin.trim_start_matches("https://").into()]);
+    let mut policy = warden::egress::HttpPolicy::new(vec![target.host.clone()]);
     policy.max_requests = grant.max_requests;
+    policy.allow_insecure = grant.allow_insecure;
     policy.timeout = std::time::Duration::from_secs(45).min(std::time::Duration::from_millis(
         request.capabilities.timeout_ms,
     ));
     policy.json_posts.push(warden::egress::JsonPostGrant {
+        protocol: grant.protocol,
         url: grant.url.clone(),
         bearer_token_file: grant.credential_file,
         model: grant.model.clone(),
@@ -228,11 +237,14 @@ fn json_config(request: &ExecutionRequest, grant: &Grant, root: &Path) -> Result
             "input_bytes":io.input_bytes,"output_bytes":io.output_bytes,"timeout_ms":io.timeout_ms
         }));
     }
-    let config = serde_json::json!({
+    let mut config = serde_json::json!({
         "contract":binding.contract_version,"task":binding.task,"system":options.system,
         "url":grant.url,"model":grant.model,"max_turns":options.max_turns,
         "max_calls":options.max_calls,"tools":tools
     });
+    if grant.allow_insecure {
+        config["allow_insecure"] = serde_json::json!(true);
+    }
     let encoded = config.to_string();
     if encoded.len() > 65536 {
         return Err("JSON Harness configuration exceeds delivery limit".into());

--- a/crates/celln-cli/src/dispatch_harness_issuer.rs
+++ b/crates/celln-cli/src/dispatch_harness_issuer.rs
@@ -37,6 +37,8 @@ pub(super) struct Binding {
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Profile {
+    #[serde(default)]
+    protocol: warden::egress::ModelProtocol,
     api_version: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     expiry: Option<expiry::Expiry>,
@@ -47,6 +49,9 @@ struct Profile {
     max_requests: usize,
     max_output_tokens: u64,
     max_total_output_tokens: u64,
+    /// Operator opt-in for an HTTP or self-signed private model endpoint.
+    #[serde(default)]
+    allow_insecure: bool,
 }
 
 // Normalize only the self-referential grant hash. Task, caller, execution ID,
@@ -85,7 +90,7 @@ fn profile(root: &Path, name: &str) -> Result<(Profile, String), String> {
         _ => return Err("unsupported operator model profile expiry contract".into()),
     }
     if !p.credential_file.is_absolute()
-        || p.url != "https://api.deepseek.com/chat/completions"
+        || warden::egress::model_endpoint_target(&p.url, p.allow_insecure).is_err()
         || p.model.is_empty()
         || p.model.len() > 128
         || p.max_requests == 0
@@ -122,9 +127,11 @@ pub(super) fn validate(
         || p.credential_file != grant.credential_file
         || p.model != grant.model
         || p.url != grant.url
+        || p.protocol != grant.protocol
         || p.max_requests != grant.max_requests
         || p.max_output_tokens != grant.max_output_tokens
         || p.max_total_output_tokens != grant.max_total_output_tokens
+        || p.allow_insecure != grant.allow_insecure
     {
         return Err("issued grant policy withdrawn, changed or request mismatched".into());
     }
@@ -151,8 +158,9 @@ fn candidate(request: &ExecutionRequest, name: &str, root: &Path) -> Result<Vec<
         "apiVersion":"celln.dev/harness-grant-v3", "contractVersion":h.contract_version,
         "json":h.json,"caller":request.workload.caller,"mote":request.mote.as_ref().ok_or("missing mote")?.hash,
         "runtime":request.tools[0].hash,"closure":request.tools[0].closure.as_ref().ok_or("missing closure")?.hash,
-        "borrowedTools":h.borrowed_tools,"url":p.url,"model":p.model,"credentialFile":p.credential_file,
-        "maxRequests":p.max_requests,"maxOutputTokens":p.max_output_tokens,"maxTotalOutputTokens":p.max_total_output_tokens
+        "protocol":p.protocol,"borrowedTools":h.borrowed_tools,"url":p.url,"model":p.model,"credentialFile":p.credential_file,
+        "maxRequests":p.max_requests,"maxOutputTokens":p.max_output_tokens,"maxTotalOutputTokens":p.max_total_output_tokens,
+        "allowInsecure":p.allow_insecure
     });
     grant["issuer"] = serde_json::to_value(Binding {
         profile: name.into(),

--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -312,14 +312,17 @@ impl EgressPolicy {
 
     fn check(&self, request: &ExecutionRequest) -> Result<()> {
         for destination in &request.capabilities.egress {
-            // ExecutionRequest::problems() validates the HTTPS-only shape
-            // before this host policy runs. Keep this check fail-closed too,
-            // so it remains safe if called independently later.
-            let host = destination
+            // ExecutionRequest::problems() validates the HTTP(S) shape before
+            // this host policy runs. Keep this check fail-closed too, so it
+            // remains safe if called independently later. The scheme and any
+            // port are stripped; only the exact host is compared.
+            let rest = destination
                 .strip_prefix("https://")
-                .filter(|host| !host.is_empty())
-                .context("egress destination is not a named HTTPS host")?;
-            if !self.allow_hosts.contains(&host.to_ascii_lowercase()) {
+                .or_else(|| destination.strip_prefix("http://"))
+                .filter(|rest| !rest.is_empty())
+                .context("egress destination is not a named HTTP(S) host")?;
+            let host = rest.split(['/', ':']).next().unwrap_or_default();
+            if host.is_empty() || !self.allow_hosts.contains(&host.to_ascii_lowercase()) {
                 bail!(
                     "egress destination {destination:?} is outside this dispatcher's host allowlist"
                 );

--- a/crates/celln-cli/src/dispatch_parent_model.rs
+++ b/crates/celln-cli/src/dispatch_parent_model.rs
@@ -15,6 +15,8 @@ use warden::{parent_lease::ReservedTurn, parent_permit::Binding};
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Profile {
+    #[serde(default)]
+    protocol: warden::egress::ModelProtocol,
     api_version: String,
     principal: String,
     request_binding: Hash,
@@ -25,6 +27,9 @@ struct Profile {
     max_requests: u64,
     max_output_tokens: u64,
     max_total_output_tokens: u64,
+    /// Operator opt-in for an HTTP or self-signed private model endpoint.
+    #[serde(default)]
+    allow_insecure: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     workspace: Option<WorkspaceProfile>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -171,7 +176,7 @@ impl ChildBrokers {
             || profile.template_binding != self.template
             || profile.url != self.url
             || profile.model != self.model
-            || profile.url != "https://api.deepseek.com/chat/completions"
+            || warden::egress::model_endpoint_target(&profile.url, profile.allow_insecure).is_err()
             || !profile.credential_file.is_absolute()
             || profile.max_output_tokens != 512
             || profile.max_requests != self.requests
@@ -239,9 +244,11 @@ impl ChildBrokers {
         {
             return Err("model profile exceeds child reservation".into());
         }
-        let mut policy = warden::egress::HttpPolicy::new(vec!["api.deepseek.com".into()]);
+        let target = warden::egress::model_endpoint_target(&profile.url, profile.allow_insecure)?;
+        let mut policy = warden::egress::HttpPolicy::new(vec![target.host.clone()]);
         policy.timeout = turn.limits.timeout.min(std::time::Duration::from_secs(45));
         policy.max_requests = profile.max_requests as usize;
+        policy.allow_insecure = profile.allow_insecure;
         let get = match profile.fetch {
             Some(fetch) => warden::egress::GetGrant {
                 allow_hosts: fetch.allow_hosts,
@@ -260,6 +267,7 @@ impl ChildBrokers {
         policy.allow_hosts.extend(get.allow_hosts.iter().cloned());
         policy.get = Some(get);
         policy.json_posts.push(warden::egress::JsonPostGrant {
+            protocol: profile.protocol,
             url: profile.url,
             model: profile.model,
             bearer_token_file: profile.credential_file,
@@ -323,6 +331,7 @@ mod tests {
         )
         .unwrap();
         let profile = Profile {
+            protocol: Default::default(),
             api_version: "celln.parent-model-profile/v1".into(),
             principal: binding.principal.clone(),
             request_binding: request
@@ -335,6 +344,7 @@ mod tests {
             max_requests: 1,
             max_output_tokens: 512,
             max_total_output_tokens: 512,
+            allow_insecure: false,
             workspace: None,
             fetch: None,
         };

--- a/crates/celln-cli/src/starter_configure.rs
+++ b/crates/celln-cli/src/starter_configure.rs
@@ -55,11 +55,8 @@ pub fn run(plan: &Path, root: &Path) -> Result<u8> {
         c.endpoint.as_str()
     });
     let model = connection.map_or("deepseek-chat", |c| c.model.as_str());
-    warden::egress::model_endpoint_target(
-        endpoint,
-        connection.is_some_and(|c| c.allow_insecure),
-    )
-    .map_err(anyhow::Error::msg)?;
+    warden::egress::model_endpoint_target(endpoint, connection.is_some_and(|c| c.allow_insecure))
+        .map_err(anyhow::Error::msg)?;
     if let Some(c) = connection {
         let identifier = |s: &str| {
             !s.is_empty()

--- a/crates/celln-cli/src/starter_configure.rs
+++ b/crates/celln-cli/src/starter_configure.rs
@@ -21,6 +21,20 @@ struct Plan {
     principal: String,
     credential_file: PathBuf,
     output: PathBuf,
+    #[serde(default)]
+    model_connection: Option<ModelConnection>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ModelConnection {
+    provider: String,
+    protocol: warden::egress::ModelProtocol,
+    endpoint: String,
+    model: String,
+    credential_profile: String,
+    #[serde(default)]
+    allow_insecure: bool,
 }
 
 fn write_new(path: &Path, bytes: &[u8]) -> Result<()> {
@@ -36,6 +50,33 @@ fn write_new(path: &Path, bytes: &[u8]) -> Result<()> {
 
 pub fn run(plan: &Path, root: &Path) -> Result<u8> {
     let plan: Plan = serde_json::from_slice(&crate::starter_package::regular(plan, 16384)?)?;
+    let connection = plan.model_connection.as_ref();
+    let endpoint = connection.map_or("https://api.deepseek.com/chat/completions", |c| {
+        c.endpoint.as_str()
+    });
+    let model = connection.map_or("deepseek-chat", |c| c.model.as_str());
+    warden::egress::model_endpoint_target(
+        endpoint,
+        connection.is_some_and(|c| c.allow_insecure),
+    )
+    .map_err(anyhow::Error::msg)?;
+    if let Some(c) = connection {
+        let identifier = |s: &str| {
+            !s.is_empty()
+                && s.len() <= 64
+                && s.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+        };
+        ensure!(
+            identifier(&c.provider)
+                && identifier(&c.credential_profile)
+                && !model.is_empty()
+                && model.len() <= 128
+                && model.trim() == model
+                && !model.chars().any(char::is_control),
+            "invalid model connection"
+        );
+    }
     ensure!(
         plan.api_version == "celln.native-starter-config/v1",
         "unsupported starter configuration"
@@ -108,11 +149,13 @@ pub fn run(plan: &Path, root: &Path) -> Result<u8> {
     ];
     let schema = |bytes: String| json!({"hash":Hash::of(bytes.as_bytes()),"bytes":bytes});
     let tools: Vec<_> = specifications.iter().map(|(name,input)| json!({"name":name,"path":format!("/{name}"),"hash":entry(name)["executable"],"description":name,"input_schema":schema(input.to_string()),"output_schema":schema(output_schema.clone()),"input_bytes":8192,"output_bytes":32768,"timeout_ms":30000})).collect();
-    let template = pilot::turn_worker::Template::new(serde_json::from_value(
-        json!({"contract":"celln.json-tools/v1","task":"","system":"Use the borrowed tools when requested. Read files with workspace-read rather than relying on remembered content. Keep replies brief.","url":"https://api.deepseek.com/chat/completions","model":"deepseek-chat","tools":tools,"max_turns":3,"max_calls":1,"require_tool_call":false}),
-    )?)?;
+    let mut template_json = json!({"contract":"celln.json-tools/v1","task":"","system":"Use the borrowed tools when requested. Read files with workspace-read rather than relying on remembered content. Keep replies brief.","url":endpoint,"model":model,"tools":tools,"max_turns":3,"max_calls":1,"require_tool_call":false});
+    if connection.is_some_and(|c| c.allow_insecure) {
+        template_json["allow_insecure"] = json!(true);
+    }
+    let template = pilot::turn_worker::Template::new(serde_json::from_value(template_json)?)?;
     let profile = serde_json::to_vec(
-        &json!({"apiVersion":"celln.parent-model-profile/v1","principal":plan.principal,"requestBinding":worker.configuration_binding(ConfigurationRole::Worker).map_err(anyhow::Error::msg)?,"templateBinding":template.binding(),"credentialFile":plan.credential_file,"url":template.policy().url,"model":template.policy().model,"maxRequests":3,"maxOutputTokens":512,"maxTotalOutputTokens":1536,"workspace":{"read":true,"write":true,"maxOperations":4,"maxFiles":8,"maxFileBytes":4096,"maxTotalBytes":16384},"fetch":{"allowHosts":["example.com"],"maxRequests":4,"maxResponseBytes":4096,"timeoutMs":10000}}),
+        &json!({"apiVersion":"celln.parent-model-profile/v1","protocol":connection.map(|c| c.protocol).unwrap_or_default(),"allowInsecure":connection.is_some_and(|c| c.allow_insecure),"principal":plan.principal,"requestBinding":worker.configuration_binding(ConfigurationRole::Worker).map_err(anyhow::Error::msg)?,"templateBinding":template.binding(),"credentialFile":plan.credential_file,"url":template.policy().url,"model":template.policy().model,"maxRequests":3,"maxOutputTokens":512,"maxTotalOutputTokens":1536,"workspace":{"read":true,"write":true,"maxOperations":4,"maxFiles":8,"maxFileBytes":4096,"maxTotalBytes":16384},"fetch":{"allowHosts":["example.com"],"maxRequests":4,"maxResponseBytes":4096,"timeoutMs":10000}}),
     )?;
     let profile_hash = Hash::of(&profile);
     let mut catalogue_tools = Vec::new();
@@ -151,7 +194,10 @@ pub fn run(plan: &Path, root: &Path) -> Result<u8> {
         write_new(&path, &profile)?;
     }
     fs::File::open(profiles)?.sync_all()?;
-    let complete = json!({"apiVersion":"celln.native-starter-configured/v1","packageHash":plan.package_hash,"catalogueHash":Hash::of(&catalogue_bytes),"nativeTemplateHash":Hash::of(&native_bytes),"principal":plan.principal,"modelProfile":profile_hash,"model":{"provider":"deepseek","model":"deepseek-chat"},"hostLimits":{"leaseSeconds":3600,"maxTurns":12,"maxModelRequests":36,"maxOutputTokens":18432},"executionAuthorized":false,"readiness":"not_established"});
+    let mut complete = json!({"apiVersion":"celln.native-starter-configured/v1","packageHash":plan.package_hash,"catalogueHash":Hash::of(&catalogue_bytes),"nativeTemplateHash":Hash::of(&native_bytes),"principal":plan.principal,"modelProfile":profile_hash,"model":{"provider":"deepseek","model":"deepseek-chat"},"hostLimits":{"leaseSeconds":3600,"maxTurns":12,"maxModelRequests":36,"maxOutputTokens":18432},"executionAuthorized":false,"readiness":"not_established"});
+    if let Some(c) = connection {
+        complete["model"] = json!({"provider":c.provider,"protocol":c.protocol,"model":c.model,"baseURL":c.endpoint,"credentialProfile":c.credential_profile,"allowInsecure":c.allow_insecure});
+    }
     write_new(
         &plan.output.join("configured.json"),
         &serde_json::to_vec_pretty(&complete)?,

--- a/crates/celln-pilot/src/fetch_proof.rs
+++ b/crates/celln-pilot/src/fetch_proof.rs
@@ -12,7 +12,7 @@ use anyhow::{bail, Context, Result};
 use celln_manifest::{Author, Entry, Hash, Manifest, Tier};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use warden::egress::{HttpPolicy, JsonPostGrant};
+use warden::egress::{HttpPolicy, JsonPostGrant, ModelProtocol};
 use warden::vmm::boot::{BootConfig, LinuxCell};
 
 fn main() -> Result<()> {
@@ -109,6 +109,7 @@ fn main() -> Result<()> {
     let mut policy = HttpPolicy::new(vec![host]);
     if let Some(bearer_token_file) = model_token_file {
         policy.json_posts.push(JsonPostGrant {
+            protocol: ModelProtocol::OpenaiChat,
             url,
             bearer_token_file,
             model: "deepseek-chat".into(),

--- a/crates/celln-pilot/src/harness_proof.rs
+++ b/crates/celln-pilot/src/harness_proof.rs
@@ -163,6 +163,7 @@ fn main() -> Result<()> {
     policy.timeout = Duration::from_secs(45);
     policy.max_requests = 6;
     policy.json_posts.push(JsonPostGrant {
+        protocol: Default::default(),
         url: url.into(),
         bearer_token_file: token,
         model: "deepseek-chat".into(),

--- a/crates/celln-pilot/src/json_harness.rs
+++ b/crates/celln-pilot/src/json_harness.rs
@@ -66,6 +66,10 @@ pub struct Config {
     /// Omission preserves the original serialized template and optional calls.
     #[serde(default, skip_serializing_if = "is_false")]
     pub require_tool_call: bool,
+    /// Operator opt-in for an HTTP or self-signed private model endpoint.
+    /// Omission preserves the original serialized template hash.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub allow_insecure: bool,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -88,7 +92,8 @@ fn compile(config: &Config) -> Result<Vec<CheckedTool<'_>>> {
     ensure!(
         !config.model.is_empty()
             && config.model.len() <= 128
-            && config.url.starts_with("https://")
+            && (config.url.starts_with("https://")
+                || (config.allow_insecure && config.url.starts_with("http://")))
             && config.url.len() <= 512,
         "invalid model selection"
     );

--- a/crates/celln-pilot/src/json_harness_proof.rs
+++ b/crates/celln-pilot/src/json_harness_proof.rs
@@ -187,6 +187,7 @@ fn main() -> Result<()> {
             policy.timeout = Duration::from_secs(45);
             policy.max_requests = 6;
             policy.json_posts.push(warden::egress::JsonPostGrant {
+                protocol: Default::default(),
                 url: "https://api.deepseek.com/chat/completions".into(),
                 bearer_token_file: token.clone(),
                 model: "deepseek-chat".into(),

--- a/crates/celln-pilot/src/json_harness_tests.rs
+++ b/crates/celln-pilot/src/json_harness_tests.rs
@@ -82,6 +82,7 @@ fn config(names: &[&str]) -> Config {
         max_turns: 6,
         max_calls: 6,
         require_tool_call: false,
+        allow_insecure: false,
         tools: names
             .iter()
             .map(|name| Tool {

--- a/crates/celln-pilot/src/parent_turn_proof.rs
+++ b/crates/celln-pilot/src/parent_turn_proof.rs
@@ -166,6 +166,7 @@ pub fn run(
             policy.timeout = Duration::from_secs(45);
             policy.max_requests = reservation.limits.model_requests as usize;
             policy.json_posts.push(warden::egress::JsonPostGrant {
+                protocol: Default::default(),
                 url: "https://api.deepseek.com/chat/completions".into(),
                 bearer_token_file: token.into(),
                 model: "deepseek-chat".into(),

--- a/crates/celln-pilot/src/turn_worker.rs
+++ b/crates/celln-pilot/src/turn_worker.rs
@@ -105,6 +105,7 @@ mod tests {
             max_turns: 1,
             max_calls: 0,
             require_tool_call: false,
+            allow_insecure: false,
         }
     }
     fn turn(task: &str) -> ReservedTurn {

--- a/crates/celln-spec/src/lib.rs
+++ b/crates/celln-spec/src/lib.rs
@@ -303,6 +303,10 @@ pub struct CapabilityRequest {
     pub workspace: WorkspaceAccess,
     #[serde(default)]
     pub egress: Vec<String>,
+    /// Explicit operator opt-in for an HTTP or self-signed model endpoint.
+    /// Absent (the default) keeps the HTTPS-only, public-address contract.
+    #[serde(rename = "allowInsecure", default)]
+    pub allow_insecure: bool,
     #[serde(rename = "timeoutMs")]
     pub timeout_ms: u64,
     #[serde(rename = "memoryBytes")]
@@ -609,11 +613,15 @@ impl ExecutionRequest {
         }
 
         for (index, destination) in self.capabilities.egress.iter().enumerate() {
-            if !is_named_https_destination(destination) {
+            if !is_allowed_destination(destination, self.capabilities.allow_insecure) {
                 problems.push(ExecutionProblem {
                     code: ExecutionProblemCode::InvalidEgress,
                     field: format!("capabilities.egress[{index}]"),
-                    message: "must name one HTTPS host without a path, query, or fragment".into(),
+                    message: if self.capabilities.allow_insecure {
+                        "must name one HTTP(S) host without a path, query, or fragment".into()
+                    } else {
+                        "must name one HTTPS host without a path, query, or fragment".into()
+                    },
                 });
             }
         }
@@ -742,6 +750,36 @@ fn is_named_https_destination(value: &str) -> bool {
         && host
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b':'))
+}
+
+/// Destination shape for an execution request. The default keeps the
+/// HTTPS-only contract; the operator opt-in additionally permits HTTP and an
+/// explicit port so a private or self-signed model can be reached.
+fn is_allowed_destination(value: &str, allow_insecure: bool) -> bool {
+    if !allow_insecure {
+        return is_named_https_destination(value);
+    }
+    let Some(authority) = value
+        .strip_prefix("https://")
+        .or_else(|| value.strip_prefix("http://"))
+    else {
+        return false;
+    };
+    if authority.is_empty() || authority.contains(['/', '?', '#']) {
+        return false;
+    }
+    let (host, port) = match authority.rsplit_once(':') {
+        Some((host, port)) => (host, Some(port)),
+        None => (authority, None),
+    };
+    if host.is_empty()
+        || !host.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'[' | b']')
+        })
+    {
+        return false;
+    }
+    port.is_none_or(|port| !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()))
 }
 
 /// A spec problem worth stopping for.

--- a/crates/celln-spec/src/lib.rs
+++ b/crates/celln-spec/src/lib.rs
@@ -773,9 +773,9 @@ fn is_allowed_destination(value: &str, allow_insecure: bool) -> bool {
         None => (authority, None),
     };
     if host.is_empty()
-        || !host.bytes().all(|byte| {
-            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'[' | b']')
-        })
+        || !host
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'[' | b']'))
     {
         return false;
     }

--- a/crates/celln-spec/src/lib.rs
+++ b/crates/celln-spec/src/lib.rs
@@ -779,7 +779,9 @@ fn is_allowed_destination(value: &str, allow_insecure: bool) -> bool {
     {
         return false;
     }
-    port.is_none_or(|port| !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()))
+    port.map_or(true, |port| {
+        !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit())
+    })
 }
 
 /// A spec problem worth stopping for.

--- a/crates/celln-warden/src/egress.rs
+++ b/crates/celln-warden/src/egress.rs
@@ -9,7 +9,9 @@ use std::time::Duration;
 
 #[path = "egress_post.rs"]
 mod post;
-pub use post::JsonPostGrant;
+pub use post::{
+    model_endpoint_host, model_endpoint_target, JsonPostGrant, ModelEndpoint, ModelProtocol,
+};
 
 /// Independent credential-free GET authority for native starter tools.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -35,6 +37,10 @@ pub struct HttpPolicy {
     /// None preserves the legacy shared GET/model budget. Some uses an
     /// independent GET budget; an empty allowlist explicitly denies all GETs.
     pub get: Option<GetGrant>,
+    /// Operator opt-in that also permits HTTP and self-signed HTTPS model
+    /// endpoints on private addresses. Default false keeps the HTTPS-only,
+    /// public-address contract.
+    pub allow_insecure: bool,
 }
 
 impl HttpPolicy {
@@ -47,8 +53,18 @@ impl HttpPolicy {
             json_posts: Vec::new(),
             workspace: None,
             get: None,
+            allow_insecure: false,
         }
     }
+}
+
+/// A validated egress destination with its resolved address.
+#[derive(Debug, PartialEq, Eq)]
+struct Authorized {
+    scheme: String,
+    host: String,
+    port: u16,
+    ip: IpAddr,
 }
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -92,18 +108,35 @@ impl HttpBroker {
 
     /// Validate a request and pin its DNS result before curl is allowed to
     /// connect. Pinning closes a DNS-rebinding SSRF hole.
-    fn authorize(&self, raw: &str) -> Result<(String, IpAddr), FetchDenied> {
-        let rest = raw.strip_prefix("https://").ok_or(FetchDenied::Scheme)?;
+    fn authorize(&self, raw: &str) -> Result<Authorized, FetchDenied> {
+        let (scheme, rest) = if let Some(rest) = raw.strip_prefix("https://") {
+            ("https", rest)
+        } else if self.policy.allow_insecure {
+            (
+                "http",
+                raw.strip_prefix("http://").ok_or(FetchDenied::Scheme)?,
+            )
+        } else {
+            return Err(FetchDenied::Scheme);
+        };
         let authority = rest.split('/').next().unwrap_or_default();
         if authority.is_empty() || authority.contains('@') {
             return Err(FetchDenied::Authority);
         }
-        let host = authority
-            .split(':')
-            .next()
-            .unwrap_or_default()
-            .to_ascii_lowercase();
-        if host.is_empty() || (authority.contains(':') && !authority.ends_with(":443")) {
+        let (host, port) = match authority.rsplit_once(':') {
+            Some((host, port)) => {
+                let port: u16 = port.parse().map_err(|_| FetchDenied::Authority)?;
+                if port == 0 {
+                    return Err(FetchDenied::Authority);
+                }
+                (host.to_ascii_lowercase(), port)
+            }
+            None => (
+                authority.to_ascii_lowercase(),
+                if scheme == "https" { 443 } else { 80 },
+            ),
+        };
+        if host.is_empty() || (!self.policy.allow_insecure && port != 443) {
             return Err(FetchDenied::Authority);
         }
         if !self
@@ -130,20 +163,32 @@ impl HttpBroker {
                 .filter_map(|line| line.split_whitespace().next()?.parse().ok())
                 .collect()
         } else {
-            (host.as_str(), 443)
+            (host.as_str(), port)
                 .to_socket_addrs()
                 .map_err(|_| FetchDenied::Address)?
                 .map(|a| a.ip())
                 .collect()
         };
-        let ip = addresses
-            .into_iter()
-            .find_map(|a| match a {
-                IpAddr::V4(v) if is_public_v4(v.octets()) => Some(IpAddr::V4(v)),
-                _ => None,
-            })
-            .ok_or(FetchDenied::Address)?;
-        Ok((host, ip))
+        let ip = if self.policy.allow_insecure {
+            addresses
+                .into_iter()
+                .find(|a| matches!(a, IpAddr::V4(_)))
+                .ok_or(FetchDenied::Address)?
+        } else {
+            addresses
+                .into_iter()
+                .find_map(|a| match a {
+                    IpAddr::V4(v) if is_public_v4(v.octets()) => Some(IpAddr::V4(v)),
+                    _ => None,
+                })
+                .ok_or(FetchDenied::Address)?
+        };
+        Ok(Authorized {
+            scheme: scheme.into(),
+            host,
+            port,
+            ip,
+        })
     }
 
     /// HTTPS GET only, bounded body and time, DNS result pinned. Redirects are
@@ -205,7 +250,7 @@ impl HttpBroker {
                     return Err(FetchDenied::Host(host.into()));
                 }
             }
-            let (host, ip) = self.authorize(&url)?;
+            let authorized = self.authorize(&url)?;
             self.used += 1;
             self.get_used += 1;
             let header =
@@ -229,7 +274,10 @@ impl HttpBroker {
                     .arg("--max-filesize")
                     .arg(max_response_bytes.to_string())
                     .arg("--resolve")
-                    .arg(format!("{host}:443:{ip}"))
+                    .arg(format!(
+                        "{}:{}:{}",
+                        authorized.host, authorized.port, authorized.ip
+                    ))
                     .arg("--dump-header")
                     .arg(header.path())
                     .arg(&url),
@@ -321,6 +369,28 @@ mod tests {
         assert_eq!(
             b.authorize("https://example.com:444/"),
             Err(FetchDenied::Authority)
+        );
+    }
+
+    #[test]
+    fn insecure_opt_in_allows_private_http_and_ports() {
+        let mut policy = HttpPolicy::new(vec!["192.168.1.237".into()]);
+        policy.allow_insecure = true;
+        let broker = HttpBroker::new(policy);
+        let authorized = broker
+            .authorize("http://192.168.1.237:8080/v1/chat/completions")
+            .unwrap();
+        assert_eq!(authorized.scheme, "http");
+        assert_eq!(authorized.host, "192.168.1.237");
+        assert_eq!(authorized.port, 8080);
+        assert_eq!(authorized.ip.to_string(), "192.168.1.237");
+        // Without the opt-in the same request stays refused.
+        let strict = HttpBroker::new(HttpPolicy::new(vec!["192.168.1.237".into()]));
+        assert_eq!(
+            strict
+                .authorize("http://192.168.1.237:8080/v1")
+                .unwrap_err(),
+            FetchDenied::Scheme
         );
     }
 

--- a/crates/celln-warden/src/egress_post.rs
+++ b/crates/celln-warden/src/egress_post.rs
@@ -8,8 +8,102 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process::Command;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ModelProtocol {
+    #[default]
+    OpenaiChat,
+    AnthropicMessages,
+}
+
+/// A validated model endpoint. The default contract is a public HTTPS host on
+/// port 443; the operator opt-in also permits HTTP and an explicit port so a
+/// private or self-signed model can be reached.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelEndpoint {
+    pub scheme: String,
+    pub host: String,
+    pub port: u16,
+    pub origin: String,
+}
+
+/// Validate the endpoint before reading any credentials. Transport additionally
+/// checks DNS/IP policy and refuses redirects and non-public addresses.
+pub fn model_endpoint_target(url: &str, allow_insecure: bool) -> Result<ModelEndpoint, String> {
+    let (scheme, rest) = if let Some(rest) = url.strip_prefix("https://") {
+        ("https", rest)
+    } else if allow_insecure {
+        (
+            "http",
+            url.strip_prefix("http://")
+                .ok_or("model endpoint requires HTTP or HTTPS")?,
+        )
+    } else {
+        return Err("model endpoint requires HTTPS".into());
+    };
+    if url.len() > 2048 || url.contains(['?', '#', '\r', '\n', '\0']) {
+        return Err("invalid model endpoint".into());
+    }
+    let (authority, path) = rest
+        .split_once('/')
+        .ok_or("complete model endpoint required")?;
+    if path.is_empty() || authority.is_empty() || authority.contains('@') {
+        return Err("invalid model endpoint".into());
+    }
+    let (host, port) = match authority.rsplit_once(':') {
+        Some((host, port)) => {
+            let port: u16 = port.parse().map_err(|_| "invalid model endpoint port")?;
+            if port == 0 {
+                return Err("invalid model endpoint port".into());
+            }
+            (host, port)
+        }
+        None => (authority, if scheme == "https" { 443 } else { 80 }),
+    };
+    if !allow_insecure && port != 443 {
+        return Err("model endpoint requires port 443".into());
+    }
+    if host.is_empty() || host.len() > 253 {
+        return Err("invalid model endpoint".into());
+    }
+    let host_valid = if allow_insecure {
+        host.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'[' | b']'))
+    } else {
+        host.split('.').all(|label| {
+            !label.is_empty()
+                && label.len() <= 63
+                && !label.starts_with('-')
+                && !label.ends_with('-')
+                && label
+                    .bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        })
+    };
+    if !host_valid {
+        return Err("invalid model endpoint".into());
+    }
+    let default_port = (scheme == "https" && port == 443) || (scheme == "http" && port == 80);
+    let origin = if default_port {
+        format!("{scheme}://{host}")
+    } else {
+        format!("{scheme}://{host}:{port}")
+    };
+    Ok(ModelEndpoint {
+        scheme: scheme.into(),
+        host: host.into(),
+        port,
+        origin,
+    })
+}
+
+pub fn model_endpoint_host(url: &str) -> Result<String, String> {
+    model_endpoint_target(url, false).map(|target| target.host)
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct JsonPostGrant {
+    pub protocol: ModelProtocol,
     pub url: String,
     /// Operator-controlled file, read per request. Never delivered to guest.
     pub bearer_token_file: PathBuf,
@@ -157,7 +251,10 @@ fn parse(raw: &str) -> Result<Request, FetchDenied> {
     Ok(request)
 }
 
-fn credential_header(path: &std::path::Path) -> Result<tempfile::NamedTempFile, FetchDenied> {
+fn credential_header(
+    path: &std::path::Path,
+    protocol: ModelProtocol,
+) -> Result<tempfile::NamedTempFile, FetchDenied> {
     let mut bytes = Vec::new();
     std::fs::File::open(path)
         .and_then(|file| file.take(4097).read_to_end(&mut bytes))
@@ -171,9 +268,126 @@ fn credential_header(path: &std::path::Path) -> Result<tempfile::NamedTempFile, 
     // tempfile creates mode 0600. curl reads this file, never a token in argv.
     let mut header =
         tempfile::NamedTempFile::new().map_err(|_| refused("credential staging failed"))?;
-    writeln!(header, "Authorization: Bearer {token}")
-        .map_err(|_| refused("credential staging failed"))?;
+    let value = match protocol {
+        ModelProtocol::OpenaiChat => format!("Authorization: Bearer {token}"),
+        ModelProtocol::AnthropicMessages => {
+            format!("x-api-key: {token}\nanthropic-version: 2023-06-01")
+        }
+    };
+    writeln!(header, "{value}").map_err(|_| refused("credential staging failed"))?;
     Ok(header)
+}
+
+// The guest contract remains bounded Chat Completions. Protocol translation is
+// host-owned and runs only after that request has passed grant validation.
+fn provider_request(
+    body: &serde_json::Value,
+    protocol: ModelProtocol,
+) -> Result<serde_json::Value, FetchDenied> {
+    use serde_json::{json, Value};
+    if protocol == ModelProtocol::OpenaiChat {
+        return Ok(body.clone());
+    }
+    let chat: ChatRequest =
+        serde_json::from_value(body.clone()).map_err(|_| refused("invalid chat request"))?;
+    let mut system = Vec::new();
+    let mut messages: Vec<Value> = Vec::new();
+    for message in chat.messages {
+        if message.role == "system" {
+            system.push(message.content.unwrap_or_default());
+            continue;
+        }
+        let role = if message.role == "tool" {
+            "user"
+        } else {
+            &message.role
+        };
+        let mut content = Vec::new();
+        if message.role == "tool" {
+            content.push(json!({"type":"tool_result", "tool_use_id":message.tool_call_id, "content":message.content.unwrap_or_default()}));
+        } else {
+            if let Some(text) = message.content.filter(|text| !text.is_empty()) {
+                content.push(json!({"type":"text", "text":text}));
+            }
+            for call in message.tool_calls.unwrap_or_default() {
+                let input: Value = serde_json::from_str(&call.function.arguments)
+                    .map_err(|_| refused("invalid tool arguments"))?;
+                if !input.is_object() {
+                    return Err(refused("tool arguments must be an object"));
+                }
+                content.push(json!({"type":"tool_use", "id":call.id, "name":call.function.name, "input":input}));
+            }
+        }
+        if messages.last().is_some_and(|last| last["role"] == role) {
+            messages.last_mut().unwrap()["content"]
+                .as_array_mut()
+                .unwrap()
+                .extend(content);
+        } else {
+            messages.push(json!({"role":role,"content":content}));
+        }
+    }
+    let mut out =
+        json!({"model":chat.model,"max_tokens":chat.max_tokens,"stream":false,"messages":messages});
+    if !system.is_empty() {
+        out["system"] = json!(system.join("\n\n"));
+    }
+    if let Some(tools) = chat.tools {
+        if chat.tool_choice.as_deref() != Some("none") {
+            out["tools"] = json!(tools.into_iter().map(|tool| json!({"name":tool.function.name,"description":tool.function.description,"input_schema":tool.function.parameters})).collect::<Vec<_>>());
+            out["tool_choice"] = json!({"type": if chat.tool_choice.as_deref() == Some("required") { "any" } else { "auto" }});
+        }
+    }
+    Ok(out)
+}
+
+fn provider_response(raw: Vec<u8>, protocol: ModelProtocol) -> Result<Vec<u8>, FetchDenied> {
+    use serde_json::{json, Value};
+    if protocol == ModelProtocol::OpenaiChat {
+        return Ok(raw);
+    }
+    let response: Value =
+        serde_json::from_slice(&raw).map_err(|_| refused("invalid provider response"))?;
+    let blocks = response["content"]
+        .as_array()
+        .ok_or_else(|| refused("provider response has no content"))?;
+    let mut text = String::new();
+    let mut calls = Vec::new();
+    for block in blocks {
+        match block["type"].as_str() {
+            Some("text") => text.push_str(
+                block["text"]
+                    .as_str()
+                    .ok_or_else(|| refused("invalid provider text"))?,
+            ),
+            Some("tool_use") => {
+                let id = block["id"]
+                    .as_str()
+                    .ok_or_else(|| refused("missing tool id"))?;
+                let name = block["name"]
+                    .as_str()
+                    .ok_or_else(|| refused("missing tool name"))?;
+                if !block["input"].is_object() {
+                    return Err(refused("invalid tool input"));
+                }
+                calls.push(json!({"id":id,"type":"function","function":{"name":name,"arguments":block["input"].to_string()}}));
+            }
+            _ => return Err(refused("unsupported provider content block")),
+        }
+    }
+    let mut message = json!({"role":"assistant","content":text});
+    if !calls.is_empty() {
+        message["tool_calls"] = json!(calls);
+    }
+    let finish = match response["stop_reason"].as_str() {
+        Some("tool_use") => "tool_calls",
+        Some("max_tokens") => "length",
+        Some("end_turn" | "stop_sequence") => "stop",
+        _ => return Err(refused("unsupported provider stop reason")),
+    };
+    let input = response["usage"]["input_tokens"].as_u64().unwrap_or(0);
+    let output = response["usage"]["output_tokens"].as_u64().unwrap_or(0);
+    serde_json::to_vec(&json!({"choices":[{"index":0,"message":message,"finish_reason":finish}],"usage":{"prompt_tokens":input,"completion_tokens":output,"total_tokens":input.saturating_add(output)}})).map_err(|_| refused("invalid normalized response"))
 }
 
 impl HttpBroker {
@@ -206,13 +420,14 @@ impl HttpBroker {
             .checked_add(output_tokens)
             .filter(|total| *total <= grant.max_total_output_tokens)
             .ok_or_else(|| refused("model cumulative output budget exhausted"))?;
-        let (host, ip) = self.authorize(&request.url)?;
+        let authorized = self.authorize(&request.url)?;
         self.used += 1;
         self.post_output_reserved.insert(request.url.clone(), next);
-        let credential = credential_header(&grant.bearer_token_file)?;
+        let credential = credential_header(&grant.bearer_token_file, grant.protocol)?;
         let mut body =
             tempfile::NamedTempFile::new().map_err(|_| refused("request staging failed"))?;
-        serde_json::to_writer(&mut body, &request.body)
+        let provider_body = provider_request(&request.body, grant.protocol)?;
+        serde_json::to_writer(&mut body, &provider_body)
             .map_err(|_| refused("request staging failed"))?;
         let response_headers =
             tempfile::NamedTempFile::new().map_err(|_| refused("response staging failed"))?;
@@ -226,7 +441,11 @@ impl HttpBroker {
                 "--noproxy",
                 "*",
                 "--proto",
-                "=https",
+                if self.policy.allow_insecure {
+                    "=http,https"
+                } else {
+                    "=https"
+                },
                 "--max-redirs",
                 "0",
                 "--request",
@@ -241,9 +460,17 @@ impl HttpBroker {
             .arg("--max-time")
             .arg(self.policy.timeout.as_secs().max(1).to_string())
             .arg("--max-filesize")
-            .arg(self.policy.max_response_bytes.to_string())
+            .arg(self.policy.max_response_bytes.to_string());
+        if self.policy.allow_insecure && authorized.scheme == "https" {
+            // Opt-in only: accept a self-signed certificate for a private host.
+            command.arg("--insecure");
+        }
+        command
             .arg("--resolve")
-            .arg(format!("{host}:443:{ip}"))
+            .arg(format!(
+                "{}:{}:{}",
+                authorized.host, authorized.port, authorized.ip
+            ))
             .arg("--dump-header")
             .arg(response_headers.path())
             .arg("--url")
@@ -265,7 +492,11 @@ impl HttpBroker {
         if !(200..300).contains(&status) {
             return Err(refused(&format!("HTTP {status}; POST not replayed")));
         }
-        Ok(out.stdout)
+        let normalized = provider_response(out.stdout, grant.protocol)?;
+        if normalized.len() > self.policy.max_response_bytes {
+            return Err(refused("normalized response exceeded byte budget"));
+        }
+        Ok(normalized)
     }
 }
 
@@ -273,6 +504,131 @@ impl HttpBroker {
 mod tests {
     use super::*;
     use crate::egress::HttpPolicy;
+
+    #[test]
+    fn anthropic_round_trip_preserves_tool_ids_results_and_usage() {
+        use serde_json::json;
+        let body = json!({"model":"chosen","max_tokens":512,"stream":false,"messages":[
+            {"role":"system","content":"Use approved tools."},
+            {"role":"user","content":"Read the file"},
+            {"role":"assistant","content":null,"tool_calls":[{"id":"call-1","type":"function","function":{"name":"read","arguments":"{\"name\":\"notes\"}"}}]},
+            {"role":"tool","tool_call_id":"call-1","content":"violet"},
+            {"role":"user","content":"What did it say?"}
+        ],"tools":[{"type":"function","function":{"name":"read","description":"Read file","parameters":{"type":"object"}}}],"tool_choice":"required"});
+        let request = provider_request(&body, ModelProtocol::AnthropicMessages).unwrap();
+        assert_eq!(request["system"], "Use approved tools.");
+        assert_eq!(request["messages"][1]["content"][0]["id"], "call-1");
+        assert_eq!(
+            request["messages"][2]["content"][0]["tool_use_id"],
+            "call-1"
+        );
+        assert_eq!(request["messages"][2]["content"][0]["content"], "violet");
+        assert_eq!(
+            request["messages"][2]["content"].as_array().unwrap().len(),
+            2
+        );
+        assert_eq!(request["tool_choice"]["type"], "any");
+        assert_eq!(request["tools"][0]["input_schema"]["type"], "object");
+        let reply = json!({"content":[{"type":"text","text":"Checking"},{"type":"tool_use","id":"next","name":"read","input":{"name":"other"}}],"stop_reason":"tool_use","usage":{"input_tokens":12,"output_tokens":7}});
+        let normalized: serde_json::Value = serde_json::from_slice(
+            &provider_response(
+                serde_json::to_vec(&reply).unwrap(),
+                ModelProtocol::AnthropicMessages,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            normalized["choices"][0]["message"]["tool_calls"][0]["id"],
+            "next"
+        );
+        assert_eq!(normalized["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(normalized["usage"]["total_tokens"], 19);
+        assert_eq!(
+            provider_request(&body, ModelProtocol::OpenaiChat).unwrap(),
+            body
+        );
+    }
+
+    #[test]
+    fn model_endpoints_reject_credential_and_transport_overrides() {
+        for url in [
+            "http://example.com/v1",
+            "https://key@example.com/v1",
+            "https://example.com:8080/v1",
+            "https://example.com/v1?key=secret",
+            "https://example.com/v1#fragment",
+        ] {
+            assert!(model_endpoint_host(url).is_err(), "accepted {url}");
+        }
+        assert_eq!(
+            model_endpoint_host("https://api.anthropic.com/v1/messages").unwrap(),
+            "api.anthropic.com"
+        );
+        assert_eq!(
+            model_endpoint_host("https://custom.example/v1/chat/completions").unwrap(),
+            "custom.example"
+        );
+    }
+
+    #[test]
+    fn insecure_endpoint_target_allows_http_private_and_ports() {
+        let target =
+            model_endpoint_target("http://192.168.1.237:8080/v1/chat/completions", true).unwrap();
+        assert_eq!(target.origin, "http://192.168.1.237:8080");
+        assert_eq!(target.port, 8080);
+        assert_eq!(target.host, "192.168.1.237");
+        assert!(model_endpoint_target("http://192.168.1.237:8080/v1", false).is_err());
+        assert_eq!(
+            model_endpoint_target("https://api.deepseek.com/chat/completions", true)
+                .unwrap()
+                .origin,
+            "https://api.deepseek.com"
+        );
+    }
+
+    #[test]
+    fn insecure_broker_posts_to_private_http_endpoint() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            let body = br#"{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"LOCAL-OK"},"finish_reason":"stop"}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.write_all(body);
+            let _ = stream.flush();
+        });
+        let mut token = tempfile::NamedTempFile::new().unwrap();
+        writeln!(token, "{}", "a".repeat(32)).unwrap();
+        let mut policy = HttpPolicy::new(vec!["127.0.0.1".into()]);
+        policy.allow_insecure = true;
+        policy.json_posts.push(JsonPostGrant {
+            protocol: ModelProtocol::OpenaiChat,
+            url: format!("http://127.0.0.1:{port}/v1/chat/completions"),
+            bearer_token_file: token.path().to_path_buf(),
+            model: "local".into(),
+            max_output_tokens: 512,
+            max_total_output_tokens: 1024,
+        });
+        let mut broker = HttpBroker::new(policy);
+        let request = serde_json::json!({"apiVersion":"celln.fetch/v1","method":"POST",
+            "url":format!("http://127.0.0.1:{port}/v1/chat/completions"),
+            "body":{"model":"local","stream":false,"max_tokens":64,
+                "messages":[{"role":"user","content":"hi"}]}})
+        .to_string();
+        let out = broker.post_json(&request).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(value["choices"][0]["message"]["content"], "LOCAL-OK");
+        server.join().unwrap();
+    }
 
     fn wire() -> String {
         serde_json::json!({"apiVersion":"celln.fetch/v1","method":"POST","url":"https://example.com/model","body":{"messages":[]}}).to_string()
@@ -283,6 +639,7 @@ mod tests {
         // every refusal below must occur before DNS or credential access.
         let mut policy = HttpPolicy::new(vec!["provider.invalid".into()]);
         policy.json_posts.push(JsonPostGrant {
+            protocol: Default::default(),
             url: "https://provider.invalid/chat".into(),
             bearer_token_file: "/must-not-be-read".into(),
             model: "approved".into(),
@@ -467,6 +824,7 @@ mod tests {
     fn endpoints_are_exact_and_untrusted_headers_are_rejected() {
         let mut policy = HttpPolicy::new(vec!["example.com".into()]);
         policy.json_posts.push(JsonPostGrant {
+            protocol: Default::default(),
             url: "https://example.com/model".into(),
             bearer_token_file: "/not-read".into(),
             model: "approved-model".into(),
@@ -514,7 +872,7 @@ mod tests {
             "rotated-test-token-at-least-24",
         ] {
             std::fs::write(&file, token).unwrap();
-            let header = credential_header(&file).unwrap();
+            let header = credential_header(&file, ModelProtocol::OpenaiChat).unwrap();
             assert_eq!(
                 std::fs::read_to_string(header.path()).unwrap(),
                 format!("Authorization: Bearer {token}\n")
@@ -523,7 +881,7 @@ mod tests {
         for token in ["short", "secret-with-injected\r\nX-Header: bad"] {
             std::fs::write(&file, token).unwrap();
             assert_eq!(
-                credential_header(&file).unwrap_err(),
+                credential_header(&file, ModelProtocol::OpenaiChat).unwrap_err(),
                 refused("invalid provider credential")
             );
         }


### PR DESCRIPTION
## Why

Celln's in-cell model loop (the `celln.reference-functions/v1` / JSON harness) was pinned to a single provider: the operator model profile and the harness grant rejected any URL except `https://api.deepseek.com/chat/completions`, and egress assumed a public HTTPS host with no port. So model calls could not work with other model APIs (OpenAI-compatible or Anthropic) or private/self-signed endpoints.

## What

Lands the generalization (originally `feat/model-connections`) onto `main`:

- **`celln-spec`** — `Capabilities.allowInsecure`; the egress origin accepts `http(s)://host[:port]` and private addresses.
- **`celln-warden`** — a `ModelProtocol` (`openai-chat` / `anthropic-messages`) with per-protocol auth headers (`Authorization: Bearer` vs `x-api-key` + `anthropic-version`) and request/response shaping (OpenAI `messages:[{role,content}]` vs Anthropic tool-use blocks). `model_endpoint_target`/`model_endpoint_host` parse any endpoint; `HttpPolicy.allow_insecure` plus `curl --proto/--insecure/--resolve` and private/port authorization for the explicit opt-in.
- **`celln-cli`** — harness/parent grants and the issuer profile now carry `protocol` and `allowInsecure`; the issuer no longer hard-pins DeepSeek, it validates the declared endpoint via `model_endpoint_target`. JSON harness config carries `allow_insecure`.
- **`celln-pilot`** — JSON harness template/proofs carry `allow_insecure` and accept an `http://` URL.

## Validation

- `cargo test -p celln-warden -p celln-spec -p celln-pilot -p celln-cli --lib` — green (102 warden tests incl. `insecure_broker_posts_to_private_http_endpoint` and Anthropic round-trip).

## Note

Companion sympozium side (`200ac4c`) already threads `ModelConnection.protocol`/`allowInsecure` into native Celln issuance. Together these make model calls work for any OpenAI-compatible or Anthropic endpoint.