### PR TITLE
feat(router): parent-aware execution plane — route /v1/parents + dispatcher drain

### DIFF
--- a/crates/celln-cli/src/dispatch_http.rs
+++ b/crates/celln-cli/src/dispatch_http.rs
@@ -503,6 +503,27 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
         }
     }
     match (method.as_str(), path.as_str()) {
+        ("POST", "/v1/drain") => {
+            if length != 0 {
+                return reply(
+                    &mut stream,
+                    400,
+                    &serde_json::json!({"error":"drain body must be empty"}),
+                );
+            }
+            match state.parents.drain() {
+                Ok(()) => reply(
+                    &mut stream,
+                    200,
+                    &serde_json::json!({"teardownConfirmed":true}),
+                ),
+                Err(_) => reply(
+                    &mut stream,
+                    503,
+                    &serde_json::json!({"teardownConfirmed":false}),
+                ),
+            }
+        }
         ("POST", "/v1/artifacts/prewarm") => {
             prewarm::handle(state, &mut stream, &mut reader, length)
         }
@@ -546,7 +567,7 @@ fn handle(mut stream: TcpStream, state: &State) -> Result<()> {
                 &mut stream,
                 200,
                 &serde_json::json!({
-                    "ok": node.eligible(),
+                    "ok": node.eligible() && !state.parents.is_draining(),
                     "kvm": node.kvm,
                     "mote_store": node.mote_store,
                     "tool_store": node.tool_store,

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -186,6 +186,9 @@ enum Cmd {
         /// Optional read-only bearer credential for GET /v1/capabilities only.
         #[arg(long)]
         capability_token_file: Option<PathBuf>,
+        /// Optional operator parent principal credential for enduring routes.
+        #[arg(long)]
+        parent_token_file: Option<PathBuf>,
         /// Durable owner ledger shared by all router replicas (coherent POSIX locks required).
         #[arg(long)]
         ownership_dir: PathBuf,
@@ -738,6 +741,7 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             token_file,
             client_token_file,
             capability_token_file,
+            parent_token_file,
             ownership_dir,
         } => router::serve(
             listen,
@@ -747,6 +751,7 @@ fn dispatch(cli: &Cli, o: &Out) -> Result<u8> {
             token_file,
             client_token_file,
             capability_token_file.as_deref(),
+            parent_token_file.as_deref(),
             ownership_dir,
         ),
         Cmd::Node(NodeCmd::Probe { probe }) => node::probe(probe, &root),

--- a/crates/celln-cli/src/router.rs
+++ b/crates/celln-cli/src/router.rs
@@ -22,6 +22,8 @@ use std::time::Duration;
 
 #[path = "router_ownership.rs"]
 mod ownership;
+#[path = "router_parents.rs"]
+mod parents;
 
 // Credentials are bounded and never echoed in errors. Reload on each request
 // to support atomic file/Secret rotation; an unreadable file fails closed.
@@ -96,6 +98,7 @@ pub fn serve(
     token_file: &Path,
     client_token_file: &Path,
     capability_token_file: Option<&Path>,
+    parent_token_file: Option<&Path>,
     ownership_dir: &Path,
 ) -> Result<u8> {
     let mut urls: Vec<String> = backends
@@ -135,6 +138,8 @@ pub fn serve(
         mode,
         cursor: AtomicUsize::new(0),
         executions: ownership::Ledger::open(ownership_dir, 100_000)?,
+        parents: ownership::Ledger::open(&ownership_dir.join("parents"), 100_000)?,
+        parent_token_file: parent_token_file.map(Path::to_owned),
         token_file: token_file.to_owned(),
         client_token_file: client_token_file.to_owned(),
         capability_token_file: capability_token_file.map(Path::to_owned),
@@ -168,6 +173,8 @@ struct RouterState {
     cursor: AtomicUsize,
     /// Shared durable ownership and anti-replay tombstones.
     executions: ownership::Ledger,
+    parents: ownership::Ledger,
+    parent_token_file: Option<PathBuf>,
     token_file: PathBuf,
     client_token_file: PathBuf,
     capability_token_file: Option<PathBuf>,
@@ -232,6 +239,8 @@ fn handle_request(stream: &mut TcpStream, state: &RouterState) -> Result<()> {
     let mut seen_length = false;
     let mut authorization = None;
     let mut pinned_backend = None;
+    let mut parent_incarnation = None;
+    let mut respond_async = false;
     let mut header_count = 0usize;
     loop {
         let header = read_bounded_line(&mut reader, MAX_HEADER_LINE)?;
@@ -267,6 +276,26 @@ fn handle_request(stream: &mut TcpStream, state: &RouterState) -> Result<()> {
                 );
             }
             pinned_backend = Some(value.trim().to_owned());
+        } else if name.eq_ignore_ascii_case("x-celln-parent-incarnation") {
+            if parent_incarnation
+                .replace(value.trim().to_owned())
+                .is_some()
+            {
+                return reply(
+                    stream,
+                    400,
+                    &serde_json::json!({"error":"duplicate parent identity"}),
+                );
+            }
+        } else if name.eq_ignore_ascii_case("prefer") {
+            if value.trim() != "respond-async" || respond_async {
+                return reply(
+                    stream,
+                    400,
+                    &serde_json::json!({"error":"unsupported or duplicate preference"}),
+                );
+            }
+            respond_async = true;
         } else if name.eq_ignore_ascii_case("content-length") {
             if seen_length || !value.trim().bytes().all(|b| b.is_ascii_digit()) {
                 return reply(
@@ -335,6 +364,19 @@ fn handle_request(stream: &mut TcpStream, state: &RouterState) -> Result<()> {
         }
     }
     match (method.as_str(), path.as_str()) {
+        (_, path) if path == "/v1/parents" || path.starts_with("/v1/parents/") => {
+            parents::forward(
+                state,
+                stream,
+                &mut reader,
+                &method,
+                path,
+                length,
+                parent_incarnation.as_deref(),
+                respond_async,
+                &backend_token,
+            )?;
+        }
         ("GET", "/v1/capabilities") => capability_report(state, stream, &backend_token)?,
         ("POST", "/v1/artifacts/prewarm") => forward_prewarm(
             stream,
@@ -434,6 +476,7 @@ fn capability_report(
             "preflightOnly":true,
             "eligibleNodes":eligible,
             "artifactReadiness":"not_checked",
+            "parentRouting":state.parent_token_file.is_some(),
             "nodes":nodes,
         }),
     )
@@ -1166,6 +1209,189 @@ mod tests {
         );
     }
 
+    #[test]
+    fn parent_affinity_survives_lost_create_and_gateway_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut first = state(dir.path());
+        let parent_file = dir.path().join("parent-token");
+        const PARENT: &str = "parent-principal-credential-at-least-24";
+        std::fs::write(&parent_file, PARENT).unwrap();
+        first.parent_token_file = Some(parent_file.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let backend = format!("http://{}", listener.local_addr().unwrap());
+        first.backends = vec![backend.clone()];
+        let id = format!("blake3:{}", "a".repeat(64));
+        let body = format!(
+            r#"{{"apiVersion":"celln.parent-create/v1","launchProfile":"blake3:{}"}}"#,
+            "b".repeat(64)
+        );
+        let headers = format!("Authorization: Bearer {CLIENT_TOKEN}\r\nX-Celln-Parent-Incarnation: {id}\r\nContent-Length: {}\r\n", body.len());
+        let owner_id = id.clone();
+        let server = std::thread::spawn(move || {
+            for expected in [
+                "GET /v1/health".to_string(),
+                "POST /v1/parents".to_string(),
+                format!("GET /v1/parents/{owner_id}"),
+                format!("POST /v1/parents/{owner_id}/turns"),
+            ] {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                let line = read_bounded_line(&mut reader, MAX_REQUEST_LINE).unwrap();
+                assert!(line.starts_with(&format!("{expected} HTTP/1.1")), "{line}");
+                let mut credential = String::new();
+                let mut length = 0;
+                let mut async_header = false;
+                loop {
+                    let h = read_bounded_line(&mut reader, MAX_HEADER_LINE).unwrap();
+                    if h.trim().is_empty() {
+                        break;
+                    }
+                    if h.starts_with("Authorization:") {
+                        credential = h.clone();
+                    }
+                    if h.starts_with("Content-Length:") {
+                        length = h
+                            .split_once(':')
+                            .unwrap()
+                            .1
+                            .trim()
+                            .parse::<usize>()
+                            .unwrap();
+                    }
+                    if h == "Prefer: respond-async\r\n" {
+                        async_header = true;
+                    }
+                }
+                let mut bytes = vec![0; length];
+                reader.read_exact(&mut bytes).unwrap();
+                if expected == "GET /v1/health" {
+                    assert_eq!(
+                        credential,
+                        format!("Authorization: Bearer {BACKEND_TOKEN}\r\n")
+                    );
+                    reply(&mut stream, 200, &serde_json::json!({"ok":true,"kvm":true})).unwrap();
+                } else {
+                    assert_eq!(credential, format!("Authorization: Bearer {PARENT}\r\n"));
+                    if expected == "POST /v1/parents" {
+                        // Owner accepted; its acknowledgement is lost.
+                        continue;
+                    }
+                    if expected.ends_with("/turns") {
+                        assert!(async_header);
+                    }
+                    reply(&mut stream, 200, &serde_json::json!({"incarnation":owner_id,"status":"Ready","retryAuthorized":false})).unwrap();
+                }
+            }
+        });
+        assert_eq!(
+            parse_status(&request(&first, "POST", "/v1/parents", &headers, &body)),
+            502
+        );
+        drop(first);
+        let mut replica = state(dir.path());
+        replica.parent_token_file = Some(parent_file);
+        replica.backends = vec![backend];
+        assert_eq!(
+            parse_status(&request(&replica, "POST", "/v1/parents", &headers, &body)),
+            409
+        );
+        let auth = format!("Authorization: Bearer {CLIENT_TOKEN}\r\n");
+        assert_eq!(
+            parse_status(&request(
+                &replica,
+                "GET",
+                &format!("/v1/parents/{id}"),
+                &auth,
+                ""
+            )),
+            200
+        );
+        assert_eq!(
+            parse_status(&request(
+                &replica,
+                "POST",
+                &format!("/v1/parents/{id}/turns"),
+                &format!("{auth}Prefer: respond-async\r\nContent-Length: 2\r\n"),
+                "{}"
+            )),
+            200
+        );
+        server.join().unwrap();
+        replica.backends = vec!["http://127.0.0.1:1".into()];
+        assert_eq!(
+            parse_status(&request(
+                &replica,
+                "GET",
+                &format!("/v1/parents/{id}"),
+                &auth,
+                ""
+            )),
+            503
+        );
+        assert_eq!(
+            parse_status(&request(&replica, "POST", "/v1/parents", &headers, &body)),
+            409
+        );
+    }
+
+    #[test]
+    fn parent_routes_refuse_discovery_credentials_and_malformed_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut owner = state(dir.path());
+        let parent = dir.path().join("parent");
+        std::fs::write(&parent, "parent-owner-credential-at-least-24").unwrap();
+        owner.parent_token_file = Some(parent.clone());
+        let discovery = dir.path().join("discovery");
+        const DISCOVERY: &str = "discovery-credential-at-least-24";
+        std::fs::write(&discovery, DISCOVERY).unwrap();
+        owner.capability_token_file = Some(discovery);
+        let id = format!("blake3:{}", "a".repeat(64));
+        for path in [
+            "/v1/parents".into(),
+            format!("/v1/parents/{id}"),
+            format!("/v1/parents/{id}/turns"),
+        ] {
+            assert_eq!(
+                parse_status(&request(
+                    &owner,
+                    "POST",
+                    &path,
+                    &format!("Authorization: Bearer {DISCOVERY}\r\n"),
+                    ""
+                )),
+                401
+            );
+        }
+        for headers in [
+            String::new(),
+            "X-Celln-Parent-Incarnation: ../../escape\r\n".into(),
+            format!("X-Celln-Parent-Incarnation: {id}\r\nX-Celln-Parent-Incarnation: {id}\r\n"),
+        ] {
+            assert_eq!(
+                parse_status(&request(
+                    &owner,
+                    "POST",
+                    "/v1/parents",
+                    &format!("Authorization: Bearer {CLIENT_TOKEN}\r\n{headers}"),
+                    ""
+                )),
+                400
+            );
+        }
+        assert!(owner.parents.lookup(&id).unwrap().is_none());
+        std::fs::write(parent, DISCOVERY).unwrap();
+        assert_eq!(
+            parse_status(&request(
+                &owner,
+                "GET",
+                &format!("/v1/parents/{id}"),
+                &format!("Authorization: Bearer {CLIENT_TOKEN}\r\n"),
+                ""
+            )),
+            503
+        );
+    }
+
     fn state(dir: &Path) -> RouterState {
         let client_token_file = dir.join("client");
         let token_file = dir.join("backend");
@@ -1176,6 +1402,8 @@ mod tests {
             mode: RoutingMode::RoundRobin,
             cursor: AtomicUsize::new(0),
             executions: ownership::Ledger::open(&dir.join("ownership"), 100).unwrap(),
+            parents: ownership::Ledger::open(&dir.join("ownership/parents"), 100).unwrap(),
+            parent_token_file: None,
             token_file,
             client_token_file,
             capability_token_file: None,

--- a/crates/celln-cli/src/router_parents.rs
+++ b/crates/celln-cli/src/router_parents.rs
@@ -1,0 +1,184 @@
+//! Parent affinity is published BEFORE create, including the immutable caller
+//! incarnation. Lost responses and gateway restarts never authorize recreation.
+use super::*;
+use serde_json::json;
+
+fn hash_valid(id: &str) -> bool {
+    id.strip_prefix("blake3:").is_some_and(|s| {
+        s.len() == 64
+            && s.bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    })
+}
+
+fn parent_id<'a>(method: &str, path: &'a str) -> Option<&'a str> {
+    let parts: Vec<_> = path.strip_prefix("/v1/parents/")?.split('/').collect();
+    let id = *parts.first()?;
+    if !hash_valid(id) {
+        return None;
+    }
+    let valid = match (method, &parts[1..]) {
+        ("GET", []) | ("POST", ["stop" | "cancel" | "turns"]) => true,
+        ("GET", ["turns", turn]) | ("POST", ["turns", turn, "cancel"]) => {
+            !turn.is_empty()
+                && turn.len() <= 64
+                && turn
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b"_-".contains(&b))
+        }
+        _ => false,
+    };
+    valid.then_some(id)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn forward(
+    state: &RouterState,
+    stream: &mut TcpStream,
+    reader: &mut impl Read,
+    method: &str,
+    path: &str,
+    length: usize,
+    incarnation: Option<&str>,
+    respond_async: bool,
+    backend_token: &Option<String>,
+) -> Result<()> {
+    let token = match state
+        .parent_token_file
+        .as_deref()
+        .map(read_token)
+        .transpose()
+    {
+        Ok(Some(token)) => token,
+        _ => {
+            return reply(
+                stream,
+                503,
+                &json!({"error":"parent routing is not configured"}),
+            )
+        }
+    };
+    // The capability bearer must never acquire a parent principal via reuse.
+    let (client, backend, capability) = credentials(state)?;
+    if [&client, &backend]
+        .into_iter()
+        .chain(capability.iter())
+        .any(|other| constant_time_eq(token.as_bytes(), other.as_bytes()))
+    {
+        return reply(
+            stream,
+            503,
+            &json!({"error":"parent credential must be distinct"}),
+        );
+    }
+    let create = method == "POST" && path == "/v1/parents";
+    let id = if create {
+        incarnation.filter(|id| hash_valid(id))
+    } else {
+        parent_id(method, path)
+    };
+    let Some(id) = id else {
+        return reply(
+            stream,
+            400,
+            &json!({"error":"invalid parent route or missing immutable incarnation"}),
+        );
+    };
+    if length > 65536 || (method == "GET" && length != 0) {
+        return reply(stream, 400, &json!({"error":"invalid parent body length"}));
+    }
+    let mut body = vec![0; length];
+    reader.read_exact(&mut body)?;
+    let backend = if create {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Create {
+            api_version: String,
+            launch_profile: String,
+        }
+        let parsed: Create = match serde_json::from_slice(&body) {
+            Ok(value) => value,
+            Err(_) => return reply(stream, 400, &json!({"error":"invalid parent create"})),
+        };
+        if parsed.api_version != "celln.parent-create/v1" || !hash_valid(&parsed.launch_profile) {
+            return reply(stream, 400, &json!({"error":"invalid parent create"}));
+        }
+        match state
+            .parents
+            .claim(id, &body, || pick_backend(state, id, backend_token))
+        {
+            Ok(ownership::Claim::New(owner)) => owner.backend,
+            Ok(ownership::Claim::Existing(_)) | Ok(ownership::Claim::Conflict) => {
+                return reply(
+                    stream,
+                    409,
+                    &json!({"error":"parent identity already claimed; reconcile original owner", "retryAuthorized":false}),
+                );
+            }
+            _ => {
+                return reply(
+                    stream,
+                    503,
+                    &json!({"error":"parent ownership unavailable", "retryAuthorized":false}),
+                )
+            }
+        }
+    } else {
+        match state.parents.lookup(id) {
+            Ok(Some(owner)) => owner.backend,
+            Ok(None) => {
+                return reply(
+                    stream,
+                    404,
+                    &json!({"error":"parent owner unknown", "retryAuthorized":false}),
+                )
+            }
+            Err(_) => {
+                return reply(
+                    stream,
+                    503,
+                    &json!({"error":"parent ownership unavailable", "retryAuthorized":false}),
+                )
+            }
+        }
+    };
+    if !state.backends.contains(&backend) {
+        return reply(
+            stream,
+            503,
+            &json!({"error":"original parent backend removed", "retryAuthorized":false}),
+        );
+    }
+    // No health-based reselection, forwarding retry, or automatic POST replay.
+    let response = (|| -> Result<String> {
+        let mut conn = connect(&backend_to_addr(&backend)?)?;
+        write!(conn, "{method} {path} HTTP/1.1\r\nHost: dispatcher\r\nAuthorization: Bearer {token}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n", body.len())?;
+        if respond_async {
+            write!(conn, "Prefer: respond-async\r\n")?;
+        }
+        write!(conn, "\r\n")?;
+        conn.write_all(&body)?;
+        conn.flush()?;
+        read_response(&mut conn)
+    })();
+    match response {
+        Ok(response) => {
+            if create && (200..300).contains(&parse_status(&response)) {
+                let result: serde_json::Value = serde_json::from_str(extract_body(&response))?;
+                if result["incarnation"].as_str() != Some(id) {
+                    return reply(
+                        stream,
+                        502,
+                        &json!({"error":"parent owner returned another incarnation", "retryAuthorized":false}),
+                    );
+                }
+            }
+            raw_reply(stream, &response)
+        }
+        Err(_) => reply(
+            stream,
+            502,
+            &json!({"error":"parent outcome uncertain; reconcile original owner", "retryAuthorized":false}),
+        ),
+    }
+}

--- a/crates/celln-warden/src/parent_registry.rs
+++ b/crates/celln-warden/src/parent_registry.rs
@@ -30,6 +30,7 @@ struct Entry {
 struct State {
     entries: BTreeMap<String, Entry>,
     reserved_bytes: u64,
+    draining: bool,
 }
 pub struct ParentRegistry {
     state: Mutex<State>,
@@ -114,6 +115,7 @@ impl ParentRegistry {
             state: Mutex::new(State {
                 entries: BTreeMap::new(),
                 reserved_bytes: 0,
+                draining: false,
             }),
             max_entries,
             memory_bytes,
@@ -177,6 +179,9 @@ impl ParentRegistry {
             .state
             .lock()
             .map_err(|_| "parent registry unavailable")?;
+        if state.draining {
+            return Err("parent owner is draining".into());
+        }
         if state.entries.contains_key(&incarnation.0) {
             return Err("parent incarnation already claimed; reconcile original owner".into());
         }
@@ -212,6 +217,9 @@ impl ParentRegistry {
             .lock()
             .map_err(|_| "parent registry unavailable")?;
         let entry = scoped(&state, principal, incarnation)?;
+        if state.draining {
+            return Err("parent owner is draining".into());
+        }
         entry
             .owner
             .as_ref()
@@ -270,6 +278,44 @@ impl ParentRegistry {
     /// Cancellation + confirmed join, without holding the registry lock across
     /// guest teardown. Concurrent stop observes Stopping, never false success.
     /// A panicked owner remains conservatively charged as teardown uncertain.
+    /// Atomically close admission, signal all live trees, then join each owner.
+    /// Keep every identity/tombstone and report uncertain teardown as failure.
+    pub fn drain(&self) -> Result<(), String> {
+        let owners = {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| "parent registry unavailable")?;
+            state.draining = true;
+            state
+                .entries
+                .iter()
+                .map(|(id, entry)| {
+                    if let Some(owner) = &entry.owner {
+                        owner.cancel();
+                    }
+                    (entry.principal.clone(), Hash(id.clone()))
+                })
+                .collect::<Vec<_>>()
+        };
+        let mut uncertain = false;
+        for (principal, id) in owners {
+            uncertain |= self.stop(&principal, &id).is_err();
+        }
+        if uncertain {
+            Err("parent drain teardown uncertain".into())
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn is_draining(&self) -> bool {
+        self.state
+            .lock()
+            .map(|state| state.draining)
+            .unwrap_or(true)
+    }
+
     pub fn stop(&self, principal: &str, incarnation: &Hash) -> Result<(), String> {
         let owner = {
             let mut state = self
@@ -322,6 +368,30 @@ mod tests {
         registry.spawn_admitted("tenant-one", id, Duration::from_secs(10), 100, || {
             Ok(|bytes: &[u8]| Ok(bytes.to_vec()))
         })
+    }
+    #[test]
+    fn drain_joins_all_owners_and_permanently_closes_admission() {
+        let registry = ParentRegistry::new(4, 400).unwrap();
+        let first = Hash::of(b"drain-one");
+        let second = Hash::of(b"drain-two");
+        spawn(&registry, &first).unwrap();
+        spawn(&registry, &second).unwrap();
+        registry.drain().unwrap();
+        assert!(registry.is_draining());
+        assert_eq!(registry.reserved_capacity().unwrap().owners, 0);
+        assert_eq!(
+            registry.status("tenant-one", &first).unwrap(),
+            Status::Stopped
+        );
+        assert_eq!(
+            registry.status("tenant-one", &second).unwrap(),
+            Status::Stopped
+        );
+        assert!(spawn(&registry, &Hash::of(b"after-drain")).is_err());
+        assert!(registry
+            .submit("tenant-one", &first, b"no more work")
+            .is_err());
+        registry.drain().unwrap();
     }
     #[test]
     fn tenant_scope_applies_to_submit_status_and_stop() {


### PR DESCRIPTION
## What

Adds the celln-side half of the sympozium **single execution plane** work (sympozium-ai/sympozium#490 / PR #491):

- **Router parent routing** — `celln route` gains `--parent-token-file`, authenticates operator parent principals, and serves `/v1/parents*` with durable parent affinity (new `crates/celln-cli/src/router_parents.rs`, wired through `router.rs` / `main.rs`).
- **Dispatcher drain** — `POST /v1/drain` closes admission, signals and joins every live parent tree, and reports `teardownConfirmed`; `/healthz` reports `ok:false` while draining. Adds `ParentRegistry::drain()` / `is_draining()`, and the registry rejects new claims while draining (`crates/celln-warden/src/parent_registry.rs`, `crates/celln-cli/src/dispatch_http.rs`).

## Why

sympozium deploys the celln router (`ghcr.io/sympozium-ai/celln`) as its gateway and layers its own `celln-installer` image `FROM ${CELLN_IMAGE}` as the host dispatcher. Landing this patch means the next celln release publishes a router with parent routing and a dispatcher binary with `/v1/drain`, so sympozium can consume them by bumping its pinned `config/celln/release.json` — with no custom per-feature images.

## Testing

- `cargo check -p celln-cli`
- `cargo test -p celln-cli -p celln-warden` — 147 + 103 passed
- Rebased onto `main` (0.5.9)
