### PR TITLE
[Celln tenancy 05c/15] Runtime scoped verifier and atomic public-key reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +116,21 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -121,6 +165,18 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cc"
@@ -164,6 +220,7 @@ dependencies = [
  "ed25519-dalek",
  "flate2",
  "is-terminal",
+ "jsonschema",
  "libc",
  "serde",
  "serde_json",
@@ -386,6 +443,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +502,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +541,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,8 +600,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -501,6 +635,16 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "indexmap"
@@ -530,10 +674,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "iso8601"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0f4bea31643be4c6a678e9aa4ae44f0db9e5609d5ca9dc9083d06eb3e9a27a"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64",
+ "bytecount",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.17",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "regex",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "kvm-bindings"
@@ -557,6 +749,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,10 +767,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -581,6 +794,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -596,6 +903,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +946,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -624,13 +972,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc_version"
@@ -653,6 +1045,18 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -739,6 +1143,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +1232,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,16 +1324,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "version_check"
@@ -895,6 +1388,60 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-link"
@@ -991,6 +1538,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d35102a9f36d089ccae9e4c6802bc118be4487b80aaffc0ab4e0cf5ce92d2873"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c01f5ab44258da43cf276c74a2763db2ff3969c9c652c3f2de07041d0b2bc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/crates/celln-cli/Cargo.toml
+++ b/crates/celln-cli/Cargo.toml
@@ -29,13 +29,14 @@ is-terminal.workspace = true
 toml.workspace = true
 tempfile.workspace = true
 zeroize = "=1.8.1"
+sha2 = "0.10"
+ed25519-dalek = "=2.1.1"
+base64 = "=0.22.1"
+jsonschema = { version = "=0.18.3", default-features = false, features = ["draft202012"] }
 
 [dev-dependencies]
 tempfile.workspace = true
-sha2 = "0.10"
 flate2 = "=1.0.35"
-ed25519-dalek = "=2.1.1"
-base64 = "=0.22.1"
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/crates/celln-cli/src/lib.rs
+++ b/crates/celln-cli/src/lib.rs
@@ -1,4 +1,6 @@
 //! Host-side Celln authorization primitives. Verification alone never bypasses
 //! the dispatcher publisher/closure/ABI checks or durable ownership admission.
+#[cfg(target_os = "linux")]
+pub mod tenancy_admission;
 mod tenancy_contract;
 pub mod tenancy_credentials;

--- a/crates/celln-cli/src/lib.rs
+++ b/crates/celln-cli/src/lib.rs
@@ -1,0 +1,4 @@
+//! Host-side Celln authorization primitives. Verification alone never bypasses
+//! the dispatcher publisher/closure/ABI checks or durable ownership admission.
+mod tenancy_contract;
+pub mod tenancy_credentials;

--- a/crates/celln-cli/src/main.rs
+++ b/crates/celln-cli/src/main.rs
@@ -1,10 +1,5 @@
 //! `celln` command-line interface.
 
-#[cfg(test)]
-mod tenancy_contract;
-#[cfg(test)]
-mod tenancy_credentials;
-
 mod agent;
 mod capabilities;
 mod cells;

--- a/crates/celln-cli/src/tenancy_admission.rs
+++ b/crates/celln-cli/src/tenancy_admission.rs
@@ -1,0 +1,540 @@
+//! Durable, credential-free admission ownership. This is not artifact admission:
+//! callers still must independently check publisher/closure/ABI/host constraints
+//! before dispatch, and must never execute a Recovery disposition.
+use crate::{
+    tenancy_contract::{canonical, digest},
+    tenancy_credentials::{Context, Refusal, Verifier},
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{Read, Write},
+    os::{
+        fd::AsRawFd,
+        unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt},
+    },
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    Credential(Refusal),
+    RequestConflict,
+    Unavailable,
+    Capacity,
+    BudgetExhausted,
+    Busy,
+    Fenced,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Record {
+    version: u8,
+    identity: Identity,
+    scope: String,
+    run_scope: String,
+    active_turn: Option<String>,
+    accepted_turns: u64,
+    decision_digest: String,
+    authority_digest: String,
+    fenced: bool,
+    run_binding: String,
+    request_digest: String,
+    owner: String,
+    outcome: Option<Outcome>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Identity {
+    pub cluster_id: String,
+    pub namespace: String,
+    pub namespace_uid: String,
+    pub run_uid: String,
+    pub parent_incarnation: Option<String>,
+    pub turn_id: Option<String>,
+}
+
+impl Identity {
+    fn from_receiver(receiver: &Context) -> Self {
+        Self {
+            cluster_id: receiver.cluster_id.clone(),
+            namespace: receiver.namespace.clone(),
+            namespace_uid: receiver.namespace_uid.clone(),
+            run_uid: receiver.run_uid.clone(),
+            parent_incarnation: receiver.parent["incarnation"].as_str().map(str::to_owned),
+            turn_id: receiver.parent["turnId"].as_str().map(str::to_owned),
+        }
+    }
+}
+
+impl Record {
+    pub fn identity(&self) -> &Identity {
+        &self.identity
+    }
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+    pub fn fenced(&self) -> bool {
+        self.fenced
+    }
+    pub fn outcome(&self) -> Option<&Outcome> {
+        self.outcome.as_ref()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub enum Outcome {
+    Receipt { digest: String },
+    Refused,
+}
+
+/// Non-cloneable fresh ownership handle. Only publication after file+directory
+/// fsync constructs one. A durable row, token JTI or Recovery is not this handle.
+pub struct Fresh {
+    record: Record,
+}
+pub enum Claim {
+    Fresh(Fresh),
+    Recovery(Record),
+}
+
+pub struct Journal {
+    directory: File,
+    owner: String,
+    capacity: usize,
+}
+
+fn authority_digest(raw: &[u8]) -> Result<String, Error> {
+    let mut value: serde_json::Value =
+        serde_json::from_slice(raw).map_err(|_| Error::Unavailable)?;
+    let object = value.as_object_mut().ok_or(Error::Unavailable)?;
+    object.remove("operation");
+    object.remove("windows");
+    Ok(digest(
+        &canonical(&serde_json::to_vec(&value).map_err(|_| Error::Unavailable)?)
+            .map_err(|_| Error::Unavailable)?,
+    ))
+}
+
+fn root_scope(receiver: &Context) -> Result<String, Error> {
+    Ok(digest(
+        &serde_json::to_vec(&(
+            "celln.admission-scope/v1",
+            &receiver.cluster_id,
+            &receiver.namespace_uid,
+            &receiver.run_uid,
+        ))
+        .map_err(|_| Error::Unavailable)?,
+    ))
+}
+
+fn blake(value: &str) -> bool {
+    value.strip_prefix("blake3:").is_some_and(|s| {
+        s.len() == 64
+            && s.bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    })
+}
+
+fn sha(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|s| {
+        s.len() == 64
+            && s.bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    })
+}
+
+fn private_regular(file: &File) -> Result<(), Error> {
+    let m = file.metadata().map_err(|_| Error::Unavailable)?;
+    if !m.is_file() || m.uid() != unsafe { libc::geteuid() } || m.mode() & 0o077 != 0 {
+        return Err(Error::Unavailable);
+    }
+    Ok(())
+}
+
+struct Lock {
+    file: File,
+    pid: u32,
+}
+impl Drop for Lock {
+    fn drop(&mut self) {
+        if std::process::id() == self.pid {
+            loop {
+                if unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) } == 0
+                    || std::io::Error::last_os_error().kind() != std::io::ErrorKind::Interrupted
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+impl Journal {
+    /// Each owner instance gets a fresh, non-restorable identity. Reopening this
+    /// directory does not resurrect a former owner's native/model contexts.
+    pub fn open(root: &Path, capacity: usize) -> Result<Self, Error> {
+        if capacity == 0 || capacity > 1_000_000 {
+            return Err(Error::Capacity);
+        }
+        match fs::DirBuilder::new().mode(0o700).create(root) {
+            Ok(()) => {
+                File::open(root.parent().ok_or(Error::Unavailable)?)
+                    .and_then(|f| f.sync_all())
+                    .map_err(|_| Error::Unavailable)?;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(_) => return Err(Error::Unavailable),
+        }
+        let directory = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW)
+            .open(root)
+            .map_err(|_| Error::Unavailable)?;
+        let metadata = directory.metadata().map_err(|_| Error::Unavailable)?;
+        if metadata.uid() != unsafe { libc::geteuid() } || metadata.mode() & 0o077 != 0 {
+            return Err(Error::Unavailable);
+        }
+        directory.sync_all().map_err(|_| Error::Unavailable)?;
+        let mut epoch = [0; 32];
+        File::open("/dev/urandom")
+            .and_then(|mut f| f.read_exact(&mut epoch))
+            .map_err(|_| Error::Unavailable)?;
+        Ok(Self {
+            directory,
+            owner: digest(&epoch),
+            capacity,
+        })
+    }
+
+    // Pin the opened directory inode, rather than following a caller-replaced
+    // pathname after construction. Names below this fd are generated digests.
+    fn root(&self) -> PathBuf {
+        PathBuf::from(format!("/proc/self/fd/{}", self.directory.as_raw_fd()))
+    }
+    fn path(&self, scope: &str) -> PathBuf {
+        self.root().join(format!("{}.json", &scope[7..]))
+    }
+    fn lock(&self) -> Result<Lock, Error> {
+        let directory = self.directory.metadata().map_err(|_| Error::Unavailable)?;
+        if directory.uid() != unsafe { libc::geteuid() } || directory.mode() & 0o077 != 0 {
+            return Err(Error::Unavailable);
+        }
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+            .open(self.root().join("admission.lock"))
+            .map_err(|_| Error::Unavailable)?;
+        private_regular(&file)?;
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+            return Err(Error::Unavailable);
+        }
+        Ok(Lock {
+            file,
+            pid: std::process::id(),
+        })
+    }
+    fn load(&self, scope: &str) -> Result<Option<Record>, Error> {
+        let file = match OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+            .open(self.path(scope))
+        {
+            Ok(file) => file,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(_) => return Err(Error::Unavailable),
+        };
+        private_regular(&file)?;
+        let mut raw = Vec::new();
+        file.take(8193)
+            .read_to_end(&mut raw)
+            .map_err(|_| Error::Unavailable)?;
+        if raw.len() > 8192 {
+            return Err(Error::Unavailable);
+        }
+        let record: Record = serde_json::from_slice(&raw).map_err(|_| Error::Unavailable)?;
+        if record.version != 1
+            || record.scope != scope
+            || [
+                &record.scope,
+                &record.run_scope,
+                &record.decision_digest,
+                &record.authority_digest,
+                &record.request_digest,
+                &record.run_binding,
+                &record.owner,
+            ]
+            .iter()
+            .any(|v| !sha(v))
+            || record.active_turn.as_ref().is_some_and(|v| !sha(v))
+            || matches!(&record.outcome, Some(Outcome::Receipt { digest }) if !blake(digest))
+            || (record.scope != record.run_scope
+                && (record.active_turn.is_some() || record.accepted_turns != 0))
+            || (record.scope == record.run_scope && !(1..=1024).contains(&record.accepted_turns))
+        {
+            return Err(Error::Unavailable);
+        }
+        Ok(Some(record))
+    }
+
+    /// Receiver context MUST come from authenticated routing/prepared owner
+    /// state, never solely from the submitted decision. Invalid authority cannot
+    /// probe duplicate state: all credential/payload checks precede lookup.
+    pub fn claim(
+        &self,
+        verifier: &Verifier,
+        token: &str,
+        decision: &[u8],
+        request: &[u8],
+        receiver: &Context,
+    ) -> Result<Claim, Error> {
+        if receiver.expected_audience != "celln-execution"
+            || !matches!(
+                receiver.expected_operation.as_str(),
+                "execution.start" | "execution.turn"
+            )
+        {
+            return Err(Error::Credential("AUTH_OPERATION_MISMATCH"));
+        }
+        let replay = verifier
+            .verify(token, decision, receiver)
+            .map_err(Error::Credential)?
+            .is_some();
+        let request_digest = digest(
+            &canonical(request).map_err(|_| Error::Credential("AUTH_REQUEST_BINDING_MISMATCH"))?,
+        );
+        if request_digest != receiver.request_digest {
+            return Err(Error::Credential("AUTH_REQUEST_BINDING_MISMATCH"));
+        }
+        let decision_digest =
+            digest(&canonical(decision).map_err(|_| Error::Credential("AUTH_CRED_MALFORMED"))?);
+        // JTI and decision digest are deliberately NOT the lookup key: changing
+        // a token/window/ceiling cannot purchase a fresh operation identity.
+        let root_scope = root_scope(receiver)?;
+        let d: serde_json::Value = serde_json::from_slice(decision)
+            .map_err(|_| Error::Credential("AUTH_CRED_MALFORMED"))?;
+        let run_binding = digest(&serde_json::to_vec(&serde_json::json!({
+            "run":d["run"], "runtime":d["runtime"], "agent":d["agent"],
+            "route":d["route"], "incarnation":d["parent"]["incarnation"],
+            "budgetId":d["budget"]["budgetId"], "runCap":d["budget"]["runCap"],
+            "maxTurns":d["budget"]["maxTurns"], "parentDeadlineUnix":d["budget"]["parentDeadlineUnix"]
+        })).map_err(|_| Error::Unavailable)?);
+        let scope = if receiver.expected_operation == "execution.turn" {
+            let turn = receiver.parent["turnId"]
+                .as_str()
+                .filter(|s| !s.is_empty())
+                .ok_or(Error::Credential("AUTH_PARENT_TURN_MISMATCH"))?;
+            digest(
+                &serde_json::to_vec(&("celln.admission-turn/v1", &root_scope, turn))
+                    .map_err(|_| Error::Unavailable)?,
+            )
+        } else {
+            if !receiver.parent["turnId"].is_null() {
+                return Err(Error::Credential("AUTH_PARENT_TURN_MISMATCH"));
+            }
+            root_scope.clone()
+        };
+        let candidate = Record {
+            version: 1,
+            identity: Identity::from_receiver(receiver),
+            scope: scope.clone(),
+            run_scope: root_scope.clone(),
+            active_turn: None,
+            accepted_turns: u64::from(scope == root_scope),
+            decision_digest,
+            authority_digest: authority_digest(decision)?,
+            fenced: false,
+            run_binding,
+            request_digest,
+            owner: self.owner.clone(),
+            outcome: None,
+        };
+        let _lock = self.lock()?;
+        let mut parent = if receiver.expected_operation == "execution.turn" {
+            let original = self
+                .load(&root_scope)?
+                .ok_or(Error::Credential("AUTH_CONTEXT_LOST"))?;
+            let mut parent_identity = candidate.identity.clone();
+            parent_identity.turn_id = None;
+            if original.run_binding != candidate.run_binding || original.identity != parent_identity
+            {
+                return Err(Error::RequestConflict);
+            }
+            if original.fenced {
+                return Err(Error::Fenced);
+            }
+            if original.owner != self.owner || original.outcome == Some(Outcome::Refused) {
+                return Err(Error::Credential("AUTH_CONTEXT_LOST"));
+            }
+            Some(original)
+        } else {
+            None
+        };
+        if let Some(existing) = self.load(&scope)? {
+            if existing.identity != candidate.identity
+                || existing.decision_digest != candidate.decision_digest
+                || existing.request_digest != candidate.request_digest
+            {
+                return Err(Error::RequestConflict);
+            }
+            return Ok(Claim::Recovery(existing));
+        }
+        if replay {
+            return Err(Error::Credential("AUTH_CONTEXT_LOST"));
+        }
+        if let Some(parent) = parent.as_mut() {
+            if parent.outcome.is_none() {
+                return Err(Error::Busy);
+            }
+            if let Some(active) = &parent.active_turn {
+                let prior = self
+                    .load(active)?
+                    .ok_or(Error::Credential("AUTH_CONTEXT_LOST"))?;
+                if prior.run_scope != root_scope || prior.owner != self.owner {
+                    return Err(Error::RequestConflict);
+                }
+                if prior.outcome.is_none() {
+                    return Err(Error::Busy);
+                }
+            }
+            parent.accepted_turns = parent
+                .accepted_turns
+                .checked_add(1)
+                .filter(|n| *n <= d["budget"]["maxTurns"].as_u64().unwrap_or(0))
+                .ok_or(Error::BudgetExhausted)?;
+            parent.active_turn = Some(scope.clone());
+        }
+        let mut count = 0;
+        for entry in fs::read_dir(self.root()).map_err(|_| Error::Unavailable)? {
+            let entry = entry.map_err(|_| Error::Unavailable)?;
+            if entry.path().extension().is_some_and(|s| s == "json") {
+                count += 1;
+                if count >= self.capacity {
+                    return Err(Error::Capacity);
+                }
+            }
+        }
+        // Fence the parent before publishing a child. A crash between these
+        // writes is ContextLost/uncertain, never permission to repeat dispatch.
+        if let Some(parent) = parent {
+            self.publish(&parent, false)?;
+        }
+        self.publish(&candidate, true)?;
+        Ok(Claim::Fresh(Fresh { record: candidate }))
+    }
+
+    /// Historical reads and cleanup require separately scoped, fresh credentials.
+    /// They retain the original authority tuple and do not re-admit execution or
+    /// require a live provider Secret/policy. A fence is not teardown confirmation.
+    pub fn access(
+        &self,
+        verifier: &Verifier,
+        token: &str,
+        decision: &[u8],
+        receiver: &Context,
+    ) -> Result<Record, Error> {
+        if receiver.expected_audience != "celln-execution"
+            || !matches!(
+                receiver.expected_operation.as_str(),
+                "execution.read" | "execution.cleanup"
+            )
+        {
+            return Err(Error::Credential("AUTH_OPERATION_MISMATCH"));
+        }
+        verifier
+            .verify(token, decision, receiver)
+            .map_err(Error::Credential)?;
+        let root = root_scope(receiver)?;
+        let scope = match receiver.parent["turnId"].as_str() {
+            Some(turn) => digest(
+                &serde_json::to_vec(&("celln.admission-turn/v1", &root, turn))
+                    .map_err(|_| Error::Unavailable)?,
+            ),
+            None => root,
+        };
+        let authority = authority_digest(decision)?;
+        let _lock = self.lock()?;
+        let mut record = self
+            .load(&scope)?
+            .ok_or(Error::Credential("AUTH_CONTEXT_LOST"))?;
+        if record.authority_digest != authority
+            || record.identity != Identity::from_receiver(receiver)
+        {
+            return Err(Error::RequestConflict);
+        }
+        if receiver.expected_operation == "execution.cleanup" && !record.fenced {
+            record.fenced = true;
+            self.publish(&record, false)?;
+        }
+        Ok(record)
+    }
+
+    fn publish(&self, record: &Record, fresh: bool) -> Result<(), Error> {
+        let mut staged =
+            tempfile::NamedTempFile::new_in(self.root()).map_err(|_| Error::Unavailable)?;
+        serde_json::to_writer(&mut staged, record).map_err(|_| Error::Unavailable)?;
+        staged
+            .flush()
+            .and_then(|_| staged.as_file().sync_all())
+            .map_err(|_| Error::Unavailable)?;
+        if fresh {
+            staged
+                .persist_noclobber(self.path(&record.scope))
+                .map_err(|_| Error::Unavailable)?;
+        } else {
+            staged
+                .persist(self.path(&record.scope))
+                .map_err(|_| Error::Unavailable)?;
+        }
+        self.directory.sync_all().map_err(|_| Error::Unavailable)
+    }
+
+    /// Record only a receipt hash or refusal, never output, prompts, credentials
+    /// or copied request payloads. Repeated identical completion is idempotent.
+    pub fn finish(&self, fresh: &Fresh, outcome: Outcome) -> Result<(), Error> {
+        if fresh.record.owner != self.owner {
+            return Err(Error::RequestConflict);
+        }
+        if let Outcome::Receipt { digest } = &outcome {
+            if !blake(digest) {
+                return Err(Error::RequestConflict);
+            }
+        }
+        let _lock = self.lock()?;
+        let mut current = self.load(&fresh.record.scope)?.ok_or(Error::Unavailable)?;
+        let old_outcome = current.outcome.take();
+        let fenced = current.fenced;
+        current.fenced = false;
+        let active = current.active_turn.take();
+        let accepted_turns = current.accepted_turns;
+        if accepted_turns < fresh.record.accepted_turns {
+            return Err(Error::RequestConflict);
+        }
+        current.accepted_turns = fresh.record.accepted_turns;
+        if current != fresh.record {
+            return Err(Error::RequestConflict);
+        }
+        if let Some(old) = old_outcome {
+            return if old == outcome {
+                Ok(())
+            } else {
+                Err(Error::RequestConflict)
+            };
+        }
+        current.active_turn = active;
+        current.fenced = fenced;
+        current.accepted_turns = accepted_turns;
+        current.outcome = Some(outcome);
+        self.publish(&current, false)
+    }
+}
+
+#[cfg(test)]
+#[path = "tenancy_admission_tests.rs"]
+mod tests;

--- a/crates/celln-cli/src/tenancy_admission_tests.rs
+++ b/crates/celln-cli/src/tenancy_admission_tests.rs
@@ -1,0 +1,349 @@
+use super::*;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use ed25519_dalek::{Signer, SigningKey};
+use serde_json::Value;
+use std::{
+    os::unix::fs::{symlink, PermissionsExt},
+    sync::Arc,
+    time::Duration,
+};
+
+struct Fixture {
+    token: String,
+    decision: Vec<u8>,
+    request: Vec<u8>,
+    context: Context,
+}
+impl Fixture {
+    fn named(name: &str) -> Self {
+        let mut raw = Vec::new();
+        flate2::read::GzDecoder::new(
+            include_bytes!("../../../tests/fixtures/celln-authorisation/v1/cases.json.gz")
+                .as_slice(),
+        )
+        .read_to_end(&mut raw)
+        .unwrap();
+        let cases: Value = serde_json::from_slice(&raw).unwrap();
+        let v = cases["vectors"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|v| v["name"] == name)
+            .unwrap();
+        let d = &cases["decisions"][v["decisionRef"].as_str().unwrap()];
+        Self {
+            token: v["credential"].as_str().unwrap().into(),
+            decision: d["canonical"].as_str().unwrap().as_bytes().to_vec(),
+            request: d["requestCanonical"].as_str().unwrap().as_bytes().to_vec(),
+            context: serde_json::from_value(v["verify"].clone()).unwrap(),
+        }
+    }
+    fn claim(&self, journal: &Journal) -> Result<Claim, Error> {
+        let verifier = Verifier::from_jwks(
+            "sympozium-control-plane".into(),
+            include_bytes!("../../../tests/fixtures/celln-authorisation/v1/signing/test-jwks.json"),
+        )
+        .unwrap();
+        journal.claim(
+            &verifier,
+            &self.token,
+            &self.decision,
+            &self.request,
+            &self.context,
+        )
+    }
+    fn turn(id: &str) -> Self {
+        let mut f = Self::named("enduring-turn");
+        let mut d: Value = serde_json::from_slice(&f.decision).unwrap();
+        let mut request: Value = serde_json::from_slice(&f.request).unwrap();
+        request["turnId"] = id.into();
+        f.request = canonical(&serde_json::to_vec(&request).unwrap()).unwrap();
+        d["parent"]["turnId"] = id.into();
+        d["requestDigest"] = digest(&f.request).into();
+        f.context.parent = d["parent"].clone();
+        f.context.request_digest = digest(&f.request);
+        f.resign(d);
+        f
+    }
+    fn access(&mut self, operation: &str) {
+        self.context.expected_operation = operation.into();
+        let mut d: Value = serde_json::from_slice(&self.decision).unwrap();
+        d["operation"] = operation.into();
+        self.resign(d);
+    }
+    fn lookup(&self, journal: &Journal) -> Result<Record, Error> {
+        let verifier = Verifier::from_jwks(
+            "sympozium-control-plane".into(),
+            include_bytes!("../../../tests/fixtures/celln-authorisation/v1/signing/test-jwks.json"),
+        )
+        .unwrap();
+        journal.access(&verifier, &self.token, &self.decision, &self.context)
+    }
+    fn resign(&mut self, d: Value) {
+        self.decision = canonical(&serde_json::to_vec(&d).unwrap()).unwrap();
+        let parts: Vec<_> = self.token.split('.').collect();
+        let mut claims: Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[1]).unwrap()).unwrap();
+        claims["operation"] = d["operation"].clone();
+        if matches!(
+            self.context.expected_operation.as_str(),
+            "execution.read" | "execution.cleanup"
+        ) {
+            claims["iat"] = self.context.now.into();
+            claims["nbf"] = self.context.now.into();
+            claims["exp"] = (self.context.now + 120).into();
+        }
+        claims["decisionDigest"] = digest(&self.decision).into();
+        claims["jti"] = format!("jti-{}", &digest(&self.decision)[7..39]).into();
+        if !d["parent"]["turnId"].is_null() {
+            claims["subject"]["turnId"] = d["parent"]["turnId"].clone();
+        }
+        let input = format!(
+            "{}.{}",
+            parts[0],
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap())
+        );
+        let signature = SigningKey::from_bytes(&[0x11; 32]).sign(input.as_bytes());
+        self.token = format!("{input}.{}", URL_SAFE_NO_PAD.encode(signature.to_bytes()));
+    }
+}
+fn private_root() -> tempfile::TempDir {
+    let root = tempfile::tempdir().unwrap();
+    fs::set_permissions(root.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    root
+}
+fn fresh(claim: Claim) -> Fresh {
+    match claim {
+        Claim::Fresh(f) => f,
+        _ => panic!("expected exactly one fresh claim"),
+    }
+}
+fn receipt() -> Outcome {
+    Outcome::Receipt {
+        digest: celln_manifest::Hash::of(b"fixture-receipt").0,
+    }
+}
+
+#[test]
+fn duplicate_and_restart_recover_without_new_execution_authority() {
+    let root = private_root();
+    let j = Journal::open(root.path(), 4).unwrap();
+    let f = Fixture::named("direct-one-shot");
+    let ticket = fresh(f.claim(&j).unwrap());
+    assert!(matches!(f.claim(&j), Ok(Claim::Recovery(_))));
+    j.finish(&ticket, receipt()).unwrap();
+    j.finish(&ticket, receipt()).unwrap();
+    assert_eq!(
+        j.finish(&ticket, Outcome::Refused),
+        Err(Error::RequestConflict)
+    );
+    let restarted = Journal::open(root.path(), 4).unwrap();
+    match f.claim(&restarted).unwrap() {
+        Claim::Recovery(r) => {
+            assert_eq!(r.owner(), j.owner);
+            assert_ne!(r.owner(), restarted.owner);
+            assert_eq!(r.outcome(), Some(&receipt()));
+        }
+        _ => panic!("restart created duplicate authority"),
+    }
+    assert_eq!(
+        restarted.finish(&ticket, receipt()),
+        Err(Error::RequestConflict)
+    );
+    for entry in fs::read_dir(root.path()).unwrap() {
+        let raw = fs::read(entry.unwrap().path()).unwrap();
+        assert!(!raw.windows(f.token.len()).any(|v| v == f.token.as_bytes()));
+        assert!(!String::from_utf8_lossy(&raw).contains("direct-input"));
+    }
+}
+
+#[test]
+fn credentials_and_payload_are_verified_before_duplicate_lookup() {
+    let root = private_root();
+    let j = Journal::open(root.path(), 4).unwrap();
+    let mut f = Fixture::named("direct-one-shot");
+    let ticket = fresh(f.claim(&j).unwrap());
+    fs::write(j.path(&ticket.record.scope), b"corrupt-record").unwrap();
+    f.request = b"{}".to_vec();
+    assert!(matches!(
+        f.claim(&j),
+        Err(Error::Credential("AUTH_REQUEST_BINDING_MISMATCH"))
+    ));
+    f.context.namespace_uid = "other-tenant".into();
+    assert!(matches!(
+        f.claim(&j),
+        Err(Error::Credential("AUTH_NAMESPACE_UID_MISMATCH"))
+    ));
+    let good = Fixture::named("direct-one-shot");
+    assert!(matches!(good.claim(&j), Err(Error::Unavailable)));
+}
+
+#[test]
+fn renewed_authority_cannot_reset_original_operation_ceiling() {
+    let root = private_root();
+    let journal = Journal::open(root.path(), 4).unwrap();
+    let mut f = Fixture::named("harness-one-shot");
+    fresh(f.claim(&journal).unwrap());
+    let mut d: Value = serde_json::from_slice(&f.decision).unwrap();
+    d["budget"]["runCap"]["requests"] =
+        (d["budget"]["runCap"]["requests"].as_u64().unwrap() + 1).into();
+    d["budget"]["turnCap"]["requests"] =
+        (d["budget"]["turnCap"]["requests"].as_u64().unwrap() + 1).into();
+    f.resign(d);
+    assert!(matches!(f.claim(&journal), Err(Error::RequestConflict)));
+}
+
+#[test]
+fn expiry_safe_read_and_cleanup_do_not_reopen_or_widen_authority() {
+    let root = private_root();
+    let journal = Journal::open(root.path(), 10).unwrap();
+    let mut parent = Fixture::named("parent-create");
+    let start = fresh(parent.claim(&journal).unwrap());
+    journal.finish(&start, receipt()).unwrap();
+    let mut turn = Fixture::turn("turn-1");
+    let child = fresh(turn.claim(&journal).unwrap());
+    parent.access("execution.read");
+    assert!(!parent.lookup(&journal).unwrap().fenced());
+    turn.access("execution.cleanup");
+    assert!(turn.lookup(&journal).unwrap().fenced());
+    assert!(!parent.lookup(&journal).unwrap().fenced());
+    journal.finish(&child, receipt()).unwrap();
+    let next = fresh(Fixture::turn("turn-2").claim(&journal).unwrap());
+    journal.finish(&next, receipt()).unwrap();
+    parent.access("execution.cleanup");
+    assert!(parent.lookup(&journal).unwrap().fenced());
+    assert!(matches!(
+        Fixture::turn("turn-3").claim(&journal),
+        Err(Error::Fenced)
+    ));
+    parent.context.now = 1790000400;
+    parent.access("execution.read");
+    assert!(parent.lookup(&journal).unwrap().fenced());
+    parent.access("execution.cleanup");
+    assert!(parent.lookup(&journal).unwrap().fenced());
+    turn.context.namespace_uid = "other-namespace".into();
+    assert!(matches!(
+        turn.lookup(&journal),
+        Err(Error::Credential("AUTH_NAMESPACE_UID_MISMATCH"))
+    ));
+}
+
+#[test]
+fn observed_loss_of_private_directory_permissions_refuses() {
+    let root = private_root();
+    let journal = Journal::open(root.path(), 4).unwrap();
+    fs::set_permissions(root.path(), fs::Permissions::from_mode(0o777)).unwrap();
+    assert!(matches!(
+        Fixture::named("direct-one-shot").claim(&journal),
+        Err(Error::Unavailable)
+    ));
+}
+
+#[test]
+fn replay_without_durable_owner_cannot_create_a_record() {
+    let root = private_root();
+    let j = Journal::open(root.path(), 4).unwrap();
+    let mut f = Fixture::named("direct-one-shot");
+    f.context.seen_admission_jti = true;
+    assert!(matches!(
+        f.claim(&j),
+        Err(Error::Credential("AUTH_CONTEXT_LOST"))
+    ));
+    assert_eq!(fs::read_dir(root.path()).unwrap().count(), 1); // lock only
+}
+
+#[test]
+fn concurrent_delivery_publishes_one_fresh_claim() {
+    let root = private_root();
+    let j = Arc::new(Journal::open(root.path(), 4).unwrap());
+    let threads: Vec<_> = (0..12)
+        .map(|_| {
+            let j = j.clone();
+            std::thread::spawn(move || {
+                let f = Fixture::named("direct-one-shot");
+                for _ in 0..100 {
+                    match f.claim(&j) {
+                        Ok(Claim::Fresh(_)) => return true,
+                        Ok(Claim::Recovery(_)) => return false,
+                        Err(Error::Unavailable) => std::thread::sleep(Duration::from_millis(2)),
+                        _ => panic!("unexpected admission refusal"),
+                    }
+                }
+                panic!("admission remained busy")
+            })
+        })
+        .collect();
+    assert_eq!(
+        threads
+            .into_iter()
+            .map(|h| usize::from(h.join().unwrap()))
+            .sum::<usize>(),
+        1
+    );
+}
+
+#[test]
+fn enduring_turns_keep_original_owner_and_count_initial_task() {
+    let root = private_root();
+    let j = Journal::open(root.path(), 20).unwrap();
+    let first = fresh(Fixture::named("parent-create").claim(&j).unwrap());
+    assert!(matches!(
+        Fixture::turn("turn-1").claim(&j),
+        Err(Error::Busy)
+    ));
+    j.finish(&first, receipt()).unwrap();
+    let turn = fresh(Fixture::turn("turn-1").claim(&j).unwrap());
+    assert!(matches!(
+        Fixture::turn("turn-2").claim(&j),
+        Err(Error::Busy)
+    ));
+    j.finish(&turn, receipt()).unwrap();
+    for id in ["turn-2", "turn-3"] {
+        let turn = fresh(Fixture::turn(id).claim(&j).unwrap());
+        j.finish(&turn, receipt()).unwrap();
+    }
+    assert!(matches!(
+        Fixture::turn("turn-4").claim(&j),
+        Err(Error::BudgetExhausted)
+    ));
+    j.finish(&first, receipt()).unwrap(); // root counter updates do not break completion idempotency
+    let restarted = Journal::open(root.path(), 20).unwrap();
+    assert!(matches!(
+        Fixture::turn("turn-4").claim(&restarted),
+        Err(Error::Credential("AUTH_CONTEXT_LOST"))
+    ));
+}
+
+#[test]
+fn incomplete_child_publication_is_uncertain_not_a_retry() {
+    let root = private_root();
+    let j = Journal::open(root.path(), 20).unwrap();
+    let first = fresh(Fixture::named("parent-create").claim(&j).unwrap());
+    j.finish(&first, receipt()).unwrap();
+    let turn = Fixture::turn("turn-1");
+    let child = fresh(turn.claim(&j).unwrap());
+    // Equivalent persisted state to a crash after the parent fence but before
+    // child publication. No native launch or real crash is claimed by this test.
+    fs::remove_file(j.path(&child.record.scope)).unwrap();
+    assert!(matches!(
+        turn.claim(&j),
+        Err(Error::Credential("AUTH_CONTEXT_LOST"))
+    ));
+}
+
+#[test]
+fn private_inode_pinning_and_nonregular_records_fail_closed() {
+    let work = tempfile::tempdir().unwrap();
+    let root = work.path().join("journal");
+    let j = Journal::open(&root, 4).unwrap();
+    fs::rename(&root, work.path().join("original")).unwrap();
+    fs::create_dir(&root).unwrap();
+    let f = Fixture::named("direct-one-shot");
+    let ticket = fresh(f.claim(&j).unwrap());
+    assert_eq!(fs::read_dir(&root).unwrap().count(), 0);
+    fs::remove_file(j.path(&ticket.record.scope)).unwrap();
+    symlink("/dev/zero", j.path(&ticket.record.scope)).unwrap();
+    assert!(matches!(f.claim(&j), Err(Error::Unavailable)));
+    fs::set_permissions(&root, fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(matches!(Journal::open(&root, 4), Err(Error::Unavailable)));
+}

--- a/crates/celln-cli/src/tenancy_contract.rs
+++ b/crates/celln-cli/src/tenancy_contract.rs
@@ -1,5 +1,5 @@
-//! Independent Rust consumer for the Sympozium #496 integer-only JCS profile.
-//! Test-only prerequisite for #500; does not admit execution or verify JWS.
+//! Bounded integer-only JCS encoding shared by the runtime verifier and its
+//! independent Sympozium #496 conformance tests. Encoding grants no authority.
 
 use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde_json::Value;

--- a/crates/celln-cli/src/tenancy_credentials.rs
+++ b/crates/celln-cli/src/tenancy_credentials.rs
@@ -1,14 +1,20 @@
-//! Test-only independent consumer of scoped JWS conformance vectors.
+//! Strict scoped JWS verifier with locally configured public keys.
 //! Not wired to HTTP admission; durable ownership remains a separate boundary.
 use super::tenancy_contract::{canonical, digest};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use ed25519_dalek::{Signature, VerifyingKey};
+use jsonschema::{Draft, JSONSchema};
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
+use std::sync::RwLock;
 
-type Refusal = &'static str;
+pub type Refusal = &'static str;
 const MALFORMED: Refusal = "AUTH_CRED_MALFORMED";
+
+#[cfg(test)]
+#[path = "tenancy_verifier_tests.rs"]
+mod production_tests;
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -41,28 +47,85 @@ struct Claims {
 }
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct Context {
-    now: i64,
-    expected_audience: String,
-    expected_operation: String,
-    cluster_id: String,
-    namespace: String,
-    namespace_uid: String,
-    run_uid: String,
-    run_spec_sha256: String,
-    parent: Value,
-    request_digest: String,
-    route: Value,
-    budget_id: String,
-    seen_admission_jti: bool,
+/// Receiver-owned expected identity. Never populate this solely from the
+/// unverified token/decision submitted by a caller. Replay recovery must be
+/// corroborated by the durable operation journal, not the token's JTI.
+pub struct Context {
+    pub now: i64,
+    pub expected_audience: String,
+    pub expected_operation: String,
+    pub cluster_id: String,
+    pub namespace: String,
+    pub namespace_uid: String,
+    pub run_uid: String,
+    pub run_spec_sha256: String,
+    pub parent: Value,
+    pub request_digest: String,
+    pub route: Value,
+    pub budget_id: String,
+    pub seen_admission_jti: bool,
 }
 
-struct Verifier {
+pub struct Verifier {
     issuer: String,
-    keys: BTreeMap<String, VerifyingKey>,
+    keys: RwLock<BTreeMap<String, VerifyingKey>>,
+    decision_schema: JSONSchema,
+    credential_schema: JSONSchema,
 }
 impl Verifier {
-    fn verify(
+    pub fn from_jwks(issuer: String, raw: &[u8]) -> Result<Self, Refusal> {
+        Self::new(issuer, parse_public_keys(raw)?)
+    }
+
+    pub fn reload_jwks(&self, raw: &[u8]) -> Result<(), Refusal> {
+        self.reload_keys(parse_public_keys(raw)?)
+    }
+
+    pub fn new(issuer: String, keys: BTreeMap<String, VerifyingKey>) -> Result<Self, Refusal> {
+        if issuer.is_empty() {
+            return Err("AUTH_CRED_KEY_UNAVAILABLE");
+        }
+        fn compile(raw: &str) -> Result<JSONSchema, Refusal> {
+            let value: Value = serde_json::from_str(raw).map_err(|_| MALFORMED)?;
+            JSONSchema::options()
+                .with_draft(Draft::Draft202012)
+                .compile(&value)
+                .map_err(|_| MALFORMED)
+        }
+        let result = Self {
+            issuer,
+            keys: RwLock::new(BTreeMap::new()),
+            decision_schema: compile(include_str!(
+                "../../../tests/fixtures/celln-authorisation/v1/schema/decision.schema.json"
+            ))?,
+            credential_schema: compile(include_str!(
+                "../../../tests/fixtures/celln-authorisation/v1/schema/credential.schema.json"
+            ))?,
+        };
+        result.reload_keys(keys)?;
+        Ok(result)
+    }
+
+    /// Normal rotation retains old keys through outstanding lifetimes plus skew.
+    /// Emergency removal affects future verification, not admitted cells.
+    pub fn reload_keys(&self, keys: BTreeMap<String, VerifyingKey>) -> Result<(), Refusal> {
+        if keys.is_empty()
+            || keys.len() > 64
+            || keys.keys().any(|id| {
+                id.is_empty()
+                    || id.len() > 64
+                    || !id
+                        .bytes()
+                        .all(|c| c.is_ascii_alphanumeric() || c == b'-' || c == b'_')
+            })
+        {
+            return Err("AUTH_CRED_KEY_UNAVAILABLE");
+        }
+        *self.keys.write().map_err(|_| "AUTH_CRED_KEY_UNAVAILABLE")? = keys;
+        Ok(())
+    }
+
+    pub fn verify(
         &self,
         token: &str,
         decision: &[u8],
@@ -91,7 +154,12 @@ impl Verifier {
         if h.typ != "celln-authorisation+jws" {
             return Err("AUTH_CRED_TYP_UNSUPPORTED");
         }
-        let key = self.keys.get(&h.kid).ok_or("AUTH_CRED_KID_UNKNOWN")?;
+        let key = *self
+            .keys
+            .read()
+            .map_err(|_| "AUTH_CRED_KEY_UNAVAILABLE")?
+            .get(&h.kid)
+            .ok_or("AUTH_CRED_KID_UNKNOWN")?;
         let signature = Signature::from_slice(&signature).map_err(|_| "AUTH_CRED_SIG_INVALID")?;
         let signed = format!("{}.{}", parts[0], parts[1]);
         key.verify_strict(signed.as_bytes(), &signature)
@@ -99,6 +167,13 @@ impl Verifier {
         let canonical_decision = canonical(decision).map_err(|_| MALFORMED)?;
         let d: Value = serde_json::from_slice(&canonical_decision).map_err(|_| MALFORMED)?;
         validate_decision(&d)?;
+        if !self.decision_schema.is_valid(&d) {
+            return Err(MALFORMED);
+        }
+        let claim_value: Value = serde_json::from_slice(&payload).map_err(|_| MALFORMED)?;
+        if !self.credential_schema.is_valid(&claim_value) {
+            return Err(MALFORMED);
+        }
         let c: Claims = serde_json::from_slice(&payload).map_err(|_| "AUTH_CRED_UNKNOWN_FIELD")?;
         if c.api_version != "celln.sympozium.ai/authorisation-credential-v1" {
             return Err("AUTH_VERSION_UNSUPPORTED");
@@ -205,6 +280,46 @@ impl Verifier {
         Ok(None)
     }
 }
+fn parse_public_keys(raw: &[u8]) -> Result<BTreeMap<String, VerifyingKey>, Refusal> {
+    #[derive(Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct KeySet {
+        keys: Vec<PublicKey>,
+    }
+    #[derive(Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct PublicKey {
+        kty: String,
+        crv: String,
+        kid: String,
+        alg: String,
+        #[serde(rename = "use")]
+        usage: String,
+        x: String,
+    }
+    if raw.len() > 65536 {
+        return Err("AUTH_CRED_KEY_UNAVAILABLE");
+    }
+    canonical(raw).map_err(|_| "AUTH_CRED_KEY_UNAVAILABLE")?;
+    let set: KeySet = serde_json::from_slice(raw).map_err(|_| "AUTH_CRED_KEY_UNAVAILABLE")?;
+    let mut keys = BTreeMap::new();
+    for k in set.keys {
+        if k.kty != "OKP" || k.crv != "Ed25519" || k.alg != "EdDSA" || k.usage != "sig" {
+            return Err("AUTH_CRED_KEY_UNAVAILABLE");
+        }
+        let bytes: [u8; 32] = URL_SAFE_NO_PAD
+            .decode(k.x)
+            .map_err(|_| "AUTH_CRED_KEY_UNAVAILABLE")?
+            .try_into()
+            .map_err(|_| "AUTH_CRED_KEY_UNAVAILABLE")?;
+        let key = VerifyingKey::from_bytes(&bytes).map_err(|_| "AUTH_CRED_KEY_UNAVAILABLE")?;
+        if keys.insert(k.kid, key).is_some() {
+            return Err("AUTH_CRED_KEY_UNAVAILABLE");
+        }
+    }
+    Ok(keys)
+}
+
 fn text(v: &Value) -> Result<&str, Refusal> {
     v.as_str().ok_or(MALFORMED)
 }
@@ -290,6 +405,7 @@ fn validate_decision(d: &Value) -> Result<(), Refusal> {
     Ok(())
 }
 
+#[cfg(test)]
 fn fixtures() -> Value {
     use std::io::Read;
     let data = include_bytes!("../../../tests/fixtures/celln-authorisation/v1/cases.json.gz");
@@ -300,6 +416,7 @@ fn fixtures() -> Value {
         .unwrap();
     serde_json::from_slice(&decoded).unwrap()
 }
+#[cfg(test)]
 fn verifier() -> Verifier {
     let jwks: Value = serde_json::from_str(include_str!(
         "../../../tests/fixtures/celln-authorisation/v1/signing/test-jwks.json"
@@ -317,10 +434,7 @@ fn verifier() -> Verifier {
             )
         })
         .collect();
-    Verifier {
-        issuer: "sympozium-control-plane".into(),
-        keys,
-    }
+    Verifier::new("sympozium-control-plane".into(), keys).unwrap()
 }
 #[test]
 fn every_shared_credential_vector_has_exact_disposition() {
@@ -388,8 +502,8 @@ fn untrusted_headers_and_removed_keys_cannot_authorize() {
         );
         assert!(verifier().verify(&altered, raw.as_bytes(), &ctx).is_err());
     }
-    let mut revoked = verifier();
-    revoked.keys.remove("test-key-1");
+    let revoked = verifier();
+    revoked.keys.write().unwrap().remove("test-key-1");
     assert_eq!(
         revoked.verify(token, raw.as_bytes(), &ctx),
         Err("AUTH_CRED_KID_UNKNOWN")

--- a/crates/celln-cli/src/tenancy_verifier_tests.rs
+++ b/crates/celln-cli/src/tenancy_verifier_tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+use ed25519_dalek::{Signer, SigningKey};
+
+const PUBLIC: &[u8] =
+    include_bytes!("../../../tests/fixtures/celln-authorisation/v1/signing/test-jwks.json");
+
+#[test]
+fn malformed_reload_is_atomic_and_private_keys_refuse() {
+    let v = Verifier::from_jwks("sympozium-control-plane".into(), PUBLIC).unwrap();
+    for raw in [
+        b"{\"keys\":[]}".as_slice(),
+        b"{}",
+        b"{\"keys\":[],\"keys\":[]}",
+    ] {
+        assert!(v.reload_jwks(raw).is_err());
+    }
+    let mut keys: Value = serde_json::from_slice(PUBLIC).unwrap();
+    keys["keys"][0]["d"] = Value::String("private-canary".into());
+    assert!(v.reload_jwks(&serde_json::to_vec(&keys).unwrap()).is_err());
+    let c = fixtures();
+    let vector = &c["vectors"][0];
+    let d = c["decisions"][vector["decisionRef"].as_str().unwrap()]["canonical"]
+        .as_str()
+        .unwrap();
+    let ctx = serde_json::from_value(vector["verify"].clone()).unwrap();
+    assert_eq!(
+        v.verify(vector["credential"].as_str().unwrap(), d.as_bytes(), &ctx),
+        Ok(None)
+    );
+    assert!(Verifier::from_jwks(String::new(), PUBLIC).is_err());
+}
+
+#[test]
+fn schema_rejects_signed_unknown_and_invalid_authority() {
+    let c = fixtures();
+    let vector = &c["vectors"][0];
+    let original: Value = serde_json::from_str(
+        c["decisions"][vector["decisionRef"].as_str().unwrap()]["canonical"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
+    let token = vector["credential"].as_str().unwrap();
+    let parts: Vec<_> = token.split('.').collect();
+    let original_claims: Value =
+        serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[1]).unwrap()).unwrap();
+    let ctx = serde_json::from_value(vector["verify"].clone()).unwrap();
+    for field in ["unknown", "null-tools", "invalid-kind", "invalid-uid"] {
+        let mut d = original.clone();
+        match field {
+            "unknown" => d["ambientAuthority"] = Value::Bool(true),
+            "null-tools" => d["tools"] = Value::Null,
+            "invalid-kind" => d["kind"] = Value::String("Other".into()),
+            _ => d["run"]["uid"] = Value::String(String::new()),
+        }
+        let raw = canonical(&serde_json::to_vec(&d).unwrap()).unwrap();
+        let mut claims = original_claims.clone();
+        claims["decisionDigest"] = Value::String(digest(&raw));
+        let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap());
+        let signing_input = format!("{}.{payload}", parts[0]);
+        // Publicly known fixture seed, confined to test code.
+        let signature = SigningKey::from_bytes(&[0x11; 32]).sign(signing_input.as_bytes());
+        let signed = format!(
+            "{signing_input}.{}",
+            URL_SAFE_NO_PAD.encode(signature.to_bytes())
+        );
+        assert_eq!(
+            verifier().verify(&signed, &raw, &ctx),
+            Err(MALFORMED),
+            "{field}"
+        );
+    }
+}
+
+#[test]
+fn valid_overlap_rotation_can_run_concurrently_with_verification() {
+    let v =
+        std::sync::Arc::new(Verifier::from_jwks("sympozium-control-plane".into(), PUBLIC).unwrap());
+    let c = fixtures();
+    let vector = c["vectors"][0].clone();
+    let d = c["decisions"][vector["decisionRef"].as_str().unwrap()]["canonical"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    std::thread::scope(|scope| {
+        for _ in 0..4 {
+            let v = v.clone();
+            let vector = vector.clone();
+            let d = d.clone();
+            scope.spawn(move || {
+                for _ in 0..20 {
+                    let ctx = serde_json::from_value(vector["verify"].clone()).unwrap();
+                    assert_eq!(
+                        v.verify(vector["credential"].as_str().unwrap(), d.as_bytes(), &ctx),
+                        Ok(None)
+                    );
+                }
+            });
+        }
+        for _ in 0..20 {
+            v.reload_jwks(PUBLIC).unwrap();
+        }
+    });
+}

--- a/docs/tenancy-admission-journal.md
+++ b/docs/tenancy-admission-journal.md
@@ -1,0 +1,63 @@
+# Namespace admission ownership journal (Sympozium #500)
+
+`celln_cli::tenancy_admission` is a Linux, private-POSIX-storage ownership
+boundary. It does not yet expose an HTTP admission endpoint or replace the
+independent native publisher/closure/schema/ABI/resource checks. No compatible
+installed mediated runtime is advertised by this library.
+
+## Ordering and recovery
+
+- Verify the scoped execution credential against receiver-owned context and
+  independently canonicalize/hash the submitted external request **before** any
+  duplicate lookup. Model/read/cleanup credentials cannot claim execution.
+- Bind a run by cluster, namespace UID and run UID. Neither token JTI, a new
+  decision digest nor a changed parent incarnation creates a new run slot.
+- Publish and fsync a credential-free ownership record before returning the
+  non-cloneable `Fresh` handle. A duplicate only returns `Recovery`, never a new
+  launch handle. The caller must find the original live operation or explicitly
+  report uncertainty/ContextLost; it must not execute a recovery response.
+- Each opened owner instance gets a fresh random identity. Restarting/reopening
+  the journal does not restore a lost native parent or model credential context.
+- Follow-up turns retain original run/runtime/agent/route/incarnation and aggregate
+  limits. Initial work counts toward maxTurns. Only one unfinished operation per
+  parent is admitted; completion does not refund a turn.
+- Fence the parent slot durably before publishing its new child. An interrupted
+  publication leaves a fail-closed uncertainty fence, not retry authority.
+- Completion stores only an immutable receipt digest or refusal. An identical
+  completion retry is idempotent; a substituted outcome conflicts.
+
+`execution.read` and `execution.cleanup` credentials can address the original
+immutable authority after the execution deadline. Their decision may change its
+operation/windows, not its executable, route, budget, request or subject binding.
+A child cleanup fences only that child; a parent fence refuses further turns.
+**A journal fence does not confirm VM teardown.** The owning runtime must cancel
+its actual controls, destroy descendants and retain cleanup-pending/ContextLost
+when it cannot confirm that work.
+
+## Storage and trust
+
+The configured directory must be private and owned by the daemon UID. It is
+pinned by an open directory fd so replacing its pathname cannot redirect writes.
+Record and lock opens refuse symlinks/nonregular files and are nonblocking.
+Records are bounded, strictly decoded and contain no tokens, tasks, request bodies
+or output. Fresh publication uses no-clobber atomic rename plus file/directory
+fsync. flock unlock is explicit and owner-PID-bound so a concurrent fork cannot
+extend a completed critical section or unlock its parent from a child.
+
+The directory is durable authority, not a disposable cache. Do not delete,
+restore older copies or externally rewrite records while credentials/owners can
+remain live. There is no automatic tombstone collection or authority reset.
+Storage errors and capacity refusal are not permission to choose another owner.
+
+## Evidence limits
+
+Ten library tests cover concurrent duplicate delivery, independent reopened owner
+instances, changed ceilings, request/namespace mismatch before duplicate lookup,
+missing replay state, turn serialization/limits, expiry-safe read and narrowed
+cleanup, inode pinning and private storage. The interrupted-publication test
+constructs the exact persisted gap; it is not an OS-crash or native execution
+claim. Run `cargo test -p celln-cli --lib tenancy_admission --locked`.
+
+Remaining: authenticated transport/receiver-context construction, native artifact
+preparation and dispatch, original-owner result/cancel routing, durable controller
+prepared operations, and actual installed native lifecycle/failure testing.

--- a/docs/tenancy-credential-conformance.md
+++ b/docs/tenancy-credential-conformance.md
@@ -21,12 +21,11 @@ Stateful accounting sequences likewise belong to the durable ledger consumer.
 
 ## Not an admission implementation
 
-This module is **test-only**, not reachable from the running router/dispatcher.
-It is a cross-language conformance prerequisite, not a complete production
-verifier. It must not be used as permission to spawn a cell. Production work
-still needs complete typed/schema validation (including artifact/HTTPS limits),
-trusted key loading/atomic rotation, receiver-owned durable context, full HTTP
-surface enforcement and dynamic parent ownership/admission. Runtime wiring must
+The initial 05b implementation was test-only. The subsequent 05c library adds
+runtime schema validation and atomic public-key loading/reload; see
+`tenancy-runtime-verifier.md`. It is still not wired into router/dispatcher
+admission. Receiver-owned durable context, full HTTP surface enforcement and
+dynamic parent ownership/admission remain required before spawning cells. Runtime wiring must
 preserve independent host publisher/closure/ABI checks.
 
 The fixture's `seenAdmissionJti` is only a replay *disposition* observation.

--- a/docs/tenancy-runtime-verifier.md
+++ b/docs/tenancy-runtime-verifier.md
@@ -1,0 +1,49 @@
+# Runtime scoped-credential verifier (05c)
+
+This slice promotes the independent Rust conformance consumer into the
+`celln_cli::tenancy_credentials` library. The library builds outside `cfg(test)`;
+fixture private/public test keys and fixture observations remain test-only.
+
+- `Verifier::from_jwks` requires an explicit issuer and local public Ed25519 JWKS.
+- Unknown/private/remote-key fields, duplicate key IDs and malformed/empty keysets
+  refuse. No URL or filesystem key resolver is provided.
+- `reload_jwks` validates before atomically replacing the public keyset. Invalid
+  reload retains the previous keys. Normal rotation must retain overlap through
+  outstanding credential lifetime plus skew. Emergency removal affects future
+  verification, not already admitted cells.
+- `verify` accepts a caller-held bearer and **receiver-owned** `Context`. Errors
+  are static reason strings, never signed payloads or bearer contents.
+- The pinned JSON Schema 2020-12 decision and credential schemas are compiled
+  locally using jsonschema, with HTTP/file resolution features disabled. Full
+  required/type/additional-property/broker-limit checks supplement semantic
+  audience/operation/identity/deadline validation and strict Ed25519 verification.
+- Integer-only canonicalisation remains bounded, duplicate-key rejecting and
+  UTF-16 ordered. Widened time arithmetic avoids integer overflow.
+
+The published bundle was corrected upstream in Sympozium `8b69b03`: accepted
+model-free/cleanup decisions now contain `tools: []`, not schema-invalid null.
+All shared verifier dispositions continue to pass after this correction.
+
+## Receiver integration requirements
+
+This is a runtime **library**, not yet router/dispatcher enforcement. Receivers
+must derive expected namespace/run/parent/operation identity from trusted routing
+and durable ownership state. Populating Context solely from caller-supplied
+claims would authenticate a signature without enforcing tenant ownership.
+
+`seen_admission_jti` only retains the shared fixture recovery observation; a
+receiver must independently recover the durable operation. A JTI must never be
+used as execution identity, request identity or a fresh budget.
+
+No host publisher, sealed-closure, schema, ABI or resource check is removed.
+Nothing in this PR enables mediated mode, dynamic parent creation or #501 host
+broker credentials. No compatible installed artifact/KVM proof is claimed.
+
+## Verification
+
+Run `cargo test -p celln-cli --lib --locked`, workspace build/tests, and focused
+`cargo clippy -p celln-cli --lib --no-deps -- -D warnings`.
+The repository-wide Rust 1.95 baseline Clippy failure remains separately tracked
+in Celln #105. Rust 1.75 compatibility is not established by a Rust 1.95 test run;
+new time/url/uuid/iso8601 resolutions are locked to older compatible releases
+rather than incidentally adopting newer high-MSRV transitive releases.


### PR DESCRIPTION
<!-- tenancy-current-status:start -->
## Current delivery status (2026-09-12)

**Partial delivery; not an installed mediated-runtime completion claim.**

Celln #105–#107 provide independent canonicalization, all 24 credential vectors, strict verifier and public-key rotation.

**Outstanding:** Wire verification into actual router/dispatcher admission; durable receiver-owned tenant/run ownership, dynamic parent admission and recovery are not complete.

Tracking: [Sympozium epic #495](https://github.com/sympozium-ai/sympozium/issues/495), [issue #500](https://github.com/sympozium-ai/sympozium/issues/500). Paired gateway: [Sympozium #516](https://github.com/sympozium-ai/sympozium/pull/516).

Next usable milestone is a genuine controller → Celln → gateway run with enforced budget, correlated result and cleanup. Existing fixture/context/legacy KVM tests do not demonstrate that journey.

Latest combined tested/published tips: Sympozium `af9142e449aa753aa2abdfc334f959f4730aaae2`; Celln `b380f35dce79e639bdcbcaffa9dbe57d279212f6`. `make test-celln-tenancy-local` passed all 14 checks, including actual Rust host relay → TLS gateway process → live Kubernetes/PostgreSQL and five real-KVM prerequisites. Evidence: `/tmp/celln-tenancy-components.TIbZ3hfp/summary.json` (local artifact), explicitly `installedAcceptance:false`. Temporary namespaces were cleaned up. The native admission/controller/browser/CNI/provider release gates remain open.
<!-- tenancy-current-status:end -->

Stacks on #106 for sympozium-ai/sympozium#500. Promotes the verifier into the non-test celln_cli library. This is runtime-capable verification, NOT completed router/dispatcher admission.

Adds full pinned decision/credential JSON Schema validation (jsonschema with network/file resolver features disabled), local public-only JWKS parsing, duplicate/unknown/private-key refusal, atomic reload retaining old keys after invalid updates, bounded canonical parsing and overflow-safe time checks. Signature verification uses ed25519-dalek. Public receiver Context explicitly requires independent durable identity attribution. Test keys remain cfg(test).

Schema enforcement found a real shared-fixture defect: tool-free positive decisions encoded null instead of the required array. Fixed in Sympozium #511 commit 8b69b03, with a regression test first observed failing. Both repositories and the complete existing stacks now use the regenerated bundle; schema was not weakened.

Commands exit 0:
- cargo fmt --all -- --check
- cargo test -p celln-cli --lib --locked (9 tests, all 24 shared verifier vectors)
- cargo clippy -p celln-cli --lib --no-deps -- -D warnings
- cargo build --workspace --locked
- cargo test --workspace --locked
- git diff --check

Earlier workspace test run hit admission-is-busy in an unchanged mote_admit test; subsequent unchanged rerun and final locked run passed. Existing repository-wide Rust 1.95 Clippy issue from #105 remains; focused verifier lint passes. Rust 1.75 compatibility is not claimed from these runs.

Next: receiver-owned durable context, complete HTTP surface wiring, dynamic parent admission and #501 brokering. No production mediated mode is enabled, no execution permission follows solely from a valid signature, and no installed/KVM artifact proof is claimed. See docs/tenancy-runtime-verifier.md.